### PR TITLE
ci: enforce explicit job graph and add ci-required aggregator (#23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,27 @@
 # Quality bar aligned with NEAT-AI-Discovery (fmt, clippy, tests, security, spell & shell checks).
+#
+# Job dependency graph (Issue #23):
+#
+#   validation ──┬── quality ─────────────┐
+#                │                         │
+#                └── security ─────────────┤
+#                                          ├──► ci-required  (aggregator)
+#   shell-checks ──────────────────────────┤
+#   spell-check ───────────────────────────┘
+#
+# * `validation` is the foundational check: it verifies the required files
+#   and Cargo metadata. Running it first means we do not burn runner minutes
+#   on a Rust compile when the repo layout itself is broken.
+# * `quality` and `security` depend on `validation` so a missing manifest
+#   fails fast without spinning up a full build or security scan.
+# * `shell-checks` and `spell-check` are lightweight and independent — they
+#   always run in parallel to surface their findings early on every push/PR.
+# * `ci-required` is a fan-in aggregator job with `if: always()`. It inspects
+#   `needs.<job>.result` and succeeds only when every gating job succeeded
+#   (or was cleanly skipped, e.g. `security` on non-PR events). Branch
+#   protection should pin exactly one required status check — this one —
+#   so the merge-readiness signal is stable regardless of how the underlying
+#   graph evolves.
 name: CI
 
 on:
@@ -21,6 +44,8 @@ env:
 jobs:
   quality:
     name: Quality Checks
+    # Foundational layout check must pass before we spend minutes compiling.
+    needs: [validation]
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-D warnings"
@@ -116,6 +141,9 @@ jobs:
         run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 
   security:
+    # Fan-in after `validation` keeps security audits aligned with the rest
+    # of the graph — no advisory scan runs against a broken repo layout.
+    needs: [validation]
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'
     with:
@@ -230,3 +258,63 @@ jobs:
 
       - name: Run codespell preflight
         run: ./scripts/spell-check.sh
+
+  # ------------------------------------------------------------------
+  # Aggregator job — single stable required check for branch protection.
+  # ------------------------------------------------------------------
+  # Branch protection should pin exactly one required check: `CI Required
+  # Checks`. This fan-in job depends on every gating job above and uses
+  # `if: always()` so it always reports a result, even when an upstream job
+  # failed. The explicit `needs.<job>.result` inspection below turns
+  # `always()` into a real gate: the step exits non-zero unless every
+  # dependency reported `success` (or `skipped`, which is the expected state
+  # for `security` on push events where the dependency-review step is
+  # deliberately disabled).
+  #
+  # Why an aggregator at all?
+  # * Stable required-check name — adding/removing a gating job no longer
+  #   requires a branch-protection update.
+  # * Deterministic re-run behaviour — a re-run of a failed upstream job
+  #   automatically re-runs the aggregator (GitHub re-evaluates fan-in
+  #   dependents), so the required check reflects the latest state.
+  # * Clear partial-failure semantics — the aggregator summarises *why* it
+  #   failed in its log, pointing reviewers at the specific upstream.
+  ci-required:
+    name: CI Required Checks
+    needs: [validation, quality, security, shell-checks, spell-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all gating jobs succeeded
+        env:
+          VALIDATION_RESULT: ${{ needs.validation.result }}
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+          SHELL_CHECKS_RESULT: ${{ needs.shell-checks.result }}
+          SPELL_CHECK_RESULT: ${{ needs.spell-check.result }}
+        run: |
+          set -euo pipefail
+          # Accept `success` (ran and passed) and `skipped` (e.g. `security`
+          # on non-PR events). Anything else — failure, cancelled, timed
+          # out — must fail the aggregator so branch protection blocks the
+          # merge.
+          fail=0
+          check() {
+            local name="$1" result="$2"
+            if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+              echo "OK   $name: $result"
+            else
+              echo "FAIL $name: $result" >&2
+              fail=1
+            fi
+          }
+          check "validation"   "$VALIDATION_RESULT"
+          check "quality"      "$QUALITY_RESULT"
+          check "security"     "$SECURITY_RESULT"
+          check "shell-checks" "$SHELL_CHECKS_RESULT"
+          check "spell-check"  "$SPELL_CHECK_RESULT"
+          if [[ "$fail" -ne 0 ]]; then
+            echo "One or more gating jobs did not succeed — blocking merge." >&2
+            exit 1
+          fi
+          echo "All gating jobs succeeded — safe to merge."

--- a/README.md
+++ b/README.md
@@ -158,6 +158,37 @@ for the six-way dispatch pattern.
 
 ## CI
 
+### Job dependency graph (Issue #23)
+
+`.github/workflows/ci.yml` declares an explicit job graph so ordering is
+predictable on re-runs and partial failures:
+
+```
+validation ──┬── quality ─────────────┐
+             │                         │
+             └── security ─────────────┤
+                                       ├──► ci-required  (aggregator)
+shell-checks ──────────────────────────┤
+spell-check ───────────────────────────┘
+```
+
+* **`validation`** is the foundation — it verifies required files and Cargo
+  metadata. `quality` and `security` `needs: [validation]` so a broken repo
+  layout fails fast without burning Rust compile minutes or a security scan.
+* **`shell-checks`** and **`spell-check`** are lightweight and run in
+  parallel with the foundation to surface findings early.
+* **`ci-required`** is a single fan-in aggregator. It `needs:` every gating
+  job, uses `if: always()` so it always reports a result, and inspects
+  `needs.<job>.result` in its run step to fail unless every dependency
+  reported `success` or `skipped`. **Branch protection should pin exactly
+  one required check — `CI Required Checks` — so the merge gate is stable
+  even when individual gating jobs are added or renamed.**
+
+The graph is validated by `scripts/check-ci-job-graph.sh` (wired into
+`quality.sh`) and covered end-to-end by `tests/scripts/workflow_job_graph.bats`.
+
+### Other PR automation
+
 Besides the quality gate (`.github/workflows/ci.yml`), PRs also run a guarded
 auto-version increment job (`.github/workflows/version-increment.yml`,
 Issue #20). On each PR the job compares `rust_scorer/Cargo.toml` against the

--- a/docs/pr-summary-23.md
+++ b/docs/pr-summary-23.md
@@ -1,0 +1,64 @@
+## Summary
+
+Make the CI workflow graph explicit and the merge gate stable. `ci.yml` now
+declares a purposeful `needs:` graph and a single fan-in aggregator job
+(`CI Required Checks`) that branch protection can pin as the one required
+check. Re-runs and partial failures are deterministic: the aggregator uses
+`if: always()` and fails unless every upstream reports `success` or
+`skipped`. Closes #23.
+
+## Graph
+
+```
+validation ──┬── quality ─────────────┐
+             │                         │
+             └── security ─────────────┤
+                                       ├──► ci-required  (aggregator)
+shell-checks ──────────────────────────┤
+spell-check ───────────────────────────┘
+```
+
+* `validation` is the foundational layout check — it runs first so a broken
+  repo layout never spins up a Rust compile or a security audit.
+* `quality` and `security` now `needs: [validation]`.
+* `shell-checks` and `spell-check` stay independent and run in parallel.
+* `ci-required` fans in all gating jobs, inspects `needs.<job>.result`
+  explicitly, and is the single required check for branch protection.
+
+## Evidence
+
+Backend/CI-only change — no web UI to screenshot. Evidence is the bats
+suite and the YAML validator:
+
+* `scripts/check-ci-job-graph.sh` parses `ci.yml` and enforces the rules
+  (expected jobs defined, `needs:` edges present, aggregator uses
+  `if: always()` and checks `needs.*.result`). Wired into `quality.sh`.
+* `./quality.sh` runs green locally (60/60 bats tests, 28 Rust unit tests,
+  3 TDD tests, 4 smoke tests).
+* `python3 -c "import yaml; ..."` confirms the `jobs` map and `needs`
+  edges match the design exactly:
+
+  ```
+  quality ['validation']
+  security ['validation']
+  validation None
+  shell-checks None
+  spell-check None
+  ci-required ['validation', 'quality', 'security', 'shell-checks', 'spell-check']
+  ```
+
+## Test Plan
+
+* Added `tests/scripts/workflow_job_graph.bats` — 9 cases covering:
+  * Happy path: a synthetic workflow with the expected graph passes.
+  * Missing aggregator job fails with a clear error.
+  * Missing `needs: [validation]` on `quality` fails.
+  * Missing `if: always()` on the aggregator fails.
+  * Aggregator without `needs.*.result` inspection fails.
+  * Aggregator missing a gating job fails with the specific job name.
+  * Missing workflow file and unknown flag yield descriptive errors.
+  * The real repository `ci.yml` satisfies every rule.
+* Existing 51 bats tests continue to pass unchanged.
+* Post-merge verification: on the PR itself, confirm `CI Required Checks`
+  appears as a status check; once green, update branch protection (human
+  step) to require only that one check.

--- a/quality.sh
+++ b/quality.sh
@@ -41,6 +41,9 @@ echo "🔐 Validating Gitleaks workflow hardening (Issue #21)..."
 echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 ./scripts/check-auto-format-workflow.sh
 
+echo "🧭 Validating CI job dependency graph (Issue #23)..."
+./scripts/check-ci-job-graph.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-ci-job-graph.sh
+++ b/scripts/check-ci-job-graph.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Validate the CI job dependency graph in .github/workflows/ci.yml (Issue #23).
+#
+# The workflow must declare explicit `needs:` relationships so that:
+#   1. Foundational jobs (file layout validation) run before expensive jobs
+#      (the Rust compile/test matrix), making re-runs and partial failures
+#      predictable.
+#   2. A single aggregator job `ci-required` fans in every gating job and
+#      succeeds only when all of them succeed (or are cleanly skipped for
+#      event types where a dependency is irrelevant, e.g. `security` on push).
+#      Branch protection pins this one stable name as the required status.
+#
+# Rules enforced:
+#   * Expected jobs are defined: validation, quality, security, shell-checks,
+#     spell-check, ci-required.
+#   * `quality` and `security` each declare `needs: [validation]` (ordering —
+#     do not waste compute until the foundation check passes).
+#   * `ci-required` lists every gating job in its `needs:` and uses
+#     `if: always()` so it reports a deterministic result even on failure.
+#   * `ci-required` inspects `needs.*.result` via an explicit success check —
+#     otherwise `always()` would mask upstream failures.
+#
+# This validator is purpose-built: it scans `ci.yml` line-by-line rather than
+# pulling in a YAML parser. Designed for reuse from BATS tests.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-ci-job-graph.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the CI workflow YAML file (default:
+                    .github/workflows/ci.yml relative to repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow declares the expected job dependency graph, a
+single aggregator job, and deterministic result semantics. Exits non-zero
+with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# Emit a JSON-ish report of each job's top-level keys (`needs`, `if`) using a
+# minimal Python scanner — same approach as check-workflow-paths.sh.
+report="$(
+  python3 - "$WORKFLOW" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+# Find the `jobs:` map. We expect it at column 0.
+jobs_start = None
+for i, line in enumerate(lines):
+    if line.rstrip() == "jobs:":
+        jobs_start = i + 1
+        break
+
+if jobs_start is None:
+    print("ERROR\tno 'jobs:' key found")
+    sys.exit(0)
+
+# Determine job entries: keys at indent == 2 under `jobs:`.
+job_indent = None
+jobs = []  # list of (name, start, end)
+i = jobs_start
+while i < len(lines):
+    line = lines[i]
+    if not line.strip() or line.lstrip().startswith("#"):
+        i += 1
+        continue
+    ind = indent_of(line)
+    # A new top-level section at column 0 ends the jobs map.
+    if ind == 0:
+        break
+    if job_indent is None:
+        job_indent = ind
+    if ind == job_indent and line.rstrip().endswith(":"):
+        name = line.strip().rstrip(":")
+        jobs.append([name, i, None])
+    i += 1
+
+# Fill in end indices.
+for k, entry in enumerate(jobs):
+    if k + 1 < len(jobs):
+        entry[2] = jobs[k + 1][1]
+    else:
+        # End at next column-0 key or EOF.
+        end = len(lines)
+        for j in range(entry[1] + 1, len(lines)):
+            if lines[j] and indent_of(lines[j]) == 0:
+                end = j
+                break
+        entry[2] = end
+
+for name, start, end in jobs:
+    block = lines[start:end]
+    needs_val = ""
+    if_val = ""
+    # Only inspect keys that are direct children of the job (indent ==
+    # job_indent + 2). Nested `if:` inside steps must be ignored.
+    child_indent = job_indent + 2
+    k = 0
+    while k < len(block):
+        line = block[k]
+        if not line.strip() or line.lstrip().startswith("#"):
+            k += 1
+            continue
+        ind = indent_of(line)
+        if ind != child_indent:
+            k += 1
+            continue
+        s = line.strip()
+        if s.startswith("needs:"):
+            tail = s[len("needs:"):].strip()
+            if tail:
+                # inline form: `needs: [a, b]` or `needs: a`
+                needs_val = tail
+            else:
+                # block-scalar list form
+                collected = []
+                m = k + 1
+                while m < len(block):
+                    nxt = block[m]
+                    if not nxt.strip():
+                        m += 1
+                        continue
+                    ni = indent_of(nxt)
+                    if ni <= child_indent:
+                        break
+                    if nxt.lstrip().startswith("- "):
+                        collected.append(nxt.strip()[2:].strip())
+                    m += 1
+                needs_val = "[" + ", ".join(collected) + "]"
+        elif s.startswith("if:"):
+            if_val = s[len("if:"):].strip()
+        k += 1
+    print(f"JOB\t{name}\t{needs_val}\t{if_val}")
+PY
+)"
+
+# Parse the report. macOS bash 3.2 lacks associative arrays, so look up each
+# job's metadata by greppping the TSV report on demand.
+if [[ "$report" == *$'\t'*"ERROR"* || "${report%%$'\t'*}" == "ERROR" ]]; then
+  fail "${report#ERROR$'\t'}"
+  exit 1
+fi
+
+# Helper: print the `needs` field for a named job (empty string if absent).
+lookup_needs() {
+  local target="$1"
+  awk -F '\t' -v name="$target" '$1=="JOB" && $2==name { print $3 }' <<< "$report"
+}
+
+# Helper: print the `if` field for a named job (empty string if absent).
+lookup_if() {
+  local target="$1"
+  awk -F '\t' -v name="$target" '$1=="JOB" && $2==name { print $4 }' <<< "$report"
+}
+
+has_job() {
+  local target="$1"
+  awk -F '\t' -v name="$target" 'BEGIN { found=1 } $1=="JOB" && $2==name { found=0 } END { exit found }' <<< "$report"
+}
+
+# 1. Expected gating jobs are defined.
+EXPECTED=(validation quality security shell-checks spell-check ci-required)
+for job in "${EXPECTED[@]}"; do
+  if has_job "$job"; then
+    ok "job '$job' defined"
+  else
+    fail "expected job '$job' is not defined"
+  fi
+done
+
+# 2. `quality` depends on `validation` (foundation runs first).
+quality_needs="$(lookup_needs quality)"
+if [[ "$quality_needs" == *"validation"* ]]; then
+  ok "job 'quality' declares needs on 'validation'"
+else
+  fail "job 'quality' must declare needs: [validation] so foundation runs first"
+fi
+
+# 3. `security` depends on `validation`.
+security_needs="$(lookup_needs security)"
+if [[ "$security_needs" == *"validation"* ]]; then
+  ok "job 'security' declares needs on 'validation'"
+else
+  fail "job 'security' must declare needs: [validation]"
+fi
+
+# 4. `ci-required` lists every gating job in its needs.
+GATING=(validation quality security shell-checks spell-check)
+ci_needs="$(lookup_needs ci-required)"
+for g in "${GATING[@]}"; do
+  if [[ "$ci_needs" == *"$g"* ]]; then
+    ok "aggregator 'ci-required' needs '$g'"
+  else
+    fail "aggregator 'ci-required' must list '$g' in needs (found: '$ci_needs')"
+  fi
+done
+
+# 5. `ci-required` uses `if: always()` so it reports a result even on upstream
+#    failure — otherwise the check would be "skipped" and branch protection
+#    would wait forever.
+ci_if="$(lookup_if ci-required)"
+if [[ "$ci_if" == *"always()"* ]]; then
+  ok "aggregator 'ci-required' uses if: always()"
+else
+  fail "aggregator 'ci-required' must set 'if: always()' for deterministic result"
+fi
+
+# 6. The aggregator's run: block must check needs.*.result explicitly —
+#    otherwise `always()` would pass the job even if an upstream job failed.
+if grep -qE 'needs\.[A-Za-z0-9_-]+\.result' "$WORKFLOW"; then
+  ok "aggregator checks needs.*.result explicitly"
+else
+  fail "aggregator must inspect 'needs.<job>.result' — always() alone masks failures"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/workflow_job_graph.bats
+++ b/tests/scripts/workflow_job_graph.bats
@@ -1,0 +1,262 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-ci-job-graph.sh — Issue #23.
+#
+# Exercises the validator end-to-end with synthetic CI workflow YAML in
+# temporary directories, plus one assertion against the real repo workflow
+# so the enforced graph and the shipped workflow cannot drift apart.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-ci-job-graph.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF_DIR="$(mktemp -d)"
+  TMP_WF="$TMP_WF_DIR/ci.yml"
+  export TMP_WF_DIR TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF_DIR"
+}
+
+write_good_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: CI
+on: [pull_request]
+jobs:
+  validation:
+    name: Project Validation
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+
+  quality:
+    name: Quality Checks
+    needs: [validation]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+
+  security:
+    needs: [validation]
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/security.yml
+
+  shell-checks:
+    name: Shell Script Quality
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+
+  spell-check:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+
+  ci-required:
+    name: CI Required Checks
+    needs: [validation, quality, security, shell-checks, spell-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all gating jobs succeeded
+        run: |
+          results=(
+            "${{ needs.validation.result }}"
+            "${{ needs.quality.result }}"
+            "${{ needs.security.result }}"
+            "${{ needs.shell-checks.result }}"
+            "${{ needs.spell-check.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              exit 1
+            fi
+          done
+EOF
+}
+
+@test "passes when the CI graph declares explicit needs and an aggregator" {
+  write_good_workflow "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"job 'validation' defined"* ]]
+  [[ "$output" == *"aggregator 'ci-required' needs 'quality'"* ]]
+  [[ "$output" == *"aggregator 'ci-required' uses if: always()"* ]]
+}
+
+@test "fails when the aggregator job is missing" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  quality:
+    needs: [validation]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  security:
+    needs: [validation]
+    uses: ./.github/workflows/security.yml
+  shell-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"expected job 'ci-required' is not defined"* ]]
+}
+
+@test "fails when quality has no needs on validation" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  security:
+    needs: [validation]
+    uses: ./.github/workflows/security.yml
+  shell-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  ci-required:
+    needs: [validation, quality, security, shell-checks, spell-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ needs.quality.result }}"
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"job 'quality' must declare needs: [validation]"* ]]
+}
+
+@test "fails when the aggregator is missing 'if: always()'" {
+  write_good_workflow "$TMP_WF"
+  # Strip the aggregator's `if: always()` line.
+  awk '
+    BEGIN { in_ci_required = 0 }
+    /^  ci-required:/ { in_ci_required = 1 }
+    in_ci_required && /^    if: always\(\)/ { next }
+    { print }
+  ' "$TMP_WF" >"$TMP_WF.new"
+  mv "$TMP_WF.new" "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must set 'if: always()'"* ]]
+}
+
+@test "fails when the aggregator does not inspect needs.*.result" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  quality:
+    needs: [validation]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  security:
+    needs: [validation]
+    uses: ./.github/workflows/security.yml
+  shell-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  ci-required:
+    needs: [validation, quality, security, shell-checks, spell-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo done
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"needs.<job>.result"* ]]
+}
+
+@test "fails when aggregator omits a gating job" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  quality:
+    needs: [validation]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  security:
+    needs: [validation]
+    uses: ./.github/workflows/security.yml
+  shell-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+  ci-required:
+    needs: [validation, quality, security, shell-checks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ needs.quality.result }}"
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must list 'spell-check'"* ]]
+}
+
+@test "reports an error when the workflow file is missing" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/nope.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository ci.yml satisfies the job graph rules" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Make the CI workflow graph explicit and the merge gate stable. `ci.yml` now
declares a purposeful `needs:` graph and a single fan-in aggregator job
(`CI Required Checks`) that branch protection can pin as the one required
check. Re-runs and partial failures are deterministic: the aggregator uses
`if: always()` and fails unless every upstream reports `success` or
`skipped`. Closes #23.

