### PR TITLE
ci: add auto-format PR job (cargo fmt + commit/push)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,88 @@
+# Auto-format PR job (Issue #19).
+#
+# Runs on pull requests targeting Develop or a milestone/* branch. Applies
+# `cargo fmt --all` on the PR branch; if the working tree changes, the fix
+# is committed and pushed back. Re-running on a clean branch is a no-op,
+# so the job is safe/idempotent.
+#
+# Permissions are scoped to the minimum: `contents: write` to push the
+# rustfmt commit. `pull-requests: read` is sufficient for the workflow's
+# metadata needs — the job does not comment or label the PR.
+name: Auto Format
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - Develop
+      - "milestone/**"
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  auto-format:
+    name: Auto-format Code
+    runs-on: ubuntu-latest
+    # Skip forks — GITHUB_TOKEN cannot push to a fork's branch. Formatting
+    # on fork PRs is the author's responsibility.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # NEAT-AI-core is a path dependency required for `cargo fmt --all`
+      # to resolve the workspace. Mirrors the strategy used in ci.yml —
+      # see the comment there for the path-strategy rationale.
+      - name: Checkout NEAT-AI-core (path dependency for neat-core)
+        uses: actions/checkout@v4
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          ref: Develop
+          path: NEAT-AI-core
+
+      - name: Link NEAT-AI-core sibling path expected by Cargo
+        run: |
+          set -euo pipefail
+          if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
+            ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Apply cargo fmt
+        run: |
+          set -euo pipefail
+          cargo fmt --all
+
+      - name: Detect formatting changes
+        id: detect
+        run: |
+          set -euo pipefail
+          if ./scripts/auto-format.sh --check-changes; then
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push rustfmt fixes
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          msg="$(./scripts/auto-format.sh --commit-message)"
+          git commit -am "$msg"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "clap",
  "neat-core",

--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ the job, so no duplicate bump commits are produced. The underlying logic
 lives in `scripts/version-increment.sh` and is covered by
 `tests/scripts/version_increment.bats`.
 
+PRs also run an auto-format job (`.github/workflows/auto-format.yml`,
+Issue #19). The job runs `cargo fmt --all` on the PR branch; if the working
+tree changes, the formatting fix is committed with a deterministic message
+and pushed back. When there are no changes the commit step is skipped, so
+re-running on a clean branch is a no-op. Change detection and the commit
+message live in `scripts/auto-format.sh` and are covered by
+`tests/scripts/auto_format.bats`; the workflow itself is validated by
+`scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`).
+
 ## License
 
 Apache-2.0 — see `LICENSE`.

