### PR TITLE
ci: tune codespell ignore list and add local preflight script

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,22 @@
+# codespell configuration — shared by CI and the local preflight script
+# (`scripts/spell-check.sh`). Keep this file as the single source of truth so
+# contributors can reproduce the CI spell check exactly and CI never
+# drifts from what runs locally.
+#
+# Curated ignore list (see README "Spell check" section for workflow):
+#   - renderD  : DRM device node name (renderD128 etc).
+#   - mape/MAPE: Mean Absolute Percentage Error — a neat-core loss function.
+#
+# Skipped paths:
+#   - target, .git, Cargo.lock              : build artefacts / VCS metadata.
+#   - tests/scripts/spell_check.bats        : intentionally contains typo
+#     fixtures that exercise the preflight (see the bats suite).
+#
+# To extend the list, prefer adding an entry here with a short justification
+# comment rather than silencing individual files. Genuine typos must continue
+# to fail the build.
+[codespell]
+skip = ./target,./.git,./Cargo.lock,./tests/scripts/spell_check.bats
+check-filenames =
+check-hidden =
+ignore-words-list = renderD,mape,MAPE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,10 +221,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run codespell
-        uses: codespell-project/actions-codespell@v2
-        with:
-          check_filenames: true
-          check_hidden: true
-          skip: "./target,./.git"
-          ignore_words_list: renderD,mape,MAPE
+      # Configuration lives in `.codespellrc` at the repo root so CI and the
+      # local preflight (`scripts/spell-check.sh`) stay in lock-step — see
+      # Issue #22 and the README "Spell check" section. Invoke the same
+      # script contributors run locally.
+      - name: Install codespell
+        run: pip install --user codespell
+
+      - name: Run codespell preflight
+        run: ./scripts/spell-check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 !.gitignore
 !.gitattributes
 !.github/
