### PR TITLE
Add rustsec/audit-check to security workflow (#3)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,11 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+  checks: write
+  issues: write
+
 jobs:
   security:
     runs-on: ubuntu-latest
@@ -26,10 +31,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
+      # Official RustSec GitHub Action — wraps cargo-audit and annotates the PR /
+      # check run with any RUSTSEC advisories found in Cargo.lock.
+      - name: Cargo Security Audit (rustsec/audit-check)
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run security audit
+      # Belt-and-braces: run cargo-audit directly so the job fails hard on
+      # advisories even if the action's annotation path is disabled.
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
         run: cargo audit
 
       - name: Dependency review

--- a/docs/pr-summary-3.md
+++ b/docs/pr-summary-3.md
@@ -1,0 +1,22 @@
+## Summary
+
+Added the official `rustsec/audit-check@v2` step to `.github/workflows/security.yml` so the Cargo Security Audit workflow satisfies all expected detection patterns (`cargo audit`, `cargo-audit`, and `rustsec/audit-check`). The RustSec action annotates check runs and PRs with any RUSTSEC advisories; the existing manual `cargo install cargo-audit` + `cargo audit` steps remain as a belt-and-braces hard failure gate, and granted `checks: write` / `issues: write` permissions so the action can report findings. Closes #3.
+
+## Evidence
+
+This is a CI-configuration-only change with no runtime code or UI to screenshot. Verification performed:
+
+- Confirmed all three required detection patterns appear in `.github/workflows/security.yml`:
+  - `cargo audit` ✓
+  - `cargo-audit` ✓
+  - `rustsec/audit-check` ✓
+- Ran `shellcheck` via `./quality.sh` — all bash scripts pass.
+- The cargo quality steps (`cargo check`, `cargo test`, etc.) require the sibling `../NEAT-AI-core` path dependency which is not cloned in this environment (documented in `AGENTS.md`); they are unaffected by a YAML-only change and are exercised by CI on PR.
+
+## Test Plan
+
+- [x] `rustsec/audit-check@v2` step present and configured with `GITHUB_TOKEN`.
+- [x] Existing `cargo audit` hard-failure step retained so the reusable workflow still fails a job on any advisory.
+- [x] `permissions:` block extended with `checks: write` and `issues: write` for the RustSec action.
+- [x] YAML validated via pattern check; shellcheck passes.
+- [ ] On next PR, verify the `Cargo Security Audit (rustsec/audit-check)` step runs and annotates the PR.


### PR DESCRIPTION
## Summary

Added the official `rustsec/audit-check@v2` step to `.github/workflows/security.yml` so the Cargo Security Audit workflow satisfies all expected detection patterns (`cargo audit`, `cargo-audit`, and `rustsec/audit-check`). The RustSec action annotates check runs and PRs with any RUSTSEC advisories; the existing manual `cargo install cargo-audit` + `cargo audit` steps remain as a belt-and-braces hard failure gate, and granted `checks: write` / `issues: write` permissions so the action can report findings. Closes #3.

## Evidence

This is a CI-configuration-only change with no runtime code or UI to screenshot. Verification performed:

- Confirmed all three required detection patterns appear in `.github/workflows/security.yml`:
  - `cargo audit` ✓
  - `cargo-audit` ✓
  - `rustsec/audit-check` ✓
- Ran `shellcheck` via `./quality.sh` — all bash scripts pass.
- The cargo quality steps (`cargo check`, `cargo test`, etc.) require the sibling `../NEAT-AI-core` path dependency which is not cloned in this environment (documented in `AGENTS.md`); they are unaffected by a YAML-only change and are exercised by CI on PR.

## Test Plan

- [x] `rustsec/audit-check@v2` step present and configured with `GITHUB_TOKEN`.
- [x] Existing `cargo audit` hard-failure step retained so the reusable workflow still fails a job on any advisory.
- [x] `permissions:` block extended with `checks: write` and `issues: write` for the RustSec action.
- [x] YAML validated via pattern check; shellcheck passes.
- [ ] On next PR, verify the `Cargo Security Audit (rustsec/audit-check)` step runs and annotates the PR.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-3 -->