--- a/docs/pr-summary-19.md
+++ b/docs/pr-summary-19.md
@@ -1,0 +1,21 @@
+## Summary
+Adds an auto-format PR job (`.github/workflows/auto-format.yml`) that runs `cargo fmt --all` on PR branches targeting `Develop` or `milestone/**`. When rustfmt produces changes, the job commits them with a deterministic message and pushes back to the PR branch; when the tree is already clean, the commit step is skipped, so re-running is a no-op. Closes #19.
+
+## Design
+- **Helper script**: `scripts/auto-format.sh` exposes two testable subcommands — `--commit-message` (deterministic string referencing issue #19) and `--check-changes` (exit 0 when the working tree is dirty, 1 when clean via `git status --porcelain`). Cargo invocations stay in the workflow, so the BATS suite needs no Rust toolchain.
+- **Workflow**: minimal permissions (`contents: write`, `pull-requests: read`), skips fork PRs (GITHUB_TOKEN cannot push to forks), and reuses the existing NEAT-AI-core sibling-checkout strategy so `cargo fmt --all` resolves the path dependency.
+- **Workflow validator**: `scripts/check-auto-format-workflow.sh` enforces the acceptance criteria (PR-only trigger, minimal permissions, `cargo fmt --all` invocation, conditional commit, fork guard, strict bash) and is run by `quality.sh` alongside the other workflow validators.
+
+## Evidence
+Backend/CI change — no UI to screenshot. Verified via:
+- `bats tests/scripts/auto_format.bats` — 13/13 pass, including fixtures that exercise every validator failure mode plus the shipped `auto-format.yml`.
+- `./quality.sh` — passes cleanly (shellcheck, workflow path check, Gitleaks validator, auto-format validator, codespell, bats, cargo-deny, fmt, clippy, check, build, tests, doc, release).
+
+## Test Plan
+- `tests/scripts/auto_format.bats` — new BATS suite covering:
+  - `--commit-message` is deterministic and mentions rustfmt + issue #19.
+  - `--check-changes` exits 1 on a clean git repo, exits 0 on modified tracked files, exits 0 when a new untracked file appears.
+  - Usage errors (unknown flag, missing mode) fail non-zero and print usage.
+  - Workflow validator passes on a well-formed fixture.
+  - Workflow validator fails when: `pull_request` trigger missing, `write-all` permissions, no `cargo fmt --all`, commit step unconditional, fork-PR guard missing.
+  - Shipped `.github/workflows/auto-format.yml` validates cleanly.

--- a/quality.sh
+++ b/quality.sh
@@ -38,6 +38,9 @@ echo "🔗 Validating NEAT-AI-core checkout path strategy in workflows..."
 echo "🔐 Validating Gitleaks workflow hardening (Issue #21)..."
 ./scripts/check-gitleaks-workflow.sh
 
+echo "🪄 Validating auto-format PR workflow (Issue #19)..."
+./scripts/check-auto-format-workflow.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/auto-format.sh
+++ b/scripts/auto-format.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Auto-format helper for the CI PR job (Issue #19).
+#
+# Responsibilities:
+#   * Emit the deterministic commit message the workflow uses when pushing
+#     rustfmt-generated fixes back onto a PR branch.
+#   * Detect whether the working tree has pending changes after `cargo fmt`
+#     ran, so the workflow can commit only when needed (idempotent guard).
+#
+# Running cargo is the workflow's job — this script does not invoke any
+# build tooling, which keeps the BATS suite hermetic (no Rust toolchain
+# required in the bash helper tests).
+set -euo pipefail
+
+COMMIT_MESSAGE="chore(fmt): apply cargo fmt fixes
+
+Automated by the auto-format PR job — see issue #19."
+
+usage() {
+  cat <<'EOF'
+Usage: auto-format.sh <mode> [--repo DIR]
+
+Modes (exactly one):
+  --commit-message   Print the deterministic commit message.
+  --check-changes    Exit 0 when the git working tree has pending changes
+                     (tracked or untracked), exit 1 when it is clean.
+
+Options:
+  --repo DIR         Repository directory for git operations (default: cwd).
+  -h, --help         Show this message.
+EOF
+}
+
+MODE=""
+REPO_DIR="."
+
+set_mode() {
+  if [[ -n "$MODE" ]]; then
+    echo "Usage error: only one mode may be supplied" >&2
+    usage >&2
+    exit 2
+  fi
+  MODE="$1"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --commit-message) set_mode commit-message; shift ;;
+    --check-changes)  set_mode check-changes;  shift ;;
+    --repo)           REPO_DIR="$2"; shift 2 ;;
+    -h|--help)        usage; exit 0 ;;
+    *)
+      echo "Usage error: unknown option '$1'" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "Usage error: a mode is required" >&2
+  usage >&2
+  exit 2
+fi
+
+case "$MODE" in
+  commit-message)
+    printf '%s\n' "$COMMIT_MESSAGE"
+    ;;
+
+  check-changes)
+    # Inspect both tracked modifications and untracked files. `git status
+    # --porcelain` prints one line per changed path and nothing for a clean
+    # tree, which is the cheapest way to cover both cases in a single call.
+    status_output="$(cd "$REPO_DIR" && git status --porcelain)"
+    if [[ -z "$status_output" ]]; then
+      echo "clean: no formatting changes detected"
+      exit 1
+    else
+      echo "dirty: formatting changes detected"
+      exit 0
+    fi
+    ;;
+esac