+!.gitleaks.toml
+!.codespellrc
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "clap",
  "neat-core",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,20 @@ cargo test --workspace --all-features
 cargo build --release -p rust_scorer
 ```
 
-Requires **shellcheck**, **cargo-deny** (`cargo install cargo-deny --locked`), and optionally **cargo-edit** for the upgrade step in `./quality.sh`.
+Requires **shellcheck**, **cargo-deny** (`cargo install cargo-deny --locked`), **codespell** (`pip install --user codespell`, used by `scripts/spell-check.sh`), and optionally **cargo-edit** for the upgrade step in `./quality.sh`.
+
+### Spell check
+
+CI runs `codespell` via `scripts/spell-check.sh`; the same script is invoked by `./quality.sh`, so the local gate and CI stay in lock-step. Reproduce the CI spell check at any time with:
+
+```bash
+./scripts/spell-check.sh
+```
+
+Configuration (ignore list, skip paths, check-filenames / check-hidden flags) is kept in a single source of truth: [`.codespellrc`](./.codespellrc). When a domain term trips codespell, prefer adding it — with a short justification comment — to `.codespellrc` over silencing the whole file. Genuine typos must continue to fail the build. Current curated domain entries:
+
+- `renderD` — DRM device node name (e.g. `renderD128`).
+- `mape` / `MAPE` — Mean Absolute Percentage Error (a `neat-core` loss function).
 
 Binaries: `rust_scorer`, `float_scan_bench` (see `rust_scorer/Cargo.toml`).
 

--- a/docs/pr-summary-22.md
+++ b/docs/pr-summary-22.md
@@ -1,0 +1,39 @@
+## Summary
+
+Tunes the codespell setup so CI and contributors share a single source of truth and can reproduce the spell check locally. Adds a `.codespellrc` config file with a curated ignore list, a new `scripts/spell-check.sh` preflight script, and wires the preflight into `./quality.sh`. CI now installs codespell and calls the same preflight, so CI and local runs stay in lock-step. Closes #22.
+
+### What changed
+
+- **`.codespellrc`** — shared codespell config. Curated ignore list (`renderD`, `mape`, `MAPE`) lives here with justification comments, plus `skip` paths (`./target`, `./.git`, `./Cargo.lock`, bats fixture file) and the `check-filenames` / `check-hidden` flags previously duplicated in CI.
+- **`scripts/spell-check.sh`** — local preflight script. Resolves user-site codespell installs (macOS / CI), fails fast with install instructions when missing, `cd`s into the target root so `.codespellrc` is picked up automatically. Supports `--root <dir>` for tests.
+- **`quality.sh`** — now invokes `scripts/spell-check.sh` alongside the other preflight checks. Running `./quality.sh` reproduces the CI spell-check job.
+- **`.github/workflows/ci.yml`** — the spell-check job now installs codespell and runs `scripts/spell-check.sh`, replacing the duplicated `ignore_words_list` / `check_filenames` / `skip` inputs. Single source of truth in `.codespellrc`.
+- **`README.md`** — new "Spell check" subsection under Build documents the workflow for running the preflight, extending the ignore list, and what the current curated entries mean.
+- **`tests/scripts/spell_check.bats`** — new bats suite exercising the preflight end-to-end (clean tree, genuine typo, curated ignores, hidden files, target/ skip, unknown flag, real repo).
+
+### Acceptance criteria
+
+- ✅ Known valid domain terms (`renderD`, `mape`, `MAPE`) no longer cause recurring CI noise — bats test `ignores curated domain terms` verifies.
+- ✅ New genuine typos still fail CI — bats test `fails on a genuine typo` verifies (`sentance` is flagged).
+- ✅ Local command path exists to reproduce CI — `scripts/spell-check.sh` is invoked by both CI and `quality.sh`; bats test `real repository passes the spell check` confirms.
+
+## Evidence
+
+Backend / CI change — no UI to screenshot. Verified via:
+
+1. `./quality.sh < /dev/null` — passes cleanly, including the new `📝 Running codespell preflight (mirrors CI spell-check job)…` step.
+2. `bats tests/scripts/spell_check.bats` — 7/7 tests passing.
+3. Direct run: `./scripts/spell-check.sh` → `codespell: no typos found`.
+
+## Test Plan
+
+- Added `tests/scripts/spell_check.bats` covering:
+  - Passes on a clean tree.
+  - Fails on a genuine typo (`sentance`).
+  - Ignores curated domain terms (`MAPE` / `mape` / `renderD`).
+  - Scans hidden files and filenames (catches `recieve` in `.hidden`).
+  - Skips the `target/` build directory.
+  - Unknown flag prints usage and exits non-zero.
+  - Real repository passes the spell check.
+- Re-ran existing bats suite (`tests/scripts/version_increment.bats`, `tests/scripts/workflow_neat_ai_core_path.bats`) — still passing.
+- Full `./quality.sh` gate re-run: fmt / clippy / check / build / test / doc / release all green.

--- a/quality.sh
+++ b/quality.sh
@@ -35,6 +35,12 @@ echo "shellcheck: all scripts passed"
 echo "🔗 Validating NEAT-AI-core checkout path strategy in workflows..."
 ./scripts/check-workflow-paths.sh
 
+echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
+if ! ./scripts/spell-check.sh; then
+  echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."
+  exit 1
+fi
+
 echo "🧰 Running bash helper tests (bats)..."
 if command -v bats &>/dev/null; then
   # Only execute the bats suites we ship under tests/scripts — keeps runtime

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/spell-check.sh
+++ b/scripts/spell-check.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# spell-check.sh — local codespell preflight that mirrors CI (Issue #22).
+#
+# Runs codespell against the repository using the shared `.codespellrc`
+# configuration so contributors can reproduce the CI spell-check job before
+# pushing. The ignore list lives in `.codespellrc` — add curated domain
+# terms there rather than silencing files ad hoc.
+#
+# Usage:
+#   scripts/spell-check.sh                 # scan the repo root
+#   scripts/spell-check.sh --root <dir>    # scan a different directory
+#
+# Exit codes:
+#   0 — no typos detected
+#   1 — typos detected or codespell missing / invalid invocation
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: spell-check.sh [--root <dir>]
+
+Runs codespell against <dir> (default: repository root) using the shared
+.codespellrc ignore list. Install codespell with:
+
+  pip install --user codespell
+
+See the "Spell check" section in README.md for the full contributor workflow.
+USAGE
+}
+
+ROOT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root)
+      ROOT="${2:-}"
+      if [[ -z "$ROOT" ]]; then
+        echo "--root requires a directory argument" >&2
+        usage >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$ROOT" ]]; then
+  # Default to the repository root relative to this script so the preflight
+  # works regardless of the caller's CWD.
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "spell-check: root directory not found: $ROOT" >&2
+  exit 1
+fi
+
+# Allow user-site installs (macOS / CI without sudo) to resolve.
+for candidate in "$HOME/Library/Python/3.13/bin" "$HOME/.local/bin"; do
+  if [[ -d "$candidate" ]]; then
+    case ":$PATH:" in
+      *":$candidate:"*) ;;
+      *) PATH="$candidate:$PATH" ;;
+    esac
+  fi
+done
+export PATH
+
+if ! command -v codespell >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+spell-check: codespell is not installed.
+
+Install it with one of:
+
+  pip install --user codespell
+  pipx install codespell
+  brew install codespell
+
+Then re-run: scripts/spell-check.sh
+EOF
+  exit 1
+fi
+
+echo "📝 Running codespell on: $ROOT"
+# codespell automatically picks up .codespellrc from its working directory,
+# so cd into the target root before invoking it. No explicit flags here —
+# keep the single source of truth in `.codespellrc`.
+(
+  cd "$ROOT"
+  if ! codespell; then
+    echo "codespell: typos detected — fix the reported words or curate the ignore list in .codespellrc (see README 'Spell check' section)." >&2
+    exit 1
+  fi
+)
+echo "codespell: no typos found"

--- a/tests/scripts/spell_check.bats
+++ b/tests/scripts/spell_check.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# Tests for scripts/spell-check.sh — Issue #22.
+#
+# Exercises the local codespell preflight against synthetic source trees so
+# behaviour (exit codes, reported typos, ignore list) is verified end-to-end
+# without touching the real repository content.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/spell-check.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  # Make the user-site codespell install visible when the shell has been
+  # started without the standard PATH extension (macOS, CI).
+  if [ -d "$HOME/Library/Python/3.13/bin" ]; then
+    export PATH="$HOME/Library/Python/3.13/bin:$PATH"
+  fi
+  if [ -d "$HOME/.local/bin" ]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
+
+  if ! command -v codespell >/dev/null 2>&1; then
+    skip "codespell not installed"
+  fi
+
+  TMP_REPO="$(mktemp -d)"
+  export TMP_REPO
+  cp "${BATS_TEST_DIRNAME}/../../.codespellrc" "$TMP_REPO/.codespellrc"
+}
+
+teardown() {
+  rm -rf "$TMP_REPO"
+}
+
+@test "passes on a clean tree" {
+  cat >"$TMP_REPO/clean.md" <<'EOF'
+# A clean document with correctly spelt words.
+EOF
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"codespell: no typos found"* ]]
+}
+
+@test "fails on a genuine typo" {
+  cat >"$TMP_REPO/typo.md" <<'EOF'
+This sentance contains a real typo.
+EOF
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_REPO"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"sentance"* ]]
+}
+
+@test "ignores curated domain terms (MAPE / mape / renderD)" {
+  cat >"$TMP_REPO/loss.md" <<'EOF'
+Mean Absolute Percentage Error (MAPE) uses lowercase mape internally.
+The renderD node entry also appears in device listings.
+EOF
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "scans hidden files and filenames" {
+  # Hidden file with a typo should still be caught.
+  cat >"$TMP_REPO/.hidden" <<'EOF'
+recieve should be flagged.
+EOF
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_REPO"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"recieve"* ]]
+}
+
+@test "skips the target/ build directory" {
+  mkdir -p "$TMP_REPO/target/debug"
+  cat >"$TMP_REPO/target/debug/noisy.txt" <<'EOF'
+recieve teh occured — typos inside build artefacts must be skipped.
+EOF
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository passes the spell check" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Tunes the codespell setup so CI and contributors share a single source of truth and can reproduce the spell check locally. Adds a `.codespellrc` config file with a curated ignore list, a new `scripts/spell-check.sh` preflight script, and wires the preflight into `./quality.sh`. CI now installs codespell and calls the same preflight, so CI and local runs stay in lock-step. Closes #22.

### What changed

- **`.codespellrc`** — shared codespell config. Curated ignore list (`renderD`, `mape`, `MAPE`) lives here with justification comments, plus `skip` paths (`./target`, `./.git`, `./Cargo.lock`, bats fixture file) and the `check-filenames` / `check-hidden` flags previously duplicated in CI.
- **`scripts/spell-check.sh`** — local preflight script. Resolves user-site codespell installs (macOS / CI), fails fast with install instructions when missing, `cd`s into the target root so `.codespellrc` is picked up automatically. Supports `--root <dir>` for tests.
- **`quality.sh`** — now invokes `scripts/spell-check.sh` alongside the other preflight checks. Running `./quality.sh` reproduces the CI spell-check job.
- **`.github/workflows/ci.yml`** — the spell-check job now installs codespell and runs `scripts/spell-check.sh`, replacing the duplicated `ignore_words_list` / `check_filenames` / `skip` inputs. Single source of truth in `.codespellrc`.
- **`README.md`** — new "Spell check" subsection under Build documents the workflow for running the preflight, extending the ignore list, and what the current curated entries mean.
- **`tests/scripts/spell_check.bats`** — new bats suite exercising the preflight end-to-end (clean tree, genuine typo, curated ignores, hidden files, target/ skip, unknown flag, real repo).

### Acceptance criteria

- ✅ Known valid domain terms (`renderD`, `mape`, `MAPE`) no longer cause recurring CI noise — bats test `ignores curated domain terms` verifies.
- ✅ New genuine typos still fail CI — bats test `fails on a genuine typo` verifies (`sentance` is flagged).
- ✅ Local command path exists to reproduce CI — `scripts/spell-check.sh` is invoked by both CI and `quality.sh`; bats test `real repository passes the spell check` confirms.

## Evidence

Backend / CI change — no UI to screenshot. Verified via:

1. `./quality.sh < /dev/null` — passes cleanly, including the new `📝 Running codespell preflight (mirrors CI spell-check job)…` step.
2. `bats tests/scripts/spell_check.bats` — 7/7 tests passing.
3. Direct run: `./scripts/spell-check.sh` → `codespell: no typos found`.

## Test Plan

- Added `tests/scripts/spell_check.bats` covering:
  - Passes on a clean tree.
  - Fails on a genuine typo (`sentance`).
  - Ignores curated domain terms (`MAPE` / `mape` / `renderD`).
  - Scans hidden files and filenames (catches `recieve` in `.hidden`).
  - Skips the `target/` build directory.
  - Unknown flag prints usage and exits non-zero.
  - Real repository passes the spell check.
- Re-ran existing bats suite (`tests/scripts/version_increment.bats`, `tests/scripts/workflow_neat_ai_core_path.bats`) — still passing.
- Full `./quality.sh` gate re-run: fmt / clippy / check / build / test / doc / release all green.



## Milestone
This PR is part of the **CI** milestone and targets the `milestone/ci` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-22 -->