### PR TITLE
Add Criterion bench infrastructure + baseline (#36)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,30 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,10 +101,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -123,6 +196,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +254,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
@@ -176,6 +290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +312,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -240,10 +371,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -285,6 +435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +454,50 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "prettyplease"
@@ -351,10 +554,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rust_scorer"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "clap",
+ "criterion",
  "neat-core",
  "rayon",
  "serde",
@@ -380,6 +613,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -431,6 +673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +709,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +735,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasip2"
@@ -574,6 +842,47 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -682,6 +991,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -220,6 +220,29 @@ where one exists. The policy — minimum majors, tracked Node 20 exceptions
 script so any workflow that adds an unpinned or outdated `uses:` reference
 fails the local gate before CI (Issue #24).
 
+## How to bench
+
+`rust_scorer` ships a Criterion suite (Issue #36) covering the forward-only
+fused path, the multi-creature directory mode, and the inner unpack + MSE
+loop. The bench is **not** part of `quality.sh` — Criterion runs are slow and
+not deterministic enough for a merge gate. Reproduce the baseline with:
+
+```bash
+./scripts/run-benches.sh
+```
+
+Or, for the issue's 50–200 MB target corpus:
+
+```bash
+BENCH_SCORING_BYTES=200000000 ./scripts/run-benches.sh
+```
+
+Tunables (all optional): `BENCH_SCORING_BYTES`, `BENCH_SCORING_INPUTS`,
+`BENCH_SCORING_OUTPUTS`, `BENCH_SCORING_HIDDEN`. Recorded baselines and
+host-specific numbers live in [`docs/performance-baseline.md`](docs/performance-baseline.md).
+Per `AGENTS.md`, performance PRs without before/after Criterion evidence are
+rejected.
+
 ## License
 
 Apache-2.0 — see `LICENSE`.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -1,0 +1,78 @@
+# Performance baseline — `rust_scorer`
+
+Establishes the Criterion baseline for the hot scoring paths so every later
+performance change can be validated with before/after evidence per the
+[Performance Task Workflow](../AGENTS.md). The bench source lives at
+[`rust_scorer/benches/scoring.rs`](../rust_scorer/benches/scoring.rs); reproduce
+the runs with [`scripts/run-benches.sh`](../scripts/run-benches.sh) or
+`cargo bench -p rust_scorer`.
+
+## Bench groups
+
+| Group | What it measures | Notes |
+|---|---|---|
+| `score_from_json_fused/forward_only` | End-to-end forward-only fused MSE accumulate over a synthetic creature + a `.bin` corpus. | Calls [`accumulate_mse_sum_forward_only_fused`](../rust_scorer/src/stream_score.rs) — the hot path the CLI runs in default mode. |
+| `score_from_creature_dir/creatures/N` | Directory mode, one shared scan + `N` creatures evaluated in parallel (`N=10`, `N=50`). | Calls [`score_from_creature_dir`](../rust_scorer/src/multi_score.rs); future `multi_score.rs` work can be A/B'd against this. |
+| `unpack_and_mse_inner/unpack_then_mse` | Micro-benchmark of the little-endian `f32` unpack + `mse_sum_batch_packed` inner loop on a fixed in-memory chunk (16 K records). | Mirrors the shared inner loop in `unpack_f32s_le` + `mse_sum_batch_packed` so vectorisation work can be measured in isolation. |
+
+## Fixture parameters
+
+| Variable | Default | Description |
+|---|---|---|
+| `BENCH_SCORING_BYTES` | `16777216` (16 MiB) | total bytes per `.bin` corpus |
+| `BENCH_SCORING_INPUTS` | `8` | inputs per record |
+| `BENCH_SCORING_OUTPUTS` | `2` | outputs per record |
+| `BENCH_SCORING_HIDDEN` | `8` | hidden neurons in the synthetic creature |
+
+The realistic perf target is the **50–200 MB** range called out in the issue.
+Defaults are kept conservative so `cargo bench` finishes in a few minutes on
+typical dev hardware; sweep upwards via `BENCH_SCORING_BYTES` for the full
+target. **Always re-run the baseline at the same `BENCH_SCORING_BYTES`** — the
+absolute numbers below are fixture-size-specific.
+
+## Baseline — 25 April 2026
+
+| Field | Value |
+|---|---|
+| Host CPU | Apple M4 (10 cores) |
+| RAM | 24 GB |
+| OS | macOS 26.4.1 (Darwin 25.4.0, arm64) |
+| Toolchain | rustc 1.95.0 (release profile, `lto = true`, `codegen-units = 1` for `rust_scorer`) |
+| Fixture | `BENCH_SCORING_BYTES=8388608` (8 MiB), `BENCH_SCORING_INPUTS=8`, `BENCH_SCORING_OUTPUTS=2`, `BENCH_SCORING_HIDDEN=8` |
+| `NEAT_SCORER_*` env | unset (defaults) |
+| Criterion | sample size 10 for the end-to-end groups, 100 for the micro-bench |
+
+Numbers below are the Criterion lower / median / upper estimates (95% CI). A
+"std dev" column is derived from the half-width of the CI.
+
+| Benchmark | Lower | **Median** | Upper | Throughput (median) | Half-width ≈ stddev proxy |
+|---|---|---|---|---|---|
+| `score_from_json_fused/forward_only` | 15.965 ms | **16.611 ms** | 17.270 ms | 481.62 MiB/s | ±0.65 ms |
+| `score_from_creature_dir/creatures/10` | 63.211 ms | **63.838 ms** | 64.480 ms | 125.32 MiB/s | ±0.63 ms |
+| `score_from_creature_dir/creatures/50` | 164.95 ms | **166.63 ms** | 169.22 ms | 48.010 MiB/s | ±2.14 ms |
+| `unpack_and_mse_inner/unpack_then_mse` | 1.1171 ms | **1.1663 ms** | 1.2247 ms | 535.87 MiB/s | ±0.054 ms |
+
+Source: `BENCH_SCORING_BYTES=8388608 cargo bench -p rust_scorer` on the host above.
+The 8 MiB fixture is small enough to run inside an unattended worker; future
+runs at the issue's 50–200 MB target should be appended as a separate dated
+section so historical numbers stay reproducible at their original size.
+
+### Reading the directory-mode throughput
+
+Throughput in `score_from_creature_dir` is reported relative to the shared
+training corpus byte count (`BENCH_SCORING_BYTES`), **not** corpus × creature
+count. Multiply by the creature count to compare against single-creature
+scoring: at `N=50` the 48 MiB/s shared-scan figure corresponds to roughly
+2.4 GiB/s of work performed (50 networks × 48 MiB/s).
+
+## Refreshing the baseline
+
+1. Run `./scripts/run-benches.sh` (default fixture) and record the median +
+   std-dev proxy for each benchmark.
+2. For an issue-target run, set `BENCH_SCORING_BYTES=200000000` (200 MB) and
+   re-run; capture the host CPU, RAM, and OS, and append a new dated section
+   above. **Do not overwrite older sections** — historical baselines are how
+   regressions are detected.
+3. When proposing a perf PR, paste the Criterion comparison output (or the
+   before/after median + CI) into the PR summary. PRs without before/after
+   evidence are rejected per `AGENTS.md`.

--- a/docs/pr-summary-36.md
+++ b/docs/pr-summary-36.md
@@ -1,0 +1,33 @@
+## Summary
+Stand up Criterion benchmark infrastructure for `rust_scorer` and capture an initial baseline so every later perf change can be validated with before/after evidence per `AGENTS.md`. Closes #36.
+
+* Added `criterion = "0.8"` (with `html_reports`) to `rust_scorer/Cargo.toml` `[dev-dependencies]` and a `[[bench]]` entry pointing at `rust_scorer/benches/scoring.rs` with `harness = false`. (The issue requested `0.5`; `quality.sh` runs `cargo upgrade --incompatible` so the manifest pins the auto-upgraded `0.8` — same crate, latest API.)
+* Added `rust_scorer/src/lib.rs` exposing `scoring`, `multi_score`, `stream_score`, and `read_tuning` so the bench (a separate compilation target) can call the same hot paths the CLI runs. The binary in `src/main.rs` is untouched — its module tree, positional CLI contract, and tests are unchanged.
+* New bench groups in `benches/scoring.rs`:
+  * `score_from_json_fused/forward_only` — end-to-end fused MSE accumulate.
+  * `score_from_creature_dir/creatures/{10,50}` — directory mode at two N values.
+  * `unpack_and_mse_inner/unpack_then_mse` — micro-bench of the `unpack_f32s_le + mse_sum_batch_packed` inner loop on a fixed in-memory chunk.
+* Fixture sizes are parameterised through `BENCH_SCORING_BYTES`, `BENCH_SCORING_INPUTS`, `BENCH_SCORING_OUTPUTS`, `BENCH_SCORING_HIDDEN`. Defaults are conservative (16 MiB) to keep `cargo bench` runtime sane; the issue's 50–200 MB target is reachable via `BENCH_SCORING_BYTES=200000000`.
+* Added `scripts/run-benches.sh` (one-command reproducer; **not** wired into `quality.sh` per the issue) plus `tests/scripts/run_benches.bats` covering argument forwarding, env-var pass-through, exit-status propagation, and the configuration banner.
+* Added `docs/performance-baseline.md` documenting the host (Apple M4 / 24 GB / macOS 26.4.1), the bench fixtures, and the recorded medians + CI half-widths for each group; updated `README.md` with a "How to bench" section linking to it.
+
+## Evidence
+
+This is performance infrastructure (no perf change), so the baseline numbers themselves are the evidence. Captured on Apple M4 / 10 cores / 24 GB / macOS 26.4.1, `BENCH_SCORING_BYTES=8388608` (8 MiB):
+
+| Benchmark | Lower | **Median** | Upper | Throughput |
+|---|---|---|---|---|
+| `score_from_json_fused/forward_only` | 15.965 ms | **16.611 ms** | 17.270 ms | 481.62 MiB/s |
+| `score_from_creature_dir/creatures/10` | 63.211 ms | **63.838 ms** | 64.480 ms | 125.32 MiB/s |
+| `score_from_creature_dir/creatures/50` | 164.95 ms | **166.63 ms** | 169.22 ms | 48.010 MiB/s |
+| `unpack_and_mse_inner/unpack_then_mse` | 1.1171 ms | **1.1663 ms** | 1.2247 ms | 535.87 MiB/s |
+
+Full numbers and the host description live in `docs/performance-baseline.md`.
+
+## Test Plan
+
+- Added `tests/scripts/run_benches.bats` (5 cases) — verifies `scripts/run-benches.sh` invokes `cargo bench -p rust_scorer`, forwards extra args, propagates env vars + exit status, and prints the fixture banner. Runs in `quality.sh` via the existing bats step.
+- Existing test suites (`cargo test --workspace`, the bin/integration smoke tests, the bats scripts) continue to pass — the lib + bin split does not change main.rs's module tree.
+- `cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` cover the bench source (it compiles into the test build graph), so any future bench change is gated by `quality.sh` even though `cargo bench` is not.
+- `cargo bench -p rust_scorer` was executed end-to-end with `BENCH_SCORING_BYTES=8388608` to populate the baseline doc above.
+- `./quality.sh < /dev/null` passes.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -8,6 +8,10 @@ description = "Native CLI binary for scoring NEAT-AI creatures against training 
 [lints]
 workspace = true
 
+[lib]
+name = "rust_scorer"
+path = "src/lib.rs"
+
 [[bin]]
 name = "rust_scorer"
 path = "src/main.rs"
@@ -15,6 +19,15 @@ path = "src/main.rs"
 [[bin]]
 name = "float_scan_bench"
 path = "src/bin/float_scan_bench.rs"
+
+# Criterion bench harness — see `benches/scoring.rs` and
+# `docs/performance-baseline.md`. Not wired into `quality.sh` (Criterion runs
+# are slow and non-deterministic enough to be unsuitable as a merge gate);
+# reproduce with `./scripts/run-benches.sh` or `cargo bench -p rust_scorer`.
+[[bench]]
+name = "scoring"
+path = "benches/scoring.rs"
+harness = false
 
 [dependencies]
 # Path relative to this file: `NEAT-AI-scorer/rust_scorer` → sibling `NEAT-AI-core/neat-core`.
@@ -30,3 +43,4 @@ rayon = "1.12"
 
 [dev-dependencies]
 tempfile = "3"
+criterion = { version = "0.8", features = ["html_reports"] }

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/benches/scoring.rs
+++ b/rust_scorer/benches/scoring.rs
@@ -1,0 +1,331 @@
+//! Criterion benchmarks for the `rust_scorer` hot paths — Issue #36.
+//!
+//! Three groups, all built on a shared lazily-created tempdir fixture so the
+//! synthetic creature(s) and `.bin` corpus are paid for **once per process**:
+//!
+//! * `score_from_json_fused` — forward-only fused path, exercised through
+//!   [`rust_scorer::stream_score::accumulate_mse_sum_forward_only_fused`] (the
+//!   same hot path the CLI runs in default mode).
+//! * `score_from_creature_dir` — directory mode at `N=10` and `N=50` creatures,
+//!   exercised through [`rust_scorer::multi_score::score_from_creature_dir`].
+//! * `unpack_and_mse_inner` — micro-benchmark over a fixed in-memory chunk
+//!   that mirrors the inner loop combining little-endian `f32` unpack and
+//!   `mse_sum_batch_packed`.
+//!
+//! ## Sizing
+//!
+//! The training corpus size and creature shape are parameterised via
+//! environment variables so contributors can sweep 50–200 MB without editing
+//! the bench. Defaults are conservative (16 MB) to keep `cargo bench` runtime
+//! reasonable on CI/dev machines; the realistic perf target is `BENCH_SCORING_BYTES=200000000`.
+//!
+//! | Variable | Default | Purpose |
+//! |---|---|---|
+//! | `BENCH_SCORING_BYTES` | `16777216` (16 MiB) | total bytes per `.bin` corpus |
+//! | `BENCH_SCORING_INPUTS` | `8` | inputs per record |
+//! | `BENCH_SCORING_OUTPUTS` | `2` | outputs per record |
+//! | `BENCH_SCORING_HIDDEN` | `8` | hidden neurons per synthetic creature |
+//!
+//! Reproduce on your host with `./scripts/run-benches.sh` or
+//! `cargo bench -p rust_scorer`. Update `docs/performance-baseline.md` with
+//! the median and standard deviation when establishing a new baseline.
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use std::hint::black_box;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use neat_core::creature::{compile_creature, parse_creature_json};
+use neat_core::loss::mse_sum_batch_packed;
+use neat_core::training_data::{TrainingDataConfig, find_bin_files};
+
+use rust_scorer::multi_score::score_from_creature_dir;
+use rust_scorer::stream_score::accumulate_mse_sum_forward_only_fused;
+
+use tempfile::TempDir;
+
+const DEFAULT_TOTAL_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_NUM_INPUTS: usize = 8;
+const DEFAULT_NUM_OUTPUTS: usize = 2;
+const DEFAULT_HIDDEN: usize = 8;
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn bench_total_bytes() -> usize {
+    env_usize("BENCH_SCORING_BYTES", DEFAULT_TOTAL_BYTES)
+}
+
+fn bench_num_inputs() -> usize {
+    env_usize("BENCH_SCORING_INPUTS", DEFAULT_NUM_INPUTS).max(1)
+}
+
+fn bench_num_outputs() -> usize {
+    env_usize("BENCH_SCORING_OUTPUTS", DEFAULT_NUM_OUTPUTS).max(1)
+}
+
+fn bench_hidden() -> usize {
+    env_usize("BENCH_SCORING_HIDDEN", DEFAULT_HIDDEN)
+}
+
+/// Build a forward-only synthetic creature JSON wired as a small dense MLP.
+fn synthetic_creature_json(num_inputs: usize, num_outputs: usize, hidden: usize) -> String {
+    let mut neurons: Vec<String> = Vec::with_capacity(hidden + num_outputs);
+    for h in 0..hidden {
+        neurons.push(format!(
+            r#"{{"type":"hidden","uuid":"hidden-{h}","bias":0.05,"squash":"TANH"}}"#
+        ));
+    }
+    for o in 0..num_outputs {
+        neurons.push(format!(
+            r#"{{"type":"output","uuid":"output-{o}","bias":0.0,"squash":"IDENTITY"}}"#
+        ));
+    }
+
+    let mut synapses: Vec<String> = Vec::with_capacity(num_inputs * hidden + hidden * num_outputs);
+    // Input -> hidden
+    for i in 0..num_inputs {
+        for h in 0..hidden {
+            // Vary weight slightly so activations are non-degenerate.
+            let w = 0.05 + 0.001 * ((i * hidden + h) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"input-{i}","toUUID":"hidden-{h}","weight":{w}}}"#
+            ));
+        }
+    }
+    // Hidden -> output
+    for h in 0..hidden {
+        for o in 0..num_outputs {
+            let w = 0.1 + 0.001 * ((h * num_outputs + o) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"hidden-{h}","toUUID":"output-{o}","weight":{w}}}"#
+            ));
+        }
+    }
+
+    format!(
+        r#"{{"input":{num_inputs},"output":{num_outputs},"forwardOnly":true,"semanticVersion":"4.0.0","neurons":[{}],"synapses":[{}]}}"#,
+        neurons.join(","),
+        synapses.join(","),
+    )
+}
+
+/// Write a single `0.bin` file holding `total_bytes` worth of synthetic packed records.
+fn write_synthetic_bin(data_dir: &Path, num_inputs: usize, num_outputs: usize, total_bytes: usize) {
+    let values_per_record = num_inputs + num_outputs;
+    let record_bytes = values_per_record * std::mem::size_of::<f32>();
+    let n_records = (total_bytes / record_bytes).max(1);
+
+    let path = data_dir.join("0.bin");
+    let f = File::create(&path).expect("create training bin file");
+    let mut w = BufWriter::with_capacity(1 << 20, f);
+    let mut bytes = Vec::with_capacity(record_bytes);
+    for i in 0..n_records {
+        bytes.clear();
+        for k in 0..values_per_record {
+            // Deterministic but record-varying values keep the network out of a saturated
+            // regime (vs all-zeroes) so the bench reflects realistic activation work.
+            let v = ((i.wrapping_mul(31) + k) as f32 * 1.0e-3).sin();
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        w.write_all(&bytes).expect("write training bytes");
+    }
+    w.flush().expect("flush bin file");
+}
+
+struct Fixture {
+    _tmp: TempDir,
+    creature_path: PathBuf,
+    creatures_root: PathBuf,
+    data_dir: PathBuf,
+    num_inputs: usize,
+    num_outputs: usize,
+    total_bytes: usize,
+}
+
+fn fixture() -> &'static Fixture {
+    static FIX: OnceLock<Fixture> = OnceLock::new();
+    FIX.get_or_init(|| {
+        let tmp = TempDir::new().expect("tempdir");
+        let creatures_root = tmp.path().join("creatures-root");
+        fs::create_dir_all(&creatures_root).unwrap();
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&data_dir).unwrap();
+
+        let num_inputs = bench_num_inputs();
+        let num_outputs = bench_num_outputs();
+        let total_bytes = bench_total_bytes();
+        let json = synthetic_creature_json(num_inputs, num_outputs, bench_hidden());
+
+        // Single-creature path: top-level synthetic.json.
+        let creature_path = tmp.path().join("synthetic.json");
+        fs::write(&creature_path, &json).unwrap();
+
+        // Multi-creature root with a fixed pool of identical creatures; per-N
+        // sub-directories are materialised lazily by the directory benchmark.
+        let pool_size = 50;
+        for n in 0..pool_size {
+            fs::write(creatures_root.join(format!("creature-{n:02}.json")), &json).unwrap();
+        }
+
+        write_synthetic_bin(&data_dir, num_inputs, num_outputs, total_bytes);
+
+        Fixture {
+            _tmp: tmp,
+            creature_path,
+            creatures_root,
+            data_dir,
+            num_inputs,
+            num_outputs,
+            total_bytes,
+        }
+    })
+}
+
+fn bench_score_from_json_fused(c: &mut Criterion) {
+    let fix = fixture();
+    let json = fs::read_to_string(&fix.creature_path).expect("read creature");
+    let creature = parse_creature_json(&json).expect("parse creature");
+    let bin_files = find_bin_files(&fix.data_dir).expect("find bin files");
+    let config = TrainingDataConfig {
+        num_inputs: fix.num_inputs,
+        num_outputs: fix.num_outputs,
+    };
+
+    let mut group = c.benchmark_group("score_from_json_fused");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(8));
+    group.throughput(Throughput::Bytes(fix.total_bytes as u64));
+    group.bench_function("forward_only", |b| {
+        b.iter_batched(
+            || compile_creature(&creature).expect("compile"),
+            |mut net| {
+                let r =
+                    accumulate_mse_sum_forward_only_fused(&bin_files, &config, &creature, &mut net)
+                        .expect("fused MSE accumulate");
+                black_box(r);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn bench_score_from_creature_dir(c: &mut Criterion) {
+    let fix = fixture();
+    let mut group = c.benchmark_group("score_from_creature_dir");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(15));
+    group.throughput(Throughput::Bytes(fix.total_bytes as u64));
+
+    for &n in &[10_usize, 50_usize] {
+        // Materialise an N-creature sub-directory by copying from the pool.
+        let sub_dir = fix
+            .creatures_root
+            .parent()
+            .unwrap()
+            .join(format!("dir-{n}"));
+        if !sub_dir.exists() {
+            fs::create_dir_all(&sub_dir).unwrap();
+            for i in 0..n {
+                let src = fix.creatures_root.join(format!("creature-{i:02}.json"));
+                let dst = sub_dir.join(format!("creature-{i:02}.json"));
+                fs::copy(&src, &dst).expect("copy creature");
+            }
+        }
+
+        group.bench_with_input(BenchmarkId::new("creatures", n), &sub_dir, |b, dir| {
+            b.iter(|| {
+                let result =
+                    score_from_creature_dir(dir, &fix.data_dir).expect("multi-creature score");
+                black_box(result);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Local copy of the production unpack inner loop. Kept in this bench file so
+/// the micro-bench does not require widening the crate's public surface; the
+/// implementation matches `multi_score::unpack_f32s_le` and
+/// `stream_score::unpack_f32s_le` byte-for-byte (single-source-of-truth lives
+/// in those modules; this duplicate is documented and exists only inside the
+/// bench harness).
+fn unpack_f32s_le_bench(src: &[u8], dst: &mut Vec<f32>, n: usize) {
+    debug_assert_eq!(src.len(), n * 4);
+    dst.clear();
+    if dst.capacity() < n {
+        dst.reserve(n - dst.capacity());
+    }
+
+    #[cfg(target_endian = "little")]
+    {
+        // SAFETY: `src.len() == n * 4`, capacity ≥ `n` after the reserve above;
+        // every element [0, n) is initialised before `set_len(n)`.
+        unsafe {
+            let out_ptr = dst.as_mut_ptr();
+            let p = src.as_ptr();
+            for i in 0..n {
+                let bits = p.add(i * 4).cast::<u32>().read_unaligned();
+                out_ptr.add(i).write(f32::from_bits(bits));
+            }
+            dst.set_len(n);
+        }
+    }
+
+    #[cfg(not(target_endian = "little"))]
+    {
+        for q in src.chunks_exact(4) {
+            dst.push(f32::from_le_bytes([q[0], q[1], q[2], q[3]]));
+        }
+    }
+}
+
+fn bench_unpack_and_mse_inner(c: &mut Criterion) {
+    let num_inputs = bench_num_inputs();
+    let num_outputs = bench_num_outputs();
+    let values_per_record = num_inputs + num_outputs;
+    // Fixed in-memory chunk: 16K records — fits in L2/L3 on most machines and
+    // exercises the inner loop without re-paying I/O setup costs.
+    let n_records = 16 * 1024;
+    let total_floats = n_records * values_per_record;
+    let total_bytes = total_floats * std::mem::size_of::<f32>();
+
+    let mut bytes = Vec::with_capacity(total_bytes);
+    for i in 0..total_floats {
+        let v = (i as f32 * 1.0e-3).sin();
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+
+    let json = synthetic_creature_json(num_inputs, num_outputs, bench_hidden());
+    let creature = parse_creature_json(&json).expect("parse creature");
+
+    let mut group = c.benchmark_group("unpack_and_mse_inner");
+    group.throughput(Throughput::Bytes(total_bytes as u64));
+    group.bench_function("unpack_then_mse", |b| {
+        let mut floats: Vec<f32> = Vec::with_capacity(total_floats);
+        let mut net = compile_creature(&creature).expect("compile");
+        b.iter(|| {
+            unpack_f32s_le_bench(&bytes, &mut floats, total_floats);
+            let s = mse_sum_batch_packed(&mut net, &floats, num_inputs, num_outputs, true);
+            black_box(s);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_score_from_json_fused,
+    bench_score_from_creature_dir,
+    bench_unpack_and_mse_inner,
+);
+criterion_main!(benches);

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -1,0 +1,14 @@
+//! Library surface for `rust_scorer` so external targets (Criterion benches,
+//! integration tests) can call the same hot paths the CLI uses.
+//!
+//! The CLI binary in `src/main.rs` continues to declare its own `mod ...;`
+//! tree — keeping `main.rs` self-contained avoids touching the stable
+//! positional CLI contract while still letting the `benches/scoring.rs`
+//! Criterion harness import the scoring modules through this crate root.
+//!
+//! Issue #36 — Criterion benchmark infrastructure.
+
+pub mod multi_score;
+pub mod read_tuning;
+pub mod scoring;
+pub mod stream_score;

--- a/scripts/run-benches.sh
+++ b/scripts/run-benches.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# scripts/run-benches.sh — Issue #36
+#
+# Reproduce the Criterion bench suite documented in
+# `docs/performance-baseline.md`. Not wired into `quality.sh`: Criterion runs
+# are slow and not deterministic enough to gate every commit, so this is the
+# manual entry point contributors use when establishing or refreshing a
+# baseline.
+#
+# Usage:
+#   ./scripts/run-benches.sh            # default (small fixture, ~minutes)
+#   BENCH_SCORING_BYTES=200000000 \
+#     ./scripts/run-benches.sh          # ~200 MB corpus (issue acceptance criterion)
+#
+# Tuning environment variables (see `rust_scorer/benches/scoring.rs`):
+#   BENCH_SCORING_BYTES   total bytes per .bin corpus (default 16 MiB)
+#   BENCH_SCORING_INPUTS  inputs per record (default 8)
+#   BENCH_SCORING_OUTPUTS outputs per record (default 2)
+#   BENCH_SCORING_HIDDEN  hidden neurons per synthetic creature (default 8)
+#
+# All extra arguments are forwarded to `cargo bench`. Common filters:
+#   ./scripts/run-benches.sh -- score_from_json_fused
+#   ./scripts/run-benches.sh -- score_from_creature_dir/creatures/10
+set -euo pipefail
+
+if [ -f "$HOME/.cargo/env" ]; then
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env"
+fi
+
+cd "$(dirname "$0")/.."
+
+echo "🏁 Running rust_scorer Criterion benches"
+echo "   BENCH_SCORING_BYTES=${BENCH_SCORING_BYTES:-16777216 (default)}"
+echo "   BENCH_SCORING_INPUTS=${BENCH_SCORING_INPUTS:-8 (default)}"
+echo "   BENCH_SCORING_OUTPUTS=${BENCH_SCORING_OUTPUTS:-2 (default)}"
+echo "   BENCH_SCORING_HIDDEN=${BENCH_SCORING_HIDDEN:-8 (default)}"
+echo
+
+cargo bench -p rust_scorer "$@"

--- a/tests/scripts/run_benches.bats
+++ b/tests/scripts/run_benches.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# Tests for scripts/run-benches.sh — Issue #36.
+#
+# The script wraps `cargo bench -p rust_scorer` so the bench fixture configuration
+# stays in one place. We don't actually invoke `cargo bench` here (Criterion runs
+# are far too slow for a unit test) — instead we shim `cargo` on PATH and assert:
+#   * the script forwards the right arguments to `cargo bench`,
+#   * the BENCH_SCORING_* env vars are passed through,
+#   * the script exits non-zero when `cargo bench` fails.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/run-benches.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_BIN="$(mktemp -d)"
+  export TMP_BIN
+  CARGO_LOG="${TMP_BIN}/cargo-log"
+  export CARGO_LOG
+
+  cat >"${TMP_BIN}/cargo" <<EOF
+#!/bin/bash
+{
+  echo "ARGS: \$*"
+  echo "BENCH_SCORING_BYTES=\${BENCH_SCORING_BYTES:-unset}"
+  echo "BENCH_SCORING_INPUTS=\${BENCH_SCORING_INPUTS:-unset}"
+} >>"${CARGO_LOG}"
+exit "\${SHIM_CARGO_EXIT:-0}"
+EOF
+  chmod +x "${TMP_BIN}/cargo"
+  PATH="${TMP_BIN}:$PATH"
+  export PATH
+  # Disable .cargo/env sourcing inside the script (would prepend the real cargo).
+  HOME_BACKUP="$HOME"
+  HOME="$TMP_BIN"
+  export HOME HOME_BACKUP
+}
+
+teardown() {
+  rm -rf "$TMP_BIN"
+  HOME="${HOME_BACKUP:-$HOME}"
+}
+
+@test "invokes cargo bench -p rust_scorer with no extra args" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  grep -q "ARGS: bench -p rust_scorer" "$CARGO_LOG"
+}
+
+@test "forwards extra arguments to cargo bench" {
+  run "$SCRIPT_UNDER_TEST" -- score_from_json_fused
+  [ "$status" -eq 0 ]
+  grep -q "ARGS: bench -p rust_scorer -- score_from_json_fused" "$CARGO_LOG"
+}
+
+@test "passes BENCH_SCORING_BYTES through to cargo bench" {
+  BENCH_SCORING_BYTES=200000000 run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  grep -q "BENCH_SCORING_BYTES=200000000" "$CARGO_LOG"
+}
+
+@test "propagates non-zero exit status from cargo bench" {
+  SHIM_CARGO_EXIT=2 run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 2 ]
+}
+
+@test "prints the active bench fixture configuration" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Running rust_scorer Criterion benches"* ]]
+  [[ "$output" == *"BENCH_SCORING_BYTES="* ]]
+  [[ "$output" == *"BENCH_SCORING_INPUTS="* ]]
+  [[ "$output" == *"BENCH_SCORING_OUTPUTS="* ]]
+  [[ "$output" == *"BENCH_SCORING_HIDDEN="* ]]
+}


### PR DESCRIPTION
## Summary
Stand up Criterion benchmark infrastructure for `rust_scorer` and capture an initial baseline so every later perf change can be validated with before/after evidence per `AGENTS.md`. Closes #36.

* Added `criterion = "0.8"` (with `html_reports`) to `rust_scorer/Cargo.toml` `[dev-dependencies]` and a `[[bench]]` entry pointing at `rust_scorer/benches/scoring.rs` with `harness = false`. (The issue requested `0.5`; `quality.sh` runs `cargo upgrade --incompatible` so the manifest pins the auto-upgraded `0.8` — same crate, latest API.)
* Added `rust_scorer/src/lib.rs` exposing `scoring`, `multi_score`, `stream_score`, and `read_tuning` so the bench (a separate compilation target) can call the same hot paths the CLI runs. The binary in `src/main.rs` is untouched — its module tree, positional CLI contract, and tests are unchanged.
* New bench groups in `benches/scoring.rs`:
  * `score_from_json_fused/forward_only` — end-to-end fused MSE accumulate.
  * `score_from_creature_dir/creatures/{10,50}` — directory mode at two N values.
  * `unpack_and_mse_inner/unpack_then_mse` — micro-bench of the `unpack_f32s_le + mse_sum_batch_packed` inner loop on a fixed in-memory chunk.
* Fixture sizes are parameterised through `BENCH_SCORING_BYTES`, `BENCH_SCORING_INPUTS`, `BENCH_SCORING_OUTPUTS`, `BENCH_SCORING_HIDDEN`. Defaults are conservative (16 MiB) to keep `cargo bench` runtime sane; the issue's 50–200 MB target is reachable via `BENCH_SCORING_BYTES=200000000`.
* Added `scripts/run-benches.sh` (one-command reproducer; **not** wired into `quality.sh` per the issue) plus `tests/scripts/run_benches.bats` covering argument forwarding, env-var pass-through, exit-status propagation, and the configuration banner.
* Added `docs/performance-baseline.md` documenting the host (Apple M4 / 24 GB / macOS 26.4.1), the bench fixtures, and the recorded medians + CI half-widths for each group; updated `README.md` with a "How to bench" section linking to it.

## Evidence

This is performance infrastructure (no perf change), so the baseline numbers themselves are the evidence. Captured on Apple M4 / 10 cores / 24 GB / macOS 26.4.1, `BENCH_SCORING_BYTES=8388608` (8 MiB):

| Benchmark | Lower | **Median** | Upper | Throughput |
|---|---|---|---|---|
| `score_from_json_fused/forward_only` | 15.965 ms | **16.611 ms** | 17.270 ms | 481.62 MiB/s |
| `score_from_creature_dir/creatures/10` | 63.211 ms | **63.838 ms** | 64.480 ms | 125.32 MiB/s |
| `score_from_creature_dir/creatures/50` | 164.95 ms | **166.63 ms** | 169.22 ms | 48.010 MiB/s |
| `unpack_and_mse_inner/unpack_then_mse` | 1.1171 ms | **1.1663 ms** | 1.2247 ms | 535.87 MiB/s |

Full numbers and the host description live in `docs/performance-baseline.md`.

## Test Plan

- Added `tests/scripts/run_benches.bats` (5 cases) — verifies `scripts/run-benches.sh` invokes `cargo bench -p rust_scorer`, forwards extra args, propagates env vars + exit status, and prints the fixture banner. Runs in `quality.sh` via the existing bats step.
- Existing test suites (`cargo test --workspace`, the bin/integration smoke tests, the bats scripts) continue to pass — the lib + bin split does not change main.rs's module tree.
- `cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` cover the bench source (it compiles into the test build graph), so any future bench change is gated by `quality.sh` even though `cargo bench` is not.
- `cargo bench -p rust_scorer` was executed end-to-end with `BENCH_SCORING_BYTES=8388608` to populate the baseline doc above.
- `./quality.sh < /dev/null` passes.