### PR TITLE
ci: add guarded auto-version increment PR job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,15 @@ jobs:
         env:
           SHELLCHECK_OPTS: -s bash
 
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Run bash helper tests (bats)
+        run: |
+          if [ -d "tests/scripts" ]; then
+            bats tests/scripts
+          fi
+
   spell-check:
     name: Spell Check
     runs-on: ubuntu-latest

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -1,0 +1,116 @@
+# Guarded auto-version increment PR job (Issue #20).
+#
+# Runs on pull requests targeting Develop or a milestone/* branch. If the
+# Cargo package version in `rust_scorer/Cargo.toml` still matches the base
+# branch, bumps the patch component once and commits the change back to the
+# PR branch. Re-running CI or a human-authored bump on the branch both
+# short-circuit via `scripts/version-increment.sh --run`, so no duplicate
+# bump commits are produced.
+name: Version Increment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - Develop
+      - "milestone/**"
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  # Gate: establish a canonical "should we attempt a bump?" signal that the
+  # actual writer job depends on. Making this a separate job keeps the
+  # ordering explicit (per acceptance criteria) and lets other PR checks
+  # pin themselves to `needs: [version-increment]` later if desired.
+  guard:
+    name: Version Bump Guard
+    runs-on: ubuntu-latest
+    # Never attempt to push onto a fork's branch — the GITHUB_TOKEN cannot
+    # write there, and bump-on-fork is the PR author's responsibility.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      should_bump: ${{ steps.check.outputs.should_bump }}
+      next_version: ${{ steps.check.outputs.next_version }}
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Fetch base ref
+        run: |
+          git fetch --no-tags --prune origin "${{ github.event.pull_request.base.ref }}"
+
+      - name: Decide whether to bump
+        id: check
+        run: |
+          set -euo pipefail
+          base_ref="origin/${{ github.event.pull_request.base.ref }}"
+          current="$(./scripts/version-increment.sh --get-version \
+            --manifest rust_scorer/Cargo.toml)"
+          if ./scripts/version-increment.sh --already-bumped \
+              --manifest rust_scorer/Cargo.toml \
+              --base-ref "$base_ref"; then
+            echo "Version already bumped on branch — skipping."
+            echo "should_bump=false" >>"$GITHUB_OUTPUT"
+            echo "next_version=$current" >>"$GITHUB_OUTPUT"
+          else
+            next="$(./scripts/version-increment.sh --bump-patch \
+              --manifest rust_scorer/Cargo.toml --dry-run)"
+            echo "Planned bump: $current -> $next"
+            echo "should_bump=true" >>"$GITHUB_OUTPUT"
+            echo "next_version=$next" >>"$GITHUB_OUTPUT"
+          fi
+
+  bump:
+    name: Apply Version Bump
+    needs: guard
+    if: needs.guard.outputs.should_bump == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch base ref
+        run: |
+          git fetch --no-tags --prune origin "${{ github.event.pull_request.base.ref }}"
+
+      # Re-check just before writing to avoid a race where a bump landed
+      # between the guard job and this job — preserves at-most-once semantics.
+      - name: Perform guarded bump
+        id: bump
+        run: |
+          set -euo pipefail
+          base_ref="origin/${{ github.event.pull_request.base.ref }}"
+          result="$(./scripts/version-increment.sh --run \
+            --manifest rust_scorer/Cargo.toml \
+            --base-ref "$base_ref")"
+          echo "$result"
+          if [[ "$result" == skip:* ]]; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push bump
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add rust_scorer/Cargo.toml
+          new_version="${{ needs.guard.outputs.next_version }}"
+          git commit -m "chore: auto-bump rust_scorer version to ${new_version}
+
+          Closes part of #20 — guarded auto-version increment."
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ see the in-tree `rust_scorer/` experiment on
 [`milestone/pure-rust-scorer-experiment`](https://github.com/stSoftwareAU/NEAT-AI/blob/milestone/pure-rust-scorer-experiment/rust_scorer/src/cost.rs)
 for the six-way dispatch pattern.
 
+## CI
+
+Besides the quality gate (`.github/workflows/ci.yml`), PRs also run a guarded
+auto-version increment job (`.github/workflows/version-increment.yml`,
+Issue #20). On each PR the job compares `rust_scorer/Cargo.toml` against the
+base branch and, if the version has not already changed on the branch, bumps
+the patch component once and pushes that commit back to the PR branch. A
+re-run of CI — or a human-authored bump on the same branch — short-circuits
+the job, so no duplicate bump commits are produced. The underlying logic
+lives in `scripts/version-increment.sh` and is covered by
+`tests/scripts/version_increment.bats`.
+
 ## License
 
 Apache-2.0 — see `LICENSE`.

--- a/docs/pr-summary-20.md
+++ b/docs/pr-summary-20.md
@@ -1,0 +1,57 @@
+## Summary
+
+Adds a guarded auto-version-increment PR job so each pull request bumps
+`rust_scorer/Cargo.toml` exactly once — and never duplicates the commit on
+re-runs or when a human has already bumped the version. Closes #20.
+
+- New helper `scripts/version-increment.sh` with four modes:
+  `--get-version`, `--bump-patch`, `--already-bumped`, `--run`. The `--run`
+  mode is idempotent and short-circuits when the branch version already
+  differs from the base ref.
+- New workflow `.github/workflows/version-increment.yml` with two jobs and
+  explicit ordering: a `guard` job decides whether a bump is needed and a
+  `bump` job re-checks and performs the commit/push. Forks are skipped
+  because `GITHUB_TOKEN` cannot push to them.
+- `quality.sh` and the CI `shell-checks` job now install/run `bats` so the
+  helper script stays covered locally and in CI.
+- README gained a short "CI" section describing the new behaviour.
+
+## Evidence
+
+This change is backend/CLI and workflow only — no UI to screenshot. Verified
+locally via:
+
+- `bats tests/scripts` — 10/10 passing (see the test plan below).
+- `./quality.sh` — full gate green (shellcheck, bats, cargo-deny, fmt,
+  clippy `-D warnings` + `filter_next`/`collapsible_if`, test, doc,
+  release build).
+- Smoke against the real repo:
+  `./scripts/version-increment.sh --get-version --manifest rust_scorer/Cargo.toml`
+  → `0.5.4`; `--already-bumped` against `origin/milestone/ci` → exit 1
+  (correctly identifies that no bump has happened yet on the branch).
+
+## Test Plan
+
+New BATS suite `tests/scripts/version_increment.bats` — each test exercises
+the script against a real temporary git repository:
+
+- [x] `get_version` reads the Cargo manifest.
+- [x] `bump-patch` returns `X.Y.(Z+1)` (both `--dry-run` and written form).
+- [x] `already-bumped` exits 0 when the branch has diverged and 1 otherwise.
+- [x] `run` performs the bump when no prior bump exists.
+- [x] `run` is idempotent — a second invocation reports `skip:` and does
+      not mutate the manifest.
+- [x] `run` respects a human-authored bump on the branch (no double-bump).
+- [x] Missing manifest produces a clear error.
+- [x] Unknown flag prints usage and exits non-zero.
+
+Acceptance criteria mapping:
+
+- *Version auto-bump happens at most once per PR unless a source change
+  requires a new bump* — handled by `--run`'s base-vs-branch comparison
+  plus re-check inside the `bump` job.
+- *Re-run CI does not create duplicate bump commits* — covered by tests 7
+  and 8 above.
+- *Job ordering/dependencies with other checks are explicit* — the `bump`
+  job declares `needs: guard` and the workflow file comments how other PR
+  checks can opt in later.

--- a/quality.sh
+++ b/quality.sh
@@ -32,6 +32,18 @@ if [[ "$SHELLCHECK_FAILED" -ne 0 ]]; then
 fi
 echo "shellcheck: all scripts passed"
 
+echo "🧰 Running bash helper tests (bats)..."
+if command -v bats &>/dev/null; then
+  # Only execute the bats suites we ship under tests/scripts — keeps runtime
+  # scoped to shell helpers and avoids pulling in unrelated directories.
+  if [ -d "tests/scripts" ]; then
+    bats tests/scripts
+  fi
+else
+  echo "⚠️  bats not installed — skipping shell helper tests"
+  echo "   Install with: brew install bats-core  (or your package manager)"
+fi
+
 echo "📦 Upgrading Rust library dependencies (optional)..."
 if command -v cargo-upgrade &>/dev/null; then
   cargo upgrade --incompatible

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/version-increment.sh
+++ b/scripts/version-increment.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Guarded Cargo version-increment helper (Issue #20).
+#
+# Responsibilities:
+#   * Read / write the [package].version field of a Cargo.toml manifest.
+#   * Detect whether the current git branch has already diverged from its
+#     base ref on that version (so re-running CI does not produce duplicate
+#     bump commits and a human-authored bump is respected).
+#   * Perform a single idempotent patch-level bump on request.
+#
+# Designed to be callable both from local shells and from a GitHub Actions
+# job (see `.github/workflows/version-increment.yml`). No direct network or
+# git-push side-effects — the workflow handles committing/pushing.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: version-increment.sh <mode> [--manifest PATH] [--base-ref REF] [--repo DIR] [--dry-run]
+
+Modes (exactly one):
+  --get-version       Print the current [package].version from the manifest.
+  --bump-patch        Increment the patch component of [package].version.
+  --already-bumped    Exit 0 if branch version differs from base, else exit 1.
+  --run               End-to-end: skip if already bumped (or manually bumped),
+                      otherwise bump-patch. Prints a one-line status.
+
+Options:
+  --manifest PATH     Cargo.toml to operate on (default: rust_scorer/Cargo.toml).
+  --base-ref REF      Base ref to diff against (default: origin/Develop).
+  --repo DIR          Repository directory for git operations (default: cwd).
+  --dry-run           For --bump-patch, print the new version without writing.
+  -h, --help          Show this message.
+EOF
+}
+
+# --- arg parsing -----------------------------------------------------------
+
+MODE=""
+MANIFEST="rust_scorer/Cargo.toml"
+BASE_REF="origin/Develop"
+REPO_DIR="."
+DRY_RUN=0
+
+set_mode() {
+  if [[ -n "$MODE" ]]; then
+    echo "Usage error: only one mode may be supplied" >&2
+    usage >&2
+    exit 2
+  fi
+  MODE="$1"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --get-version)    set_mode get-version;    shift ;;
+    --bump-patch)     set_mode bump-patch;     shift ;;
+    --already-bumped) set_mode already-bumped; shift ;;
+    --run)            set_mode run;            shift ;;
+    --manifest)       MANIFEST="$2"; shift 2 ;;
+    --base-ref)       BASE_REF="$2"; shift 2 ;;
+    --repo)           REPO_DIR="$2"; shift 2 ;;
+    --dry-run)        DRY_RUN=1; shift ;;
+    -h|--help)        usage; exit 0 ;;
+    *)
+      echo "Usage error: unknown option '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "Usage error: a mode is required" >&2
+  usage >&2
+  exit 2
+fi
+
+# --- helpers ---------------------------------------------------------------
+
+# Extract the first `version = "X.Y.Z"` line beneath a [package] header.
+extract_version() {
+  local manifest="$1"
+  if [[ ! -f "$manifest" ]]; then
+    echo "Error: manifest '$manifest' not found" >&2
+    return 1
+  fi
+  awk '
+    /^\[package\]/ { in_pkg = 1; next }
+    /^\[/          { in_pkg = 0 }
+    in_pkg && /^[[:space:]]*version[[:space:]]*=/ {
+      match($0, /"[^"]+"/)
+      if (RSTART > 0) {
+        v = substr($0, RSTART + 1, RLENGTH - 2)
+        print v
+        exit
+      }
+    }
+  ' "$manifest"
+}
+
+# Read the manifest version from a specific git ref (base branch).
+extract_version_at_ref() {
+  local repo="$1" ref="$2" manifest_rel="$3"
+  (
+    cd "$repo"
+    # Allow the ref to not exist (e.g. shallow fetch) — return empty string
+    # so the caller can treat it as "unknown" and default to "not bumped".
+    if ! git rev-parse --verify "$ref" >/dev/null 2>&1; then
+      return 0
+    fi
+    git show "${ref}:${manifest_rel}" 2>/dev/null | awk '
+      /^\[package\]/ { in_pkg = 1; next }
+      /^\[/          { in_pkg = 0 }
+      in_pkg && /^[[:space:]]*version[[:space:]]*=/ {
+        match($0, /"[^"]+"/)
+        if (RSTART > 0) {
+          v = substr($0, RSTART + 1, RLENGTH - 2)
+          print v
+          exit
+        }
+      }
+    '
+  )
+}
+
+# Rewrite the [package].version line in-place.
+write_version() {
+  local manifest="$1" new_version="$2"
+  # Only touch the first version = "..." line under [package].
+  awk -v new="$new_version" '
+    BEGIN { done = 0 }
+    /^\[package\]/ { in_pkg = 1; print; next }
+    /^\[/          { in_pkg = 0 }
+    {
+      if (in_pkg && !done && $0 ~ /^[[:space:]]*version[[:space:]]*=/) {
+        sub(/"[^"]+"/, "\"" new "\"")
+        done = 1
+      }
+      print
+    }
+  ' "$manifest" >"${manifest}.tmp"
+  mv "${manifest}.tmp" "$manifest"
+}
+
+# Compute the relative manifest path inside the repo (for git show).
+manifest_rel_path() {
+  local repo="$1" manifest="$2"
+  if [[ "$manifest" = /* ]]; then
+    # Strip repo prefix + leading slash.
+    local abs_repo
+    abs_repo="$(cd "$repo" && pwd)"
+    local rel="${manifest#"$abs_repo"/}"
+    echo "$rel"
+  else
+    echo "$manifest"
+  fi
+}
+
+bump_patch() {
+  local version="$1"
+  if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+    echo "Error: version '$version' is not semver X.Y.Z" >&2
+    return 1
+  fi
+  local major="${BASH_REMATCH[1]}"
+  local minor="${BASH_REMATCH[2]}"
+  local patch="${BASH_REMATCH[3]}"
+  local suffix="${BASH_REMATCH[4]}"
+  printf '%s.%s.%s%s\n' "$major" "$minor" "$((patch + 1))" "$suffix"
+}
+
+# --- modes -----------------------------------------------------------------
+
+case "$MODE" in
+  get-version)
+    extract_version "$MANIFEST"
+    ;;
+
+  bump-patch)
+    current="$(extract_version "$MANIFEST")"
+    next="$(bump_patch "$current")"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "$next"
+    else
+      write_version "$MANIFEST" "$next"
+      echo "$next"
+    fi
+    ;;
+
+  already-bumped)
+    current="$(extract_version "$MANIFEST")"
+    rel="$(manifest_rel_path "$REPO_DIR" "$MANIFEST")"
+    base_version="$(extract_version_at_ref "$REPO_DIR" "$BASE_REF" "$rel")"
+    if [[ -z "$base_version" ]]; then
+      # Base ref unreachable — treat as "not bumped" so CI stays conservative.
+      exit 1
+    fi
+    if [[ "$current" != "$base_version" ]]; then
+      exit 0
+    else
+      exit 1
+    fi
+    ;;
+
+  run)
+    current="$(extract_version "$MANIFEST")"
+    rel="$(manifest_rel_path "$REPO_DIR" "$MANIFEST")"
+    base_version="$(extract_version_at_ref "$REPO_DIR" "$BASE_REF" "$rel")"
+
+    if [[ -n "$base_version" && "$current" != "$base_version" ]]; then
+      echo "skip: version already bumped on branch (base=${base_version}, branch=${current})"
+      exit 0
+    fi
+
+    next="$(bump_patch "$current")"
+    write_version "$MANIFEST" "$next"
+    echo "bumped: ${current} -> ${next}"
+    ;;
+esac

--- a/tests/scripts/version_increment.bats
+++ b/tests/scripts/version_increment.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# Tests for scripts/version-increment.sh — guarded Cargo version bump helper.
+# Exercises the script with real temporary git repositories so behaviour
+# (exit codes, version strings, commit side-effects) is verified end-to-end.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/version-increment.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_REPO="$(mktemp -d)"
+  export TMP_REPO
+
+  (
+    cd "$TMP_REPO"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+
+    mkdir -p rust_scorer
+    cat >rust_scorer/Cargo.toml <<'EOF'
+[package]
+name = "rust_scorer"
+version = "0.5.4"
+edition = "2024"
+EOF
+    git add rust_scorer/Cargo.toml
+    git commit -q -m "initial"
+
+    git checkout -q -b feature
+  )
+}
+
+teardown() {
+  rm -rf "$TMP_REPO"
+}
+
+@test "get_version prints the current Cargo package version" {
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.5.4" ]
+}
+
+@test "bump-patch increments only the patch component" {
+  run "$SCRIPT_UNDER_TEST" --bump-patch --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"0.5.5"* ]]
+}
+
+@test "bump-patch writes the new version into the manifest" {
+  run "$SCRIPT_UNDER_TEST" --bump-patch --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$status" -eq 0 ]
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$output" = "0.5.5" ]
+}
+
+@test "already-bumped? exits 0 when branch version differs from base" {
+  (
+    cd "$TMP_REPO"
+    "$SCRIPT_UNDER_TEST" --bump-patch --manifest rust_scorer/Cargo.toml
+    git add rust_scorer/Cargo.toml
+    git commit -q -m "chore: bump version"
+  )
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "already-bumped? exits 1 when branch version matches base" {
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 1 ]
+}
+
+@test "run performs a bump when none has happened on the branch" {
+  run "$SCRIPT_UNDER_TEST" --run --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bumped"* ]]
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$output" = "0.5.5" ]
+}
+
+@test "run is idempotent — a second invocation on the same branch does not bump again" {
+  (
+    cd "$TMP_REPO"
+    "$SCRIPT_UNDER_TEST" --run --manifest rust_scorer/Cargo.toml --base-ref main --repo "$TMP_REPO" >/dev/null
+    git add rust_scorer/Cargo.toml
+    git commit -q -m "chore: bump"
+  )
+  run "$SCRIPT_UNDER_TEST" --run --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skip"* ]]
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$output" = "0.5.5" ]
+}
+
+@test "run respects a manual bump on the branch (no double-bump)" {
+  (
+    cd "$TMP_REPO"
+    # Simulate a human manually bumping to 0.6.0
+    sed -i.bak 's/version = "0.5.4"/version = "0.6.0"/' rust_scorer/Cargo.toml
+    rm -f rust_scorer/Cargo.toml.bak
+    git add rust_scorer/Cargo.toml
+    git commit -q -m "chore: manual bump"
+  )
+  run "$SCRIPT_UNDER_TEST" --run --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skip"* ]]
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$output" = "0.6.0" ]
+}
+
+@test "missing manifest yields a clear error" {
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/does-not-exist.toml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a guarded auto-version-increment PR job so each pull request bumps
`rust_scorer/Cargo.toml` exactly once — and never duplicates the commit on
re-runs or when a human has already bumped the version. Closes #20.

- New helper `scripts/version-increment.sh` with four modes:
  `--get-version`, `--bump-patch`, `--already-bumped`, `--run`. The `--run`
  mode is idempotent and short-circuits when the branch version already
  differs from the base ref.
- New workflow `.github/workflows/version-increment.yml` with two jobs and
  explicit ordering: a `guard` job decides whether a bump is needed and a
  `bump` job re-checks and performs the commit/push. Forks are skipped
  because `GITHUB_TOKEN` cannot push to them.
- `quality.sh` and the CI `shell-checks` job now install/run `bats` so the
  helper script stays covered locally and in CI.
- README gained a short "CI" section describing the new behaviour.

## Evidence

This change is backend/CLI and workflow only — no UI to screenshot. Verified
locally via:

- `bats tests/scripts` — 10/10 passing (see the test plan below).
- `./quality.sh` — full gate green (shellcheck, bats, cargo-deny, fmt,
  clippy `-D warnings` + `filter_next`/`collapsible_if`, test, doc,
  release build).
- Smoke against the real repo:
  `./scripts/version-increment.sh --get-version --manifest rust_scorer/Cargo.toml`
  → `0.5.4`; `--already-bumped` against `origin/milestone/ci` → exit 1
  (correctly identifies that no bump has happened yet on the branch).

## Test Plan

New BATS suite `tests/scripts/version_increment.bats` — each test exercises
the script against a real temporary git repository:

- [x] `get_version` reads the Cargo manifest.
- [x] `bump-patch` returns `X.Y.(Z+1)` (both `--dry-run` and written form).
- [x] `already-bumped` exits 0 when the branch has diverged and 1 otherwise.
- [x] `run` performs the bump when no prior bump exists.
- [x] `run` is idempotent — a second invocation reports `skip:` and does
      not mutate the manifest.
- [x] `run` respects a human-authored bump on the branch (no double-bump).
- [x] Missing manifest produces a clear error.
- [x] Unknown flag prints usage and exits non-zero.

Acceptance criteria mapping:

- *Version auto-bump happens at most once per PR unless a source change
  requires a new bump* — handled by `--run`'s base-vs-branch comparison
  plus re-check inside the `bump` job.
- *Re-run CI does not create duplicate bump commits* — covered by tests 7
  and 8 above.
- *Job ordering/dependencies with other checks are explicit* — the `bump`
  job declares `needs: guard` and the workflow file comments how other PR
  checks can opt in later.



## Milestone
This PR is part of the **CI** milestone and targets the `milestone/ci` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-20 -->