### PR TITLE
ci: harden Gitleaks PR scan with pinned binary and diff-range scope (#21)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -11,12 +11,14 @@
 #   - target, .git, Cargo.lock              : build artefacts / VCS metadata.
 #   - tests/scripts/spell_check.bats        : intentionally contains typo
 #     fixtures that exercise the preflight (see the bats suite).
+#   - docs/pr-summary-*.md                  : historical PR narratives that
+#     may quote typo fixtures from the PR they describe (Issue #21).
 #
 # To extend the list, prefer adding an entry here with a short justification
 # comment rather than silencing individual files. Genuine typos must continue
 # to fail the build.
 [codespell]
-skip = ./target,./.git,./Cargo.lock,./tests/scripts/spell_check.bats
+skip = ./target,./.git,./Cargo.lock,./tests/scripts/spell_check.bats,./docs/pr-summary-*.md
 check-filenames =
 check-hidden =
 ignore-words-list = renderD,mape,MAPE

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,19 @@
 name: Gitleaks
 
+# Secret-scanning gate for pull requests. The scan is deliberately scoped to
+# the PR commit range (`origin/<base>..HEAD`) so reviewers see findings that
+# belong to the proposed change, not unrelated history already audited by
+# earlier scans.
+#
+# Why pin the Gitleaks binary?
+#   * Reproducibility — a given PR always executes the same scanner binary,
+#     so rule updates never silently change PR-gating behaviour.
+#   * Supply-chain hygiene — the downloaded archive is verified against a
+#     known SHA256 checksum, so a compromised release asset cannot silently
+#     replace the scanner.
+#   * Transparency — bumping Gitleaks is an explicit, reviewable change to
+#     both GITLEAKS_VERSION and GITLEAKS_SHA256 below.
+
 on:
   pull_request:
     branches: ["*"]
@@ -11,22 +25,48 @@ jobs:
   gitleaks:
     name: Gitleaks Secrets Detection
     runs-on: ubuntu-latest
+    # Pinned release. Bump both values together and record the upstream
+    # release notes / rationale in the PR that lifts them.
+    env:
+      GITLEAKS_VERSION: "8.24.2"
+      GITLEAKS_SHA256: "fa0500f6b7e41d28791ebc680f5dd9899cd42b58629218a5f041efa899151a8e"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # Full history so `origin/<base>..HEAD` resolves on every PR.
           fetch-depth: 0
 
-      - name: Install gitleaks CLI
+      - name: Install pinned Gitleaks binary
         run: |
-          version="8.24.2"
-          archive="gitleaks_${version}_linux_x64.tar.gz"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/${archive}" -o "${archive}"
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          echo "Downloading pinned Gitleaks v${GITLEAKS_VERSION} from ${url}"
+          curl -sSfL "${url}" -o "${archive}"
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum --check -
           tar -xzf "${archive}" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
 
-      - name: Run Gitleaks
+      - name: Fetch base ref for diff scan
         run: |
+          set -euo pipefail
+          # Ensure origin/<base_ref> resolves locally before gitleaks uses it
+          # in --log-opts. actions/checkout fetches the PR merge ref but not
+          # always the base branch tip.
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          echo "Base ref: origin/${{ github.base_ref }} -> $(git rev-parse "origin/${{ github.base_ref }}")"
+          echo "HEAD:     $(git rev-parse HEAD)"
+
+      - name: Run Gitleaks on PR diff range
+        run: |
+          set -euo pipefail
+          # --log-opts scopes the scan to commits introduced by this PR.
+          # --redact prevents leaked values from appearing in CI logs.
+          # --verbose keeps the output actionable for reviewers.
+          # Gitleaks exits non-zero on any finding, which fails the job —
+          # that is the intended strict-failure semantics.
           gitleaks detect \
             --source . \
             --log-opts="origin/${{ github.base_ref }}..HEAD" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "clap",
  "neat-core",

--- a/docs/pr-summary-21.md
+++ b/docs/pr-summary-21.md
@@ -1,0 +1,52 @@
+## Summary
+
+Hardens the Gitleaks PR-scan workflow so every run is reproducible, supply-chain verifiable, and scoped to the PR diff range. Closes #21.
+
+### What changed
+
+- **`.github/workflows/gitleaks.yml`** — rewritten with pinned binary install, SHA256 checksum verification, explicit `git fetch` of the PR base ref, `set -euo pipefail` in every `run:` block, and an inline comment explaining why the version is pinned. Scan scope stays at `origin/<base>..HEAD` so only the PR commit range is evaluated. Strict failure semantics are preserved — Gitleaks exits non-zero on any finding and the job fails.
+- **`scripts/check-gitleaks-workflow.sh`** — new validator that enforces the hardening rules against the workflow file. Designed for reuse from `quality.sh` and the bats suite; fails fast with a descriptive message when a rule regresses.
+- **`tests/scripts/gitleaks_workflow.bats`** — new 12-case bats suite covering every rule (each mutated fixture triggers the matching failure) plus a real-workflow assertion.
+- **`quality.sh`** — runs the new validator alongside the existing workflow-path check.
+- **`.codespellrc`** — excludes `docs/pr-summary-*.md` from codespell. These files quote typo fixtures from the PRs they describe (Issue #22 introduced this pattern) and were breaking every subsequent PR's quality gate.
+
+### Pinned version rationale
+
+Gitleaks is pinned to **v8.24.2** with SHA256 `fa0500f6b7e41d28791ebc680f5dd9899cd42b58629218a5f041efa899151a8e`. Pinning gives us:
+
+1. **Reproducibility** — a given PR always executes the same scanner binary, so rule updates never silently change PR-gating behaviour.
+2. **Supply-chain hygiene** — the downloaded archive is verified against a known checksum, so a compromised release asset cannot silently replace the scanner.
+3. **Transparency** — bumping Gitleaks is an explicit, reviewable change to both `GITLEAKS_VERSION` and `GITLEAKS_SHA256`.
+
+### Acceptance criteria
+
+- ✅ Replace/augment `gitleaks-action` with pinned binary install — direct release-tarball download, verified by SHA256.
+- ✅ Scan `origin/<base>..HEAD` in PR context — `--log-opts="origin/${{ github.base_ref }}..HEAD"` plus an explicit `git fetch origin <base_ref>` step so the ref resolves locally.
+- ✅ Keep logs actionable and failure semantics strict — `set -euo pipefail` in every run block, `--verbose --redact`, Gitleaks' non-zero exit on findings propagates to the job status.
+- ✅ Workflow documents the pinned version and why it is pinned — header comment block explains reproducibility, supply-chain hygiene, and the bump protocol.
+
+## Evidence
+
+Backend / CI change — no UI to screenshot. Verified via:
+
+1. `./quality.sh < /dev/null` — passes cleanly end-to-end (shellcheck, workflow validators, codespell, bats, cargo-deny, fmt, clippy, check, build, test, doc, release).
+2. `bats tests/scripts/gitleaks_workflow.bats` — 12/12 tests passing (hardened fixture passes; mutated fixtures each fail on the expected rule; real workflow satisfies every rule).
+3. Direct run: `./scripts/check-gitleaks-workflow.sh` → all nine hardening rules report `OK`.
+
+## Test Plan
+
+- Added `tests/scripts/gitleaks_workflow.bats` covering:
+  - Hardened fixture passes validation.
+  - Fails when the workflow uses `gitleaks-action` instead of a pinned binary.
+  - Fails when the pinned release URL is missing.
+  - Fails when there is no comment documenting the pin rationale.
+  - Fails when the archive checksum is not verified.
+  - Fails when the scan does not limit to `base..HEAD`.
+  - Fails when the base ref is not explicitly fetched.
+  - Fails when strict bash is missing from run blocks.
+  - Fails when the workflow does not invoke `gitleaks detect`.
+  - Reports an error when the workflow file does not exist.
+  - Unknown flag prints usage and exits non-zero.
+  - Real repository `gitleaks.yml` satisfies every hardening rule.
+- Existing bats suites (`spell_check.bats`, `version_increment.bats`, `workflow_neat_ai_core_path.bats`) continue to pass.
+- Full `./quality.sh` gate re-run: fmt / clippy / check / build / test / doc / release all green.

--- a/quality.sh
+++ b/quality.sh
@@ -35,6 +35,9 @@ echo "shellcheck: all scripts passed"
 echo "🔗 Validating NEAT-AI-core checkout path strategy in workflows..."
 ./scripts/check-workflow-paths.sh
 
+echo "🔐 Validating Gitleaks workflow hardening (Issue #21)..."
+./scripts/check-gitleaks-workflow.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-gitleaks-workflow.sh
+++ b/scripts/check-gitleaks-workflow.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Validate the hardened Gitleaks workflow (Issue #21).
+#
+# The Gitleaks workflow must:
+#   1. Install the Gitleaks binary from a pinned release (no floating
+#      gitleaks-action reference) so PR scans are reproducible.
+#   2. Verify the downloaded archive against a pinned SHA256 checksum so a
+#      compromised release asset cannot silently replace the scanner.
+#   3. Document the pinned version with a human-readable comment explaining
+#      why the pin exists (reviewer context, supply-chain rationale).
+#   4. Run `gitleaks detect` with `--log-opts=<base>..HEAD` so only the PR
+#      commit range is scanned (the whole history is already covered by
+#      nightly / main-branch scans in other pipelines).
+#   5. Use strict bash in every `run:` block (`set -euo pipefail`) so a
+#      failure in any sub-command fails the job rather than being swallowed.
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/gitleaks.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-gitleaks-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the Gitleaks workflow YAML file (default:
+                    .github/workflows/gitleaks.yml relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every hardening rule listed in the
+script header. Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/gitleaks.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+content="$(cat "$WORKFLOW")"
+
+# 1. No gitleaks-action marketplace reference — must be pinned binary install.
+if grep -qE '(^|[[:space:]-])uses:[[:space:]]*gitleaks/gitleaks-action' "$WORKFLOW"; then
+  fail "uses gitleaks-action — replace with pinned binary install"
+else
+  ok "no gitleaks-action reference (pinned binary install in use)"
+fi
+
+# 2. Pinned version present. The release URL must reference either a literal
+#    vX.Y.Z tag or an env variable whose value is bound in the workflow
+#    itself (e.g., `GITLEAKS_VERSION: "8.24.2"`).
+if grep -qE 'gitleaks/releases/download/v[0-9]+\.[0-9]+\.[0-9]+/' "$WORKFLOW"; then
+  ok "pinned Gitleaks release URL present (literal version tag)"
+elif grep -qE 'gitleaks/releases/download/v\$\{' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]*GITLEAKS_VERSION:[[:space:]]*"?[0-9]+\.[0-9]+\.[0-9]+"?' "$WORKFLOW"; then
+  ok "pinned Gitleaks release URL present (env-bound version)"
+else
+  fail "no pinned Gitleaks release URL (expect .../releases/download/vX.Y.Z/ or env-bound GITLEAKS_VERSION)"
+fi
+
+# 3. Pin rationale comment present — reviewers need to know why we pin.
+if grep -qiE '^[[:space:]]*#.*pin' "$WORKFLOW"; then
+  ok "pin rationale comment present"
+else
+  fail "no comment explaining why the version is pinned"
+fi
+
+# 4. SHA256 checksum verification of the downloaded archive.
+if grep -qE 'sha256sum[[:space:]]+(-c|--check)' "$WORKFLOW" \
+  || grep -qE 'shasum[[:space:]]+-a[[:space:]]+256[[:space:]]+(-c|--check)' "$WORKFLOW"; then
+  ok "archive checksum verification present"
+else
+  fail "no SHA256 checksum verification of the downloaded Gitleaks archive"
+fi
+
+# 5. PR-diff scan scope: --log-opts must limit to base..HEAD.
+if grep -qE '\-\-log-opts=?.*\.\.HEAD' "$WORKFLOW"; then
+  ok "--log-opts limits scan to PR diff range (base..HEAD)"
+else
+  fail "no --log-opts=<base>..HEAD — scan scope is not limited to the PR"
+fi
+
+# 6. github.base_ref referenced so the scan range is derived from the PR.
+if grep -qE 'github\.base_ref' "$WORKFLOW"; then
+  ok "base ref derived from github.base_ref"
+else
+  fail "scan range does not reference github.base_ref (base branch unknown)"
+fi
+
+# 7. Explicit fetch of the base ref so origin/<base> resolves locally.
+if grep -qE 'git[[:space:]]+fetch.*origin.*base_ref' "$WORKFLOW"; then
+  ok "explicit git fetch of the base ref present"
+else
+  fail "no explicit 'git fetch origin <base_ref>' — origin/<base> may not resolve"
+fi
+
+# 8. Strict bash in every run: block. We require `set -euo pipefail` at least
+#    once per workflow; a workflow that runs multiple shell steps without it
+#    is masking failures.
+if grep -qE 'set[[:space:]]+-euo[[:space:]]+pipefail' "$WORKFLOW"; then
+  ok "strict bash (set -euo pipefail) present"
+else
+  fail "no 'set -euo pipefail' in run: blocks — failures may be swallowed"
+fi
+
+# 9. Gitleaks invocation must exist and use 'detect' (scans commit range).
+if grep -qE 'gitleaks[[:space:]]+detect' "$WORKFLOW"; then
+  ok "gitleaks detect invocation present"
+else
+  fail "no 'gitleaks detect' invocation"
+fi
+
+# Silence unused-variable warning from shellcheck for $content, which future
+# extensions may use to parse the file directly.
+: "${content:=}"
+
+exit "$EXIT_CODE"

--- a/tests/scripts/gitleaks_workflow.bats
+++ b/tests/scripts/gitleaks_workflow.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-gitleaks-workflow.sh — Issue #21.
+#
+# Exercises the hardening validator with synthetic workflow YAML in
+# temporary directories so behaviour (exit codes, reported failures) is
+# verified end-to-end without touching the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-gitleaks-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Individual failure tests mutate this fixture
+# to drop or break one rule at a time.
+write_hardened_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Gitleaks
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks Secrets Detection
+    runs-on: ubuntu-latest
+    # Version is pinned so PR scans are reproducible and a compromised
+    # release asset cannot silently replace the scanner.
+    env:
+      GITLEAKS_VERSION: "8.24.2"
+      GITLEAKS_SHA256: "0000000000000000000000000000000000000000000000000000000000000000"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pinned Gitleaks binary
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}" -o "${archive}"
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum --check -
+          tar -xzf "${archive}" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+
+      - name: Fetch base ref for diff scan
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}"
+
+      - name: Run Gitleaks on PR diff range
+        run: |
+          set -euo pipefail
+          gitleaks detect \
+            --source . \
+            --log-opts="origin/${{ github.base_ref }}..HEAD" \
+            --redact \
+            --verbose
+EOF
+}
+
+@test "passes on a hardened workflow" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pinned Gitleaks release URL present"* ]]
+  [[ "$output" == *"archive checksum verification present"* ]]
+  [[ "$output" == *"--log-opts limits scan to PR diff range"* ]]
+  [[ "$output" == *"strict bash (set -euo pipefail) present"* ]]
+}
+
+@test "fails when the workflow uses gitleaks-action instead of a pinned binary" {
+  cat >"$TMP_WF/gitleaks.yml" <<'EOF'
+name: Gitleaks
+on: [pull_request]
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gitleaks/gitleaks-action@v2
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"uses gitleaks-action"* ]]
+}
+
+@test "fails when the pinned release URL is missing" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  # Replace the pinned URL with an unpinned command.
+  sed -i.bak 's|https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}|https://example.com/gitleaks-latest.tar.gz|' "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no pinned Gitleaks release URL"* ]]
+}
+
+@test "fails when there is no comment documenting the pin rationale" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  # Strip every comment line from the fixture.
+  grep -v '^[[:space:]]*#' "$TMP_WF/gitleaks.yml" >"$TMP_WF/gitleaks.stripped.yml"
+  mv "$TMP_WF/gitleaks.stripped.yml" "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no comment explaining why the version is pinned"* ]]
+}
+
+@test "fails when the archive checksum is not verified" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  # Remove the sha256sum verification line.
+  grep -v 'sha256sum' "$TMP_WF/gitleaks.yml" >"$TMP_WF/gitleaks.stripped.yml"
+  mv "$TMP_WF/gitleaks.stripped.yml" "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no SHA256 checksum verification"* ]]
+}
+
+@test "fails when the scan does not limit to base..HEAD" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  sed -i.bak 's|--log-opts="origin/${{ github.base_ref }}..HEAD"|--no-git|' "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no --log-opts=<base>..HEAD"* ]]
+}
+
+@test "fails when the base ref is not explicitly fetched" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  # Remove the git fetch step line.
+  grep -v 'git fetch' "$TMP_WF/gitleaks.yml" >"$TMP_WF/gitleaks.stripped.yml"
+  mv "$TMP_WF/gitleaks.stripped.yml" "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no explicit 'git fetch origin <base_ref>'"* ]]
+}
+
+@test "fails when strict bash is missing from run blocks" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  grep -v 'set -euo pipefail' "$TMP_WF/gitleaks.yml" >"$TMP_WF/gitleaks.stripped.yml"
+  mv "$TMP_WF/gitleaks.stripped.yml" "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'set -euo pipefail'"* ]]
+}
+
+@test "fails when the workflow does not invoke gitleaks detect" {
+  write_hardened_workflow "$TMP_WF/gitleaks.yml"
+  sed -i.bak 's|gitleaks detect|gitleaks version|' "$TMP_WF/gitleaks.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'gitleaks detect' invocation"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository gitleaks workflow satisfies every hardening rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Hardens the Gitleaks PR-scan workflow so every run is reproducible, supply-chain verifiable, and scoped to the PR diff range. Closes #21.

### What changed

- **`.github/workflows/gitleaks.yml`** — rewritten with pinned binary install, SHA256 checksum verification, explicit `git fetch` of the PR base ref, `set -euo pipefail` in every `run:` block, and an inline comment explaining why the version is pinned. Scan scope stays at `origin/<base>..HEAD` so only the PR commit range is evaluated. Strict failure semantics are preserved — Gitleaks exits non-zero on any finding and the job fails.
- **`scripts/check-gitleaks-workflow.sh`** — new validator that enforces the hardening rules against the workflow file. Designed for reuse from `quality.sh` and the bats suite; fails fast with a descriptive message when a rule regresses.
- **`tests/scripts/gitleaks_workflow.bats`** — new 12-case bats suite covering every rule (each mutated fixture triggers the matching failure) plus a real-workflow assertion.
- **`quality.sh`** — runs the new validator alongside the existing workflow-path check.
- **`.codespellrc`** — excludes `docs/pr-summary-*.md` from codespell. These files quote typo fixtures from the PRs they describe (Issue #22 introduced this pattern) and were breaking every subsequent PR's quality gate.

### Pinned version rationale

Gitleaks is pinned to **v8.24.2** with SHA256 `fa0500f6b7e41d28791ebc680f5dd9899cd42b58629218a5f041efa899151a8e`. Pinning gives us:

1. **Reproducibility** — a given PR always executes the same scanner binary, so rule updates never silently change PR-gating behaviour.
2. **Supply-chain hygiene** — the downloaded archive is verified against a known checksum, so a compromised release asset cannot silently replace the scanner.
3. **Transparency** — bumping Gitleaks is an explicit, reviewable change to both `GITLEAKS_VERSION` and `GITLEAKS_SHA256`.

### Acceptance criteria

- ✅ Replace/augment `gitleaks-action` with pinned binary install — direct release-tarball download, verified by SHA256.
- ✅ Scan `origin/<base>..HEAD` in PR context — `--log-opts="origin/${{ github.base_ref }}..HEAD"` plus an explicit `git fetch origin <base_ref>` step so the ref resolves locally.
- ✅ Keep logs actionable and failure semantics strict — `set -euo pipefail` in every run block, `--verbose --redact`, Gitleaks' non-zero exit on findings propagates to the job status.
- ✅ Workflow documents the pinned version and why it is pinned — header comment block explains reproducibility, supply-chain hygiene, and the bump protocol.

## Evidence

Backend / CI change — no UI to screenshot. Verified via:

1. `./quality.sh < /dev/null` — passes cleanly end-to-end (shellcheck, workflow validators, codespell, bats, cargo-deny, fmt, clippy, check, build, test, doc, release).
2. `bats tests/scripts/gitleaks_workflow.bats` — 12/12 tests passing (hardened fixture passes; mutated fixtures each fail on the expected rule; real workflow satisfies every rule).
3. Direct run: `./scripts/check-gitleaks-workflow.sh` → all nine hardening rules report `OK`.

## Test Plan

- Added `tests/scripts/gitleaks_workflow.bats` covering:
  - Hardened fixture passes validation.
  - Fails when the workflow uses `gitleaks-action` instead of a pinned binary.
  - Fails when the pinned release URL is missing.
  - Fails when there is no comment documenting the pin rationale.
  - Fails when the archive checksum is not verified.
  - Fails when the scan does not limit to `base..HEAD`.
  - Fails when the base ref is not explicitly fetched.
  - Fails when strict bash is missing from run blocks.
  - Fails when the workflow does not invoke `gitleaks detect`.
  - Reports an error when the workflow file does not exist.
  - Unknown flag prints usage and exits non-zero.
  - Real repository `gitleaks.yml` satisfies every hardening rule.
- Existing bats suites (`spell_check.bats`, `version_increment.bats`, `workflow_neat_ai_core_path.bats`) continue to pass.
- Full `./quality.sh` gate re-run: fmt / clippy / check / build / test / doc / release all green.



## Milestone
This PR is part of the **CI** milestone and targets the `milestone/ci` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-21 -->