### PR TITLE
Add Cargo Security Audit workflow with weekly schedule (#64)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,53 @@
+name: Cargo Audit
+
+# Standalone Cargo Security Audit workflow (Issue #64).
+#
+# Why a dedicated workflow? The reusable `security.yml` workflow already runs
+# `cargo audit` as part of CI on each pull request. This file mirrors that
+# coverage but adds a weekly cron schedule so advisories published *after*
+# the last PR still surface — the lockfile does not change but the RustSec
+# advisory database does, so a freshly published CVE against a pinned
+# dependency would otherwise go unnoticed until the next merge.
+#
+# Triggers:
+#   * pull_request   — belt-and-braces alongside security.yml; cargo-audit
+#                      is fast (seconds) so the duplication is negligible
+#                      and keeps the standalone workflow self-contained.
+#   * schedule       — Mondays 06:00 UTC; catches new advisories weekly.
+#   * workflow_dispatch — manual trigger for ad-hoc audits.
+#
+# Action versions follow `scripts/check-workflow-action-versions.sh`:
+# `actions/checkout@v5` (Node 24 policy) and `dtolnay/rust-toolchain@stable`
+# (composite/shell action — no Node runtime, ref policy not applicable).
+
+on:
+  pull_request:
+    branches: ["*"]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Avoid duplicate scheduled / dispatch runs piling up; PR runs are deduped
+# per-branch.
+concurrency:
+  group: cargo-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/README.md
+++ b/README.md
@@ -253,6 +253,15 @@ message live in `scripts/auto-format.sh` and are covered by
 `tests/scripts/auto_format.bats`; the workflow itself is validated by
 `scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`).
 
