### PR TITLE
ci: upgrade and pin GitHub Actions for Node 24 compatibility (#24)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -44,7 +44,7 @@ jobs:
       # to resolve the workspace. Mirrors the strategy used in ci.yml —
       # see the comment there for the path-strategy rationale.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
       #     the expected sibling without the workflow having to rewrite
       #     Cargo.toml.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -95,7 +95,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -155,13 +155,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # NEAT-AI-core checkout path strategy — see note in the `quality` job
       # above. Summary: in-workspace clone + sibling symlink so Cargo resolves
       # the `../../NEAT-AI-core/neat-core` path dependency on the runner.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -208,7 +208,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check bash script syntax
         run: |
@@ -224,7 +224,9 @@ jobs:
           exit $EXIT_CODE
 
       - name: Run ShellCheck (koalaman/shellcheck via ludeeus/action-shellcheck)
-        uses: ludeeus/action-shellcheck@master
+        # Pinned to a tagged release (Issue #24) — `@master` is unpinned and
+        # a compromised upstream commit would silently alter CI behaviour.
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: "."
           severity: warning
@@ -247,7 +249,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Configuration lives in `.codespellrc` at the repo root so CI and the
       # local preflight (`scripts/spell-check.sh`) stay in lock-step — see

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -32,7 +32,7 @@ jobs:
       GITLEAKS_SHA256: "fa0500f6b7e41d28791ebc680f5dd9899cd42b58629218a5f041efa899151a8e"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Full history so `origin/<base>..HEAD` resolves on every PR.
           fetch-depth: 0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Path strategy for the NEAT-AI-core sibling (Issue #18):
       #   * `actions/checkout` refuses any `path:` that resolves outside
@@ -30,7 +30,7 @@ jobs:
       #     below recreates that layout on the runner so Cargo resolves the
       #     path dependency without rewriting any manifest.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,7 +15,7 @@ jobs:
       image: semgrep/semgrep
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Semgrep
         run: semgrep ci --config p/default

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: Develop
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
       #     below recreates that layout on the runner so Cargo (and therefore
       #     `cargo upgrade`) resolves the path dependency.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -87,7 +87,7 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/upgrade-dependencies

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -38,7 +38,7 @@ jobs:
       next_version: ${{ steps.check.outputs.next_version }}
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.8"
+version = "0.5.10"
 dependencies = [
  "clap",
  "neat-core",

--- a/README.md
+++ b/README.md
@@ -208,6 +208,18 @@ message live in `scripts/auto-format.sh` and are covered by
 `tests/scripts/auto_format.bats`; the workflow itself is validated by
 `scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`).
 
+### GitHub Actions version policy (Node 24 compat)
+
+GitHub is deprecating the Node 20 runtime for JavaScript actions, so the
+workflow files pin each `uses:` reference to a major that runs on Node 24
+where one exists. The policy — minimum majors, tracked Node 20 exceptions
+(`actions/dependency-review-action@v4`, `rustsec/audit-check@v2` — no Node
+24 release upstream yet), and composite/shell allow-list — is encoded in
+`scripts/check-workflow-action-versions.sh` and validated end-to-end by
+`tests/scripts/workflow_action_versions.bats`. `quality.sh` invokes the
+script so any workflow that adds an unpinned or outdated `uses:` reference
+fails the local gate before CI (Issue #24).
+
 ## License
 
 Apache-2.0 — see `LICENSE`.

--- a/docs/pr-summary-24.md
+++ b/docs/pr-summary-24.md
@@ -1,0 +1,75 @@
+## Summary
+
+Upgraded the GitHub Actions versions used across every workflow to majors that
+run on the Node 24 runtime, and added a `quality.sh`-wired validator so the
+policy is enforced locally before CI. Two upstream actions (`rustsec/audit-check`
+and `actions/dependency-review-action`) have no Node 24 release yet, so they are
+documented as tracked Node 20 exceptions in both the validator and the README.
+
+Closes #24.
+
+### Action upgrades
+
+| Action | Before | After | Notes |
+| --- | --- | --- | --- |
+| `actions/checkout` | `@v4` | `@v5` | Node 24 runtime |
+| `actions/cache` | `@v4` | `@v5` | Node 24 runtime |
+| `peter-evans/create-pull-request` | `@v7` | `@v8` | Node 24 runtime |
+| `ludeeus/action-shellcheck` | `@master` | `@2.0.0` | Pinned to a tagged release |
+| `actions/dependency-review-action` | `@v4` | `@v4` | Tracked Node 20 exception (no v5 upstream) |
+| `rustsec/audit-check` | `@v2` | `@v2` | Tracked Node 20 exception (no v3 upstream) |
+| `dtolnay/rust-toolchain` | `@stable` | `@stable` | Composite/shell action — no Node runtime |
+
+### Policy enforcement
+
+Added `scripts/check-workflow-action-versions.sh` which scans every
+`.github/workflows/*.yml` file and classifies each `uses:` reference against a
+policy table: required minimum major, tracked Node 20 exception (must stay on
+exactly the listed major until upstream ships a Node 24 release), or
+composite/shell action (policy not applicable). Unknown actions produce a
+non-failing WARN so future additions are flagged for review.
+
+`quality.sh` now calls the script so a regression — for example, accidentally
+bumping a `ludeeus/action-shellcheck@master` reference back to a branch ref, or
+pinning `actions/checkout@v4` on a new workflow — fails locally before it
+reaches CI.
+
+## Evidence
+
+This is a CI/tooling change with no web interface to screenshot. The evidence
+is the full local quality gate running clean against the upgraded workflows
+and the new validator:
+
+```
+$ ./quality.sh < /dev/null
+...
+🔢 Validating workflow action versions for Node 24 compat (Issue #24)...
+OK   .../.github/workflows/auto-format.yml:37: actions/checkout@v5 (>= v5)
+OK   .../.github/workflows/ci.yml:98:  actions/cache@v5 (>= v5)
+OK   .../.github/workflows/ci.yml:229: ludeeus/action-shellcheck@2.0.0 (>= v2)
+OK   .../.github/workflows/security.yml:51: rustsec/audit-check@v2 (Node 20 exception, tracked)
+OK   .../.github/workflows/security.yml:65: actions/dependency-review-action@v4 (Node 20 exception, tracked)
+OK   .../.github/workflows/upgrade-dependencies.yml:90: peter-evans/create-pull-request@v8 (>= v8)
+...
+✅ All quality checks passed!
+```
+
+`bats tests/scripts/workflow_action_versions.bats` — 13 tests, all pass. The
+full `bats tests/scripts/` suite runs 73 tests, all pass.
+
+## Test Plan
+
+- Added `tests/scripts/workflow_action_versions.bats` (13 cases) driving the
+  validator against synthetic workflow fixtures. Coverage includes:
+  - A compliant workflow passes.
+  - Regressions on each `required:` action (checkout < v5, cache < v5,
+    create-pull-request < v8, shellcheck on `@master`) fail with a specific
+    message naming the offending action + ref.
+  - Bumping a Node 20 exception to an unknown major (e.g.
+    `rustsec/audit-check@v3`) fails so new majors are not silently adopted.
+  - Unknown actions emit a `WARN` without failing.
+  - Comments-containing-uses, reusable-workflow calls, missing directories,
+    empty directories, and unknown flags are handled correctly.
+  - The real repository workflows satisfy the full Node 24 compat policy.
+- Full workflow-helper suite (`bats tests/scripts/`) — 73 / 73 pass.
+- Full Rust workspace quality gate (`./quality.sh`) — green.

--- a/quality.sh
+++ b/quality.sh
@@ -44,6 +44,9 @@ echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 echo "🧭 Validating CI job dependency graph (Issue #23)..."
 ./scripts/check-ci-job-graph.sh
 
+echo "🔢 Validating workflow action versions for Node 24 compat (Issue #24)..."
+./scripts/check-workflow-action-versions.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Validate GitHub Actions versions used across workflows for Node 24
+# compatibility (Issue #24).
+#
+# Why this exists:
+#   * GitHub has begun deprecating the Node 20 runtime for custom actions. Any
+#     action pinned to a major version that still runs on Node 20 emits a
+#     deprecation warning on every run and will eventually stop working on
+#     hosted runners.
+#   * A hand-rolled check is lighter than dependabot-for-actions and keeps
+#     policy co-located with the rest of our CI helpers. It also lets us
+#     record explicit, auditable *exceptions* (upstream actions that have no
+#     Node 24 release yet).
+#
+# Policy encoded below (in `lookup_policy`):
+#   * `required:<N>` — action MUST be pinned to at least major version N. If
+#     a workflow references an older major (or a non-numeric ref like
+#     `master`/`main`), the script fails.
+#   * `node20:<N>` — action's latest stable major still uses Node 20. The
+#     workflow must stay on exactly major N until upstream ships a Node 24
+#     release. Each exception is documented inline.
+#   * `no-node` — composite/shell action that does not ship a Node runtime.
+#     Allowed to use non-semver refs (e.g. `@stable`).
+#   * (no match) — unknown action, warn but do not fail. New actions should
+#     be added to the policy explicitly so they get audited.
+#
+# Implementation note: bash 3.2 (macOS default) has no associative arrays,
+# so policy lookup is a `case` statement.
+#
+# Designed for reuse from BATS tests and `quality.sh`.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-workflow-action-versions.sh [--workflows DIR]
+
+Options:
+  --workflows DIR   Directory containing workflow YAML files (default:
+                    .github/workflows relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when every `uses:` reference satisfies the Node 24 compatibility
+policy. Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOWS_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflows)
+      WORKFLOWS_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOWS_DIR" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
+fi
+
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
+  exit 2
+fi
+
+# Look up the policy for a given action. Prints one of:
+#   required:<N>    — action must be pinned at @vN or newer (Node 24 bump)
+#   node20:<N>      — tracked Node 20 exception; must stay on exactly @vN
+#   no-node         — composite/shell action; no Node runtime
+#   (empty)         — unknown action; caller emits a WARN
+lookup_policy() {
+  local action="$1"
+  case "$action" in
+    actions/checkout)                 echo "required:5" ;;
+    actions/cache)                    echo "required:5" ;;
+    peter-evans/create-pull-request)  echo "required:8" ;;
+    ludeeus/action-shellcheck)        echo "required:2" ;;
+    # actions/dependency-review-action: action.yml declares `using: node20`
+    # at v4.9.x (2026-04). No v5 release exists yet. Revisit when upstream
+    # ships a Node 24 runtime.
+    actions/dependency-review-action) echo "node20:4" ;;
+    # rustsec/audit-check: v2.0.0 (2025) still uses Node 20. No v3 exists.
+    # Revisit when upstream publishes a Node 24 release.
+    rustsec/audit-check)              echo "node20:2" ;;
+    # dtolnay/rust-toolchain is a composite/shell action. No Node runtime,
+    # so the Node 24 deprecation does not apply.
+    dtolnay/rust-toolchain)           echo "no-node" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Scan a single workflow file and emit tab-separated records:
+#   <file>\t<line>\t<action>\t<ref>
+scan_workflow() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+pattern = re.compile(r"^\s*(?:-\s*)?uses:\s*([^@\s]+)@([^\s#]+)")
+with open(path, "r", encoding="utf-8") as fh:
+    for lineno, raw in enumerate(fh, start=1):
+        # Skip comment lines so policy examples in comments do not trigger.
+        stripped = raw.lstrip()
+        if stripped.startswith("#"):
+            continue
+        match = pattern.match(raw)
+        if not match:
+            continue
+        action, ref = match.group(1), match.group(2)
+        # Reusable workflow calls like `./.github/workflows/security.yml`
+        # do not carry a version; skip them.
+        if action.startswith("./"):
+            continue
+        print(f"{path}\t{lineno}\t{action}\t{ref}")
+PY
+}
+
+# Parse the major version from a ref like "v5", "v5.0.1", "5", or "master".
+# Sets MAJOR to the parsed integer, or empty when the ref has no numeric
+# major component (branch ref).
+parse_major() {
+  local ref="$1"
+  MAJOR=""
+  local trimmed="${ref#v}"
+  local digits="${trimmed%%[^0-9]*}"
+  if [[ -n "$digits" ]]; then
+    MAJOR="$digits"
+  fi
+}
+
+EXIT_CODE=0
+FOUND_ANY=0
+
+while IFS= read -r workflow; do
+  [[ -f "$workflow" ]] || continue
+  FOUND_ANY=1
+
+  findings="$(scan_workflow "$workflow")"
+  [[ -z "$findings" ]] && continue
+
+  while IFS=$'\t' read -r file lineno action ref; do
+    [[ -z "${action:-}" ]] && continue
+
+    policy="$(lookup_policy "$action")"
+    parse_major "$ref"
+    major="$MAJOR"
+
+    case "$policy" in
+      required:*)
+        want="${policy#required:}"
+        if [[ -z "$major" ]]; then
+          echo "FAIL $file:$lineno: $action@$ref — branch ref disallowed; pin to v$want or newer (Node 24 compat)." >&2
+          EXIT_CODE=1
+        elif (( major < want )); then
+          echo "FAIL $file:$lineno: $action@$ref — requires @v$want or newer (Node 24 compat)." >&2
+          EXIT_CODE=1
+        else
+          echo "OK   $file:$lineno: $action@$ref (>= v$want)"
+        fi
+        ;;
+      node20:*)
+        want="${policy#node20:}"
+        if [[ -z "$major" || "$major" != "$want" ]]; then
+          echo "FAIL $file:$lineno: $action@$ref — tracked Node 20 exception must stay on @v$want until upstream ships a Node 24 release." >&2
+          EXIT_CODE=1
+        else
+          echo "OK   $file:$lineno: $action@$ref (Node 20 exception, tracked)"
+        fi
+        ;;
+      no-node)
+        echo "OK   $file:$lineno: $action@$ref (no Node runtime — policy not applicable)"
+        ;;
+      "")
+        echo "WARN $file:$lineno: $action@$ref — not in policy tables; review and add to check-workflow-action-versions.sh."
+        ;;
+    esac
+  done <<< "$findings"
+done < <(find "$WORKFLOWS_DIR" -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) -type f | sort)
+
+if [[ "$FOUND_ANY" -eq 0 ]]; then
+  echo "No workflow files found in $WORKFLOWS_DIR" >&2
+  exit 2
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/workflow_action_versions.bats
+++ b/tests/scripts/workflow_action_versions.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-workflow-action-versions.sh — Issue #24.
+#
+# Drives the validator with synthetic workflow YAML in a temp directory so
+# policy behaviour (exit codes, reported failures) is verified end-to-end
+# without relying on the real repo workflows staying static.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-workflow-action-versions.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# A minimal compliant workflow — every action referenced satisfies the
+# current policy. Individual failure tests rewrite a single line to break
+# exactly one rule at a time.
+write_compliant_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Example
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ludeeus/action-shellcheck@2.0.0
+      - uses: peter-evans/create-pull-request@v8
+      - uses: actions/dependency-review-action@v4
+      - uses: rustsec/audit-check@v2
+EOF
+}
+
+@test "passes on a workflow that satisfies every policy rule" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"actions/checkout@v5"* ]]
+  [[ "$output" == *"actions/cache@v5"* ]]
+  [[ "$output" == *"peter-evans/create-pull-request@v8"* ]]
+  [[ "$output" == *"ludeeus/action-shellcheck@2.0.0"* ]]
+  [[ "$output" == *"Node 20 exception, tracked"* ]]
+}
+
+@test "fails when actions/checkout is older than v5" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@v4|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout@v4"* ]]
+  [[ "$output" == *"requires @v5 or newer"* ]]
+}
+
+@test "fails when actions/cache is older than v5" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  sed -i.bak 's|actions/cache@v5|actions/cache@v4|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/cache@v4"* ]]
+  [[ "$output" == *"requires @v5 or newer"* ]]
+}
+
+@test "fails when peter-evans/create-pull-request is older than v8" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  sed -i.bak 's|peter-evans/create-pull-request@v8|peter-evans/create-pull-request@v7|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"peter-evans/create-pull-request@v7"* ]]
+  [[ "$output" == *"requires @v8 or newer"* ]]
+}
+
+@test "fails when ludeeus/action-shellcheck uses a branch ref" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  sed -i.bak 's|ludeeus/action-shellcheck@2.0.0|ludeeus/action-shellcheck@master|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ludeeus/action-shellcheck@master"* ]]
+  [[ "$output" == *"branch ref disallowed"* ]]
+}
+
+@test "fails when a Node 20 exception is bumped to an unknown major" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  # rustsec/audit-check has no v3 yet — enforcing "stay on v2" surfaces the
+  # accidental bump so someone can verify the new major before we adopt it.
+  sed -i.bak 's|rustsec/audit-check@v2|rustsec/audit-check@v3|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"rustsec/audit-check@v3"* ]]
+  [[ "$output" == *"tracked Node 20 exception"* ]]
+}
+
+@test "warns but does not fail on an unknown action" {
+  cat >"$TMP_WF/example.yml" <<'EOF'
+name: Example
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: some-random/action@v1
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARN"* ]]
+  [[ "$output" == *"some-random/action@v1"* ]]
+  [[ "$output" == *"not in policy tables"* ]]
+}
+
+@test "ignores uses lines that live inside YAML comments" {
+  cat >"$TMP_WF/example.yml" <<'EOF'
+name: Example
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Historical note: we used to rely on `uses: actions/checkout@v4`.
+      - uses: actions/checkout@v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"actions/checkout@v4"* ]]
+  [[ "$output" == *"actions/checkout@v5"* ]]
+}
+
+@test "ignores reusable-workflow calls (./.github/workflows/*.yml)" {
+  cat >"$TMP_WF/example.yml" <<'EOF'
+name: Example
+on: [pull_request]
+jobs:
+  security:
+    uses: ./.github/workflows/security.yml
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  # No actions to audit, but the scan still runs — exits 0 with no findings.
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+  [[ "$output" != *"WARN"* ]]
+}
+
+@test "reports an error when the workflows directory does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/does-not-exist"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Workflows directory not found"* ]]
+}
+
+@test "reports an error when the workflows directory is empty" {
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No workflow files found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository workflows satisfy the Node 24 compat policy" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Upgraded the GitHub Actions versions used across every workflow to majors that
run on the Node 24 runtime, and added a `quality.sh`-wired validator so the
policy is enforced locally before CI. Two upstream actions (`rustsec/audit-check`
and `actions/dependency-review-action`) have no Node 24 release yet, so they are
documented as tracked Node 20 exceptions in both the validator and the README.

Closes #24.

### Action upgrades

| Action | Before | After | Notes |
| --- | --- | --- | --- |
| `actions/checkout` | `@v4` | `@v5` | Node 24 runtime |
| `actions/cache` | `@v4` | `@v5` | Node 24 runtime |
| `peter-evans/create-pull-request` | `@v7` | `@v8` | Node 24 runtime |
| `ludeeus/action-shellcheck` | `@master` | `@2.0.0` | Pinned to a tagged release |
| `actions/dependency-review-action` | `@v4` | `@v4` | Tracked Node 20 exception (no v5 upstream) |
| `rustsec/audit-check` | `@v2` | `@v2` | Tracked Node 20 exception (no v3 upstream) |
| `dtolnay/rust-toolchain` | `@stable` | `@stable` | Composite/shell action — no Node runtime |

### Policy enforcement

Added `scripts/check-workflow-action-versions.sh` which scans every
`.github/workflows/*.yml` file and classifies each `uses:` reference against a
policy table: required minimum major, tracked Node 20 exception (must stay on
exactly the listed major until upstream ships a Node 24 release), or
composite/shell action (policy not applicable). Unknown actions produce a
non-failing WARN so future additions are flagged for review.

`quality.sh` now calls the script so a regression — for example, accidentally
bumping a `ludeeus/action-shellcheck@master` reference back to a branch ref, or
pinning `actions/checkout@v4` on a new workflow — fails locally before it
reaches CI.

## Evidence

This is a CI/tooling change with no web interface to screenshot. The evidence
is the full local quality gate running clean against the upgraded workflows
and the new validator:

```
$ ./quality.sh < /dev/null
...
🔢 Validating workflow action versions for Node 24 compat (Issue #24)...
OK   .../.github/workflows/auto-format.yml:37: actions/checkout@v5 (>= v5)
OK   .../.github/workflows/ci.yml:98:  actions/cache@v5 (>= v5)
OK   .../.github/workflows/ci.yml:229: ludeeus/action-shellcheck@2.0.0 (>= v2)
OK   .../.github/workflows/security.yml:51: rustsec/audit-check@v2 (Node 20 exception, tracked)
OK   .../.github/workflows/security.yml:65: actions/dependency-review-action@v4 (Node 20 exception, tracked)
OK   .../.github/workflows/upgrade-dependencies.yml:90: peter-evans/create-pull-request@v8 (>= v8)
...
✅ All quality checks passed!
```

`bats tests/scripts/workflow_action_versions.bats` — 13 tests, all pass. The
full `bats tests/scripts/` suite runs 73 tests, all pass.

## Test Plan

- Added `tests/scripts/workflow_action_versions.bats` (13 cases) driving the
  validator against synthetic workflow fixtures. Coverage includes:
  - A compliant workflow passes.
  - Regressions on each `required:` action (checkout < v5, cache < v5,
    create-pull-request < v8, shellcheck on `@master`) fail with a specific
    message naming the offending action + ref.
  - Bumping a Node 20 exception to an unknown major (e.g.
    `rustsec/audit-check@v3`) fails so new majors are not silently adopted.
  - Unknown actions emit a `WARN` without failing.
  - Comments-containing-uses, reusable-workflow calls, missing directories,
    empty directories, and unknown flags are handled correctly.
  - The real repository workflows satisfy the full Node 24 compat policy.
- Full workflow-helper suite (`bats tests/scripts/`) — 73 / 73 pass.
- Full Rust workspace quality gate (`./quality.sh`) — green.



## Milestone
This PR is part of the **CI** milestone and targets the `milestone/ci` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-24 -->