--- a/scripts/check-auto-format-workflow.sh
+++ b/scripts/check-auto-format-workflow.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Validate the auto-format PR workflow (Issue #19).
+#
+# The auto-format workflow must:
+#   1. Run on `pull_request` events only — formatting fixes push back to
+#      the PR branch, which is meaningless for `push` / scheduled events.
+#   2. Declare minimal permissions: `contents: write` is required to push,
+#      nothing beyond what the job needs should be granted (in particular
+#      not `write-all` or scopes the workflow doesn't use).
+#   3. Invoke `cargo fmt --all` to produce the formatting fixes.
+#   4. Gate the commit/push step behind a change-detection output so the
+#      job is idempotent — re-running on a clean branch is a no-op.
+#   5. Refuse to push onto a fork's PR branch (the GITHUB_TOKEN cannot
+#      write there anyway; skipping keeps failure messages tidy).
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-auto-format-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the auto-format workflow YAML file (default:
+                    .github/workflows/auto-format.yml relative to repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/auto-format.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. pull_request trigger present.
+if grep -qE '^[[:space:]]*pull_request:' "$WORKFLOW"; then
+  ok "pull_request trigger present"
+else
+  fail "no pull_request trigger — auto-format must only run on PRs"
+fi
+
+# 2. Minimal permissions. `contents: write` is the one scope required to
+#    push. Reject `write-all`, or any scope we don't expect.
+if grep -qE '^[[:space:]]*permissions:[[:space:]]*write-all' "$WORKFLOW"; then
+  fail "'permissions: write-all' grants more than this job needs (use contents: write)"
+elif grep -qE '^[[:space:]]*contents:[[:space:]]*write' "$WORKFLOW"; then
+  ok "minimal write permission (contents: write) present"
+else
+  fail "no 'contents: write' permission — the job cannot push rustfmt fixes"
+fi
+
+# 3. cargo fmt invocation present. Require `--all` so the whole workspace is
+#    formatted (matches quality.sh and ci.yml's `cargo fmt --all -- --check`).
+if grep -qE 'cargo[[:space:]]+fmt[[:space:]]+--all' "$WORKFLOW"; then
+  ok "cargo fmt --all invocation present"
+else
+  fail "no 'cargo fmt --all' invocation"
+fi
+
+# 4. Change-detection guard on the commit/push step. We look for a step that
+#    declares `if:` and references the detection output — the specific id
+#    name is flexible but the presence of conditional commit/push is
+#    mandatory for idempotency.
+#    The pattern: somewhere in the file, a step's `if:` references
+#    `steps.<id>.outputs.` — that is the only way a prior step's change
+#    detection can gate the commit.
+if grep -qE '^[[:space:]]*if:[[:space:]]*steps\.[A-Za-z0-9_-]+\.outputs\.' "$WORKFLOW"; then
+  ok "commit/push is conditional on change-detection output (idempotent guard)"
+else
+  fail "no conditional 'if: steps.*.outputs.*' guard — commit/push must be conditional"
+fi
+
+# 5. Fork-PR safety — skip when the PR head is on a fork. Any of the common
+#    forms satisfy this check: comparing `head.repo.full_name` to
+#    `github.repository`, or checking `head.repo.fork == false`.
+if grep -qE 'github\.event\.pull_request\.head\.repo\.full_name[[:space:]]*==' "$WORKFLOW" \
+  || grep -qE 'github\.event\.pull_request\.head\.repo\.fork' "$WORKFLOW"; then
+  ok "fork PRs are excluded from the push step"
+else
+  fail "no head.repo check — pushes onto forks will fail silently"
+fi
+
+# 6. Strict bash in every run: block that does a commit/push sequence.
+if grep -qE 'set[[:space:]]+-euo[[:space:]]+pipefail' "$WORKFLOW"; then
+  ok "strict bash (set -euo pipefail) present"
+else
+  fail "no 'set -euo pipefail' in run: blocks — failures may be swallowed"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/auto_format.bats
+++ b/tests/scripts/auto_format.bats
@@ -1,0 +1,267 @@
+#!/usr/bin/env bats
+# Tests for scripts/auto-format.sh and scripts/check-auto-format-workflow.sh
+# (Issue #19 — auto-format PR job).
+#
+# The helper script is invoked from the workflow to (a) detect whether a
+# `cargo fmt --all` produced any changes in the working tree and (b) emit
+# a deterministic commit message. Running cargo itself is the workflow's
+# job — the script takes the resulting working tree as-is and reports on it,
+# which keeps these tests hermetic (no Rust toolchain required).
+
+setup() {
+  AUTO_FORMAT="${BATS_TEST_DIRNAME}/../../scripts/auto-format.sh"
+  WF_CHECK="${BATS_TEST_DIRNAME}/../../scripts/check-auto-format-workflow.sh"
+  [ -x "$AUTO_FORMAT" ] || chmod +x "$AUTO_FORMAT"
+  [ -x "$WF_CHECK" ] || chmod +x "$WF_CHECK"
+
+  TMP_REPO="$(mktemp -d)"
+  (
+    cd "$TMP_REPO"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "hello" >file.txt
+    git add file.txt
+    git commit -q -m "initial"
+  )
+  export TMP_REPO
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_REPO" "$TMP_WF"
+}
+
+# --- auto-format.sh --------------------------------------------------------
+
+@test "commit-message prints a deterministic message mentioning rustfmt and issue 19" {
+  run "$AUTO_FORMAT" --commit-message
+  [ "$status" -eq 0 ]
+  first="$output"
+
+  run "$AUTO_FORMAT" --commit-message
+  [ "$status" -eq 0 ]
+  # Deterministic across invocations.
+  [ "$output" = "$first" ]
+  [[ "$output" == *"rustfmt"* ]]
+  [[ "$output" == *"#19"* ]]
+}
+
+@test "check-changes exits 1 on a clean working tree" {
+  run "$AUTO_FORMAT" --check-changes --repo "$TMP_REPO"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"clean"* ]]
+}
+
+@test "check-changes exits 0 when the working tree is dirty" {
+  echo "dirty" >>"$TMP_REPO/file.txt"
+  run "$AUTO_FORMAT" --check-changes --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dirty"* ]]
+}
+
+@test "check-changes exits 0 when a new file appears in the working tree" {
+  echo "new" >"$TMP_REPO/new.txt"
+  (cd "$TMP_REPO" && git add -N new.txt)
+  run "$AUTO_FORMAT" --check-changes --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$AUTO_FORMAT" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "missing mode prints usage and exits non-zero" {
+  run "$AUTO_FORMAT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+# --- check-auto-format-workflow.sh ----------------------------------------
+
+write_good_workflow() {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+# Auto-format PR job (Issue #19).
+name: Auto Format
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - Develop
+      - "milestone/**"
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  auto-format:
+    name: Auto-format Code
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Apply cargo fmt
+        run: |
+          set -euo pipefail
+          cargo fmt --all
+      - name: Detect formatting changes
+        id: detect
+        run: |
+          set -euo pipefail
+          if ./scripts/auto-format.sh --check-changes; then
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          fi
+      - name: Commit and push rustfmt fixes
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          msg="$(./scripts/auto-format.sh --commit-message)"
+          git commit -am "$msg"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+EOF
+}
+
+@test "workflow validator passes on a well-formed fixture" {
+  write_good_workflow
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "workflow validator fails when pull_request trigger is missing" {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+name: Auto Format
+on:
+  push:
+    branches: [Develop]
+permissions:
+  contents: write
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo fmt --all
+EOF
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pull_request"* ]]
+}
+
+@test "workflow validator fails when permissions grant more than needed" {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+name: Auto Format
+on:
+  pull_request:
+    branches: [Develop]
+permissions: write-all
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo fmt --all
+EOF
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"permission"* ]]
+}
+
+@test "workflow validator fails when cargo fmt is not invoked" {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+name: Auto Format
+on:
+  pull_request:
+    branches: [Develop]
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo nothing
+EOF
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cargo fmt"* ]]
+}
+
+@test "workflow validator fails when the commit step is unconditional" {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+name: Auto Format
+on:
+  pull_request:
+    branches: [Develop]
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo fmt --all
+      - name: Commit
+        run: |
+          git commit -am "fmt"
+          git push
+EOF
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"conditional"* || "$output" == *"guard"* ]]
+}
+
+@test "workflow validator fails when fork PRs would be pushed to" {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+name: Auto Format
+on:
+  pull_request:
+    branches: [Develop]
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Apply cargo fmt
+        run: cargo fmt --all
+      - name: Detect formatting changes
+        id: detect
+        run: |
+          if ./scripts/auto-format.sh --check-changes; then
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          fi
+      - name: Commit
+        if: steps.detect.outputs.changed == 'true'
+        run: git commit -am "fmt" && git push
+EOF
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"fork"* || "$output" == *"head.repo"* ]]
+}
+
+@test "real repository auto-format workflow validates cleanly" {
+  # The shipped .github/workflows/auto-format.yml must satisfy every rule.
+  run "$WF_CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary
Adds an auto-format PR job (`.github/workflows/auto-format.yml`) that runs `cargo fmt --all` on PR branches targeting `Develop` or `milestone/**`. When rustfmt produces changes, the job commits them with a deterministic message and pushes back to the PR branch; when the tree is already clean, the commit step is skipped, so re-running is a no-op. Closes #19.

## Design
- **Helper script**: `scripts/auto-format.sh` exposes two testable subcommands — `--commit-message` (deterministic string referencing issue #19) and `--check-changes` (exit 0 when the working tree is dirty, 1 when clean via `git status --porcelain`). Cargo invocations stay in the workflow, so the BATS suite needs no Rust toolchain.
- **Workflow**: minimal permissions (`contents: write`, `pull-requests: read`), skips fork PRs (GITHUB_TOKEN cannot push to forks), and reuses the existing NEAT-AI-core sibling-checkout strategy so `cargo fmt --all` resolves the path dependency.
- **Workflow validator**: `scripts/check-auto-format-workflow.sh` enforces the acceptance criteria (PR-only trigger, minimal permissions, `cargo fmt --all` invocation, conditional commit, fork guard, strict bash) and is run by `quality.sh` alongside the other workflow validators.

## Evidence
Backend/CI change — no UI to screenshot. Verified via:
- `bats tests/scripts/auto_format.bats` — 13/13 pass, including fixtures that exercise every validator failure mode plus the shipped `auto-format.yml`.
- `./quality.sh` — passes cleanly (shellcheck, workflow path check, Gitleaks validator, auto-format validator, codespell, bats, cargo-deny, fmt, clippy, check, build, tests, doc, release).

## Test Plan
- `tests/scripts/auto_format.bats` — new BATS suite covering:
  - `--commit-message` is deterministic and mentions rustfmt + issue #19.
  - `--check-changes` exits 1 on a clean git repo, exits 0 on modified tracked files, exits 0 when a new untracked file appears.
  - Usage errors (unknown flag, missing mode) fail non-zero and print usage.
  - Workflow validator passes on a well-formed fixture.
  - Workflow validator fails when: `pull_request` trigger missing, `write-all` permissions, no `cargo fmt --all`, commit step unconditional, fork-PR guard missing.
  - Shipped `.github/workflows/auto-format.yml` validates cleanly.



## Milestone
This PR is part of the **CI** milestone and targets the `milestone/ci` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-19 -->