## Graph

```
validation ──┬── quality ─────────────┐
             │                         │
             └── security ─────────────┤
                                       ├──► ci-required  (aggregator)
shell-checks ──────────────────────────┤
spell-check ───────────────────────────┘
```

* `validation` is the foundational layout check — it runs first so a broken
  repo layout never spins up a Rust compile or a security audit.
* `quality` and `security` now `needs: [validation]`.
* `shell-checks` and `spell-check` stay independent and run in parallel.
* `ci-required` fans in all gating jobs, inspects `needs.<job>.result`
  explicitly, and is the single required check for branch protection.

## Evidence

Backend/CI-only change — no web UI to screenshot. Evidence is the bats
suite and the YAML validator:

* `scripts/check-ci-job-graph.sh` parses `ci.yml` and enforces the rules
  (expected jobs defined, `needs:` edges present, aggregator uses
  `if: always()` and checks `needs.*.result`). Wired into `quality.sh`.
* `./quality.sh` runs green locally (60/60 bats tests, 28 Rust unit tests,
  3 TDD tests, 4 smoke tests).
* `python3 -c "import yaml; ..."` confirms the `jobs` map and `needs`
  edges match the design exactly:

  ```
  quality ['validation']
  security ['validation']
  validation None
  shell-checks None
  spell-check None
  ci-required ['validation', 'quality', 'security', 'shell-checks', 'spell-check']
  ```

## Test Plan

* Added `tests/scripts/workflow_job_graph.bats` — 9 cases covering:
  * Happy path: a synthetic workflow with the expected graph passes.
  * Missing aggregator job fails with a clear error.
  * Missing `needs: [validation]` on `quality` fails.
  * Missing `if: always()` on the aggregator fails.
  * Aggregator without `needs.*.result` inspection fails.
  * Aggregator missing a gating job fails with the specific job name.
  * Missing workflow file and unknown flag yield descriptive errors.
  * The real repository `ci.yml` satisfies every rule.
* Existing 51 bats tests continue to pass unchanged.
* Post-merge verification: on the PR itself, confirm `CI Required Checks`
  appears as a status check; once green, update branch protection (human
  step) to require only that one check.



## Milestone
This PR is part of the **CI** milestone and targets the `milestone/ci` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-23 -->