### PR TITLE
docs: add Related Repositories section to README (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,33 @@ Place **NEAT-AI-core** and **NEAT-AI-scorer** as **siblings** (e.g. `…/src/NEA
 
 Scorer-specific Rust stays here; **`neat-core`** tracks **NEAT-AI-core**.
 
+## Related Repositories
+
+The NEAT-AI project is split across several repositories. This repo, **NEAT-AI-scorer**, is the native MSE scorer CLI consumed by **NEAT-AI** during training.
+
+| Repository | Role |
+|------------|------|
+| [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI) | Deno/TypeScript orchestrator — the NEAT neural-network runtime that trains and evaluates creatures. |
+| [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) | Shared Rust computation library (`neat-core` crate) with fused batch losses and `training_bin_stream`. |
+| [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) | Rust discovery module invoked by NEAT-AI via Deno FFI. |
+| [NEAT-AI-Snapshot](https://github.com/stSoftwareAU/NEAT-AI-Snapshot) | Snapshot storage for trained creatures. |
+| [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer) | **This repo** — native MSE scorer CLI; depends on `neat-core` via path dependency. |
+| [NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore) | Visualiser that consumes NEAT-AI-Snapshot data. |
+| [NEAT-AI-Examples](https://github.com/stSoftwareAU/NEAT-AI-Examples) | Usage examples built on NEAT-AI. |
+
+### Dependency graph
+
+```mermaid
+graph TD
+    Examples[NEAT-AI-Examples] --> NEAT[NEAT-AI]
+    NEAT -->|Deno FFI| Discovery[NEAT-AI-Discovery]
+    NEAT -->|spawns CLI| Scorer[NEAT-AI-scorer]
+    NEAT -->|writes| Snapshot[NEAT-AI-Snapshot]
+    Scorer -->|path dep| Core[NEAT-AI-core]
+    Discovery -->|path dep| Core
+    Explore[NEAT-AI-Explore] -->|reads| Snapshot
+```
+
 ## Why MSE-only?
 
 The CLI scores creatures with **mean squared error** only — there is no `--cost` flag

--- a/docs/pr-summary-12.md
+++ b/docs/pr-summary-12.md
@@ -1,0 +1,11 @@
+## Summary
+Added a `## Related Repositories` section to `README.md` listing all 7 public NEAT-AI-* repositories with one-line descriptions, links, and a Mermaid dependency diagram. Closes #12.
+
+The section follows the acceptance criteria from the canonical block defined in stSoftwareAU/NEAT-AI-core#18: all 7 public repos are linked, each has a one-sentence role description, and the Mermaid graph shows dependency direction (path deps, Deno FFI invocation, snapshot reads, etc.). The existing "Source" table was left untouched — the new section is broader and complementary.
+
+## Evidence
+README-only documentation change; no UI or runtime behaviour affected. `./quality.sh` passes cleanly (shellcheck, cargo-deny, fmt, clippy `-D warnings`, workspace tests 23+2 passed, rustdoc, release build).
+
+## Test Plan
+- `./quality.sh` — full local gate passes after the change.
+- No new tests required: README-only change with no code paths touched.


### PR DESCRIPTION
## Summary
Added a `## Related Repositories` section to `README.md` listing all 7 public NEAT-AI-* repositories with one-line descriptions, links, and a Mermaid dependency diagram. Closes #12.

The section follows the acceptance criteria from the canonical block defined in stSoftwareAU/NEAT-AI-core#18: all 7 public repos are linked, each has a one-sentence role description, and the Mermaid graph shows dependency direction (path deps, Deno FFI invocation, snapshot reads, etc.). The existing "Source" table was left untouched — the new section is broader and complementary.

## Evidence
README-only documentation change; no UI or runtime behaviour affected. `./quality.sh` passes cleanly (shellcheck, cargo-deny, fmt, clippy `-D warnings`, workspace tests 23+2 passed, rustdoc, release build).

## Test Plan
- `./quality.sh` — full local gate passes after the change.
- No new tests required: README-only change with no code paths touched.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-12 -->