+A standalone Cargo Security Audit workflow (`.github/workflows/cargo-audit.yml`,
+Issue #64) mirrors the `cargo audit` step in the reusable `security.yml` but
+adds a weekly cron schedule (`0 6 * * 1`) plus `workflow_dispatch`. The
+schedule catches advisories published *after* the last PR — the lockfile
+does not change but the RustSec advisory database does. The workflow is
+validated by `scripts/check-cargo-audit-workflow.sh` (invoked from
+`quality.sh`) and covered end-to-end by
+`tests/scripts/cargo_audit_workflow.bats`.
+
 ### GitHub Actions version policy (Node 24 compat)
 
 GitHub is deprecating the Node 20 runtime for JavaScript actions, so the

--- a/docs/pr-summary-64.md
+++ b/docs/pr-summary-64.md
@@ -1,0 +1,65 @@
+## Summary
+
+Added a standalone Cargo Security Audit workflow at
+`.github/workflows/cargo-audit.yml` that runs `cargo audit` on every pull
+request, on a weekly cron schedule (`0 6 * * 1`), and on demand via
+`workflow_dispatch`. The reusable `security.yml` already runs `cargo
+audit` on PRs, but it has no schedule — so a freshly published RustSec
+advisory against a pinned dependency would only surface on the next
+merge. The weekly schedule closes that gap.
+
+The workflow is hardened to match the rest of `.github/workflows/`:
+least-privilege permissions (`contents: read`), pinned action majors
+(`actions/checkout@v5`, `dtolnay/rust-toolchain@stable`), and a
+`concurrency` group so scheduled / dispatch runs do not pile up.
+
+Hardening rules are encoded in a dedicated validator
+(`scripts/check-cargo-audit-workflow.sh`) wired into `quality.sh`, so any
+future regression in the workflow YAML fails the local gate before CI.
+
+Closes #64.
+
+## Evidence
+
+This is a pure CI / shell change with no UI surface. Verification:
+
+- New BATS suite `tests/scripts/cargo_audit_workflow.bats` (11 tests)
+  drives the validator end-to-end against synthetic fixtures and the
+  real workflow file.
+- `./quality.sh` passes locally with the new validator wired in
+  (shellcheck, all workflow validators, codespell, bats, cargo-deny,
+  clippy, check, build, test, doc, release build).
+
+```mermaid
+flowchart LR
+    A[Issue #64] --> B[cargo-audit.yml]
+    B --> C{trigger}
+    C -->|pull_request| D[cargo audit on PR]
+    C -->|cron weekly| E[catches new advisories]
+    C -->|workflow_dispatch| F[manual run]
+    G[check-cargo-audit-workflow.sh] -->|validates| B
+    H[quality.sh] -->|invokes| G
+    I[cargo_audit_workflow.bats] -->|tests| G
+```
+
+## Test Plan
+
+- New `tests/scripts/cargo_audit_workflow.bats` (11 tests) covering:
+  - canonical fixture passes
+  - missing `pull_request` trigger fails
+  - missing `schedule` trigger fails
+  - missing `permissions: contents: read` block fails
+  - unpinned `actions/checkout` fails
+  - missing `dtolnay/rust-toolchain` fails
+  - missing `cargo audit` invocation fails
+  - `rustsec/audit-check` action accepted as the audit entry point
+  - missing workflow file reports an error
+  - unknown flag prints usage and exits non-zero
+  - real repository workflow satisfies every rule
+- Existing `scripts/check-workflow-action-versions.sh` and
+  `scripts/check-workflow-paths.sh` were re-run to confirm the new
+  workflow does not regress the Node 24 policy or the NEAT-AI-core path
+  strategy (cargo-audit does not check out the sibling so the path
+  validator correctly skips it).
+- `./quality.sh` passes end-to-end on a fresh checkout with the
+  `NEAT-AI-core` sibling cloned.

--- a/quality.sh
+++ b/quality.sh
@@ -41,6 +41,9 @@ echo "🔐 Validating Gitleaks workflow hardening (Issue #21)..."
 echo "🛡️  Validating Semgrep SAST workflow (Issue #47)..."
 ./scripts/check-semgrep-workflow.sh
 
+echo "🦀 Validating Cargo Security Audit workflow (Issue #64)..."
+./scripts/check-cargo-audit-workflow.sh
+
 echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 ./scripts/check-auto-format-workflow.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.20"
+version = "0.5.21"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-cargo-audit-workflow.sh
+++ b/scripts/check-cargo-audit-workflow.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Validate the standalone Cargo Security Audit workflow (Issue #64).
+#
+# The cargo-audit workflow must:
+#   1. Trigger on pull_request so every change is audited before merge.
+#   2. Trigger on a cron schedule so freshly published advisories surface
+#      even on quiet branches (the lockfile does not change but the
+#      advisory database does).
+#   3. Declare an explicit `permissions:` block (least privilege).
+#   4. Pin `actions/checkout` to a numeric major version (Node 24 policy).
+#   5. Install a Rust toolchain via `dtolnay/rust-toolchain` so cargo-audit
+#      can be installed and run.
+#   6. Invoke cargo-audit — either directly (`cargo audit` after a
+#      `cargo install cargo-audit` step) or via the official RustSec
+#      action (`rustsec/audit-check@vN`).
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/cargo-audit.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-cargo-audit-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the cargo-audit workflow YAML file (default:
+                    .github/workflows/cargo-audit.yml relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/cargo-audit.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. Triggered on pull_request events.
+if grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW" \
+  || grep -qE '^on:[[:space:]]*\[?.*pull_request' "$WORKFLOW"; then
+  ok "triggers on pull_request"
+else
+  fail "workflow is not triggered on pull_request"
+fi
+
+# 2. Schedule trigger present (cron) — covers advisory-DB updates.
+if grep -qE '^[[:space:]]+schedule:' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+- cron:' "$WORKFLOW"; then
+  ok "triggers on schedule (cron)"
+else
+  fail "no schedule (cron) trigger — weekly audit run required"
+fi
+
+# 3. Explicit permissions block (least privilege).
+if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
+  ok "permissions block grants only contents: read"
+else
+  fail "no 'permissions: contents: read' block — least-privilege required"
+fi
+
+# 4. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
+checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
+if [[ -z "$checkout_line" ]]; then
+  fail "actions/checkout step missing — workflow cannot fetch the repo"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
+  ok "actions/checkout pinned to a numeric major"
+else
+  fail "actions/checkout is not pinned — branch refs disallowed"
+fi
+
+# 5. Rust toolchain provisioned via dtolnay/rust-toolchain.
+if grep -qE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$WORKFLOW"; then
+  ok "dtolnay/rust-toolchain present"
+else
+  fail "dtolnay/rust-toolchain missing — Rust toolchain not provisioned"
+fi
+
+# 6. cargo-audit invoked — either via the rustsec action OR a direct
+#    `cargo audit` run (after `cargo install cargo-audit`).
+if grep -qE 'uses:[[:space:]]*rustsec/audit-check@' "$WORKFLOW"; then
+  ok "cargo audit invoked via rustsec/audit-check action"
+elif grep -qE '^[[:space:]]+(- )?run:[[:space:]]*cargo audit' "$WORKFLOW" \
+  || grep -qE 'cargo[[:space:]]+audit([[:space:]]|$)' "$WORKFLOW"; then
+  ok "cargo audit invoked directly"
+else
+  fail "cargo audit is not invoked — neither rustsec/audit-check nor a 'cargo audit' run step found"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/cargo_audit_workflow.bats
+++ b/tests/scripts/cargo_audit_workflow.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-cargo-audit-workflow.sh — Issue #64.
+#
+# Exercises the Cargo Security Audit workflow validator with synthetic
+# workflow YAML in temporary directories so behaviour (exit codes, reported
+# failures) is verified end-to-end without mutating the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-cargo-audit-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_audit_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Cargo Audit
+
+# Standalone Cargo Security Audit workflow (Issue #64). Mirrors the
+# cargo-audit step embedded in the reusable security workflow but adds a
+# weekly schedule so advisories published after the last PR still surface.
+
+on:
+  pull_request:
+    branches: ["*"]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"triggers on pull_request"* ]]
+  [[ "$output" == *"triggers on schedule"* ]]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+  [[ "$output" == *"dtolnay/rust-toolchain present"* ]]
+  [[ "$output" == *"cargo audit invoked"* ]]
+}
+
+@test "fails when the workflow is not triggered on pull_request" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  python3 - "$TMP_WF/cargo-audit.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not triggered on pull_request"* ]]
+}
+
+@test "fails when the workflow has no schedule trigger" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  python3 - "$TMP_WF/cargo-audit.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("  schedule:\n    - cron: \"0 6 * * 1\"\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no schedule"* ]]
+}
+
+@test "fails when the permissions block is missing" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  python3 - "$TMP_WF/cargo-audit.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("permissions:\n  contents: read\n\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read'"* ]]
+}
+
+@test "fails when actions/checkout is unpinned" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@main|' "$TMP_WF/cargo-audit.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when dtolnay/rust-toolchain is missing" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  sed -i.bak '/dtolnay\/rust-toolchain/d' "$TMP_WF/cargo-audit.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"dtolnay/rust-toolchain"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when cargo audit is not invoked" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  sed -i.bak '/cargo audit/d' "$TMP_WF/cargo-audit.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cargo audit"* ]]
+  [[ "$output" == *"not invoked"* ]]
+}
+
+@test "accepts rustsec/audit-check action as the audit entry point" {
+  cat >"$TMP_WF/cargo-audit.yml" <<'EOF'
+name: Cargo Audit
+# Issue #64 — uses the official rustsec/audit-check action.
+on:
+  pull_request:
+    branches: ["*"]
+  schedule:
+    - cron: "0 6 * * 1"
+permissions:
+  contents: read
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cargo audit invoked"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository cargo-audit workflow satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Added a standalone Cargo Security Audit workflow at
`.github/workflows/cargo-audit.yml` that runs `cargo audit` on every pull
request, on a weekly cron schedule (`0 6 * * 1`), and on demand via
`workflow_dispatch`. The reusable `security.yml` already runs `cargo
audit` on PRs, but it has no schedule — so a freshly published RustSec
advisory against a pinned dependency would only surface on the next
merge. The weekly schedule closes that gap.

The workflow is hardened to match the rest of `.github/workflows/`:
least-privilege permissions (`contents: read`), pinned action majors
(`actions/checkout@v5`, `dtolnay/rust-toolchain@stable`), and a
`concurrency` group so scheduled / dispatch runs do not pile up.

Hardening rules are encoded in a dedicated validator
(`scripts/check-cargo-audit-workflow.sh`) wired into `quality.sh`, so any
future regression in the workflow YAML fails the local gate before CI.

Closes #64.

## Evidence

This is a pure CI / shell change with no UI surface. Verification:

- New BATS suite `tests/scripts/cargo_audit_workflow.bats` (11 tests)
  drives the validator end-to-end against synthetic fixtures and the
  real workflow file.
- `./quality.sh` passes locally with the new validator wired in
  (shellcheck, all workflow validators, codespell, bats, cargo-deny,
  clippy, check, build, test, doc, release build).

```mermaid
flowchart LR
    A[Issue #64] --> B[cargo-audit.yml]
    B --> C{trigger}
    C -->|pull_request| D[cargo audit on PR]
    C -->|cron weekly| E[catches new advisories]
    C -->|workflow_dispatch| F[manual run]
    G[check-cargo-audit-workflow.sh] -->|validates| B
    H[quality.sh] -->|invokes| G
    I[cargo_audit_workflow.bats] -->|tests| G
```

## Test Plan

- New `tests/scripts/cargo_audit_workflow.bats` (11 tests) covering:
  - canonical fixture passes
  - missing `pull_request` trigger fails
  - missing `schedule` trigger fails
  - missing `permissions: contents: read` block fails
  - unpinned `actions/checkout` fails
  - missing `dtolnay/rust-toolchain` fails
  - missing `cargo audit` invocation fails
  - `rustsec/audit-check` action accepted as the audit entry point
  - missing workflow file reports an error
  - unknown flag prints usage and exits non-zero
  - real repository workflow satisfies every rule
- Existing `scripts/check-workflow-action-versions.sh` and
  `scripts/check-workflow-paths.sh` were re-run to confirm the new
  workflow does not regress the Node 24 policy or the NEAT-AI-core path
  strategy (cargo-audit does not check out the sibling so the path
  validator correctly skips it).
- `./quality.sh` passes end-to-end on a fresh checkout with the
  `NEAT-AI-core` sibling cloned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)