### PR TITLE
Add Cargo Format and Clippy workflow (Issue #66)

### DIFF
--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -1,0 +1,92 @@
+name: Cargo Quality
+
+# Standalone Cargo Format and Clippy workflow (Issue #66).
+#
+# Why a dedicated workflow when ci.yml already runs fmt + clippy?
+#   * ci.yml only triggers on pushes/PRs against `Develop`. This workflow
+#     fires on PRs against ANY branch (`branches: ["*"]`), so feature
+#     branches and stacked PRs targeting non-Develop bases also get fmt
+#     and clippy coverage.
+#   * Keeps a small, fast, single-purpose gate that is cheap to re-run
+#     when iterating on style or lint fixes.
+#
+# Coverage is intentionally NOT uploaded here — the suggested template
+# from the workflow-sync issue includes a Codecov step, but this repo
+# has no `CODECOV_TOKEN` configured and adding `codecov/codecov-action`
+# would also require a new entry in
+# `scripts/check-workflow-action-versions.sh`. Coverage upload should be
+# tracked as its own follow-up (see Issue #1636 referenced in the
+# template) rather than smuggled in under the fmt + clippy banner.
+
+on:
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Avoid duplicate scheduled / dispatch runs piling up; PR runs are deduped
+# per-branch.
+concurrency:
+  group: cargo-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_JOBS: "2"
+
+jobs:
+  quality:
+    name: Cargo Format and Clippy
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # NEAT-AI-core is a path dependency required for `cargo fmt --all`
+      # and `cargo clippy` to resolve the workspace. Mirrors the strategy
+      # used in ci.yml — see the comment there for the path-strategy
+      # rationale.
+      - name: Checkout NEAT-AI-core (path dependency for neat-core)
+        uses: actions/checkout@v5
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          ref: Develop
+          path: NEAT-AI-core
+
+      - name: Link NEAT-AI-core sibling path expected by Cargo
+        run: |
+          set -euo pipefail
+          if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
+            ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-quality-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-quality-
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: |
+          cargo clippy --all-targets --all-features -- \
+            -D warnings \
+            -D clippy::filter_next \
+            -D clippy::collapsible_if

--- a/README.md
+++ b/README.md
@@ -262,6 +262,15 @@ validated by `scripts/check-cargo-audit-workflow.sh` (invoked from
 `quality.sh`) and covered end-to-end by
 `tests/scripts/cargo_audit_workflow.bats`.
 
+A standalone Cargo Quality workflow (`.github/workflows/cargo-quality.yml`,
+Issue #66) runs `cargo fmt --check` and `cargo clippy -- -D warnings` on
+pull requests against **any** branch (`branches: ["*"]`). `ci.yml` only
+fires for PRs targeting `Develop`, so this dedicated workflow gives feature
+branches and stacked PRs the same fmt + clippy gate without spinning up the
+full CI graph. The workflow is validated by
+`scripts/check-cargo-quality-workflow.sh` (invoked from `quality.sh`) and
+covered end-to-end by `tests/scripts/cargo_quality_workflow.bats`.
+
 ### GitHub Actions version policy (Node 24 compat)
 
 GitHub is deprecating the Node 20 runtime for JavaScript actions, so the

--- a/docs/pr-summary-66.md
+++ b/docs/pr-summary-66.md
@@ -1,0 +1,60 @@
+## Summary
+
+Added a standalone Cargo Quality (fmt + clippy) GitHub Actions workflow at
+`.github/workflows/cargo-quality.yml` per the workflow-sync template, with
+the same hardening pattern (least-privilege permissions, pinned action
+versions, NEAT-AI-core path-dependency checkout) used by the rest of the
+CI suite. Adds a matching validator script and BATS tests so the workflow
+cannot silently regress. Closes #66.
+
+`ci.yml` already runs fmt and clippy, but only for PRs targeting `Develop`.
+This new workflow fires on PRs against **any** branch
+(`branches: ["*"]`), so feature branches and stacked PRs targeting
+non-Develop bases get the same fmt + clippy gate without spinning up the
+full CI graph.
+
+The Codecov upload from the suggested template was deliberately omitted —
+the repo has no `CODECOV_TOKEN` configured and adding
+`codecov/codecov-action` would also require a new entry in
+`scripts/check-workflow-action-versions.sh`. That should be a separate
+follow-up rather than smuggled in under the fmt + clippy banner.
+
+## Evidence
+
+Backend / CI-only change — no UI to screenshot.
+
+- `bats tests/scripts/cargo_quality_workflow.bats` — 11/11 pass.
+- `./quality.sh < /dev/null` — full local gate passes (shellcheck,
+  workflow validators including the new one, codespell, bats, cargo-deny,
+  fmt, clippy, check, build, test, doc with `-D warnings`, release).
+- `scripts/check-workflow-action-versions.sh` — every `uses:` reference in
+  the new workflow satisfies the Node 24 policy (no new actions
+  introduced).
+- `scripts/check-workflow-paths.sh` — the new workflow uses the canonical
+  `path: NEAT-AI-core` checkout strategy.
+
+```mermaid
+flowchart LR
+    PR[PR opened against ANY branch] --> CQ[cargo-quality.yml]
+    CQ --> Checkout[actions/checkout@v5]
+    Checkout --> Sibling[Checkout NEAT-AI-core sibling]
+    Sibling --> Toolchain[dtolnay/rust-toolchain<br/>+ rustfmt, clippy]
+    Toolchain --> Fmt[cargo fmt --all -- --check]
+    Fmt --> Clippy[cargo clippy --all-targets<br/>--all-features -- -D warnings]
+```
+
+## Test Plan
+
+- [x] Added `tests/scripts/cargo_quality_workflow.bats` covering: canonical
+      pass, missing `pull_request` trigger, missing permissions block,
+      unpinned `actions/checkout`, missing `dtolnay/rust-toolchain`,
+      missing `rustfmt`/`clippy` components, missing `cargo fmt --check`,
+      missing `cargo clippy -D warnings`, missing workflow file, unknown
+      flag, and end-to-end against the real `cargo-quality.yml`.
+- [x] Added `scripts/check-cargo-quality-workflow.sh` — invoked from
+      `quality.sh`, mirrors the structure of `check-cargo-audit-workflow.sh`.
+- [x] Updated `quality.sh` to invoke the new validator alongside the
+      existing workflow checks.
+- [x] Updated `README.md` "Pull request automation" section to describe
+      the new workflow.
+- [x] Confirmed `./quality.sh < /dev/null` passes end-to-end.

--- a/quality.sh
+++ b/quality.sh
@@ -44,6 +44,9 @@ echo "🛡️  Validating Semgrep SAST workflow (Issue #47)..."
 echo "🦀 Validating Cargo Security Audit workflow (Issue #64)..."
 ./scripts/check-cargo-audit-workflow.sh
 
+echo "🧹 Validating Cargo Quality (fmt + clippy) workflow (Issue #66)..."
+./scripts/check-cargo-quality-workflow.sh
+
 echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 ./scripts/check-auto-format-workflow.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.21"
+version = "0.5.22"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-cargo-quality-workflow.sh
+++ b/scripts/check-cargo-quality-workflow.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Validate the standalone Cargo Quality (fmt + clippy) workflow (Issue #66).
+#
+# The cargo-quality workflow must:
+#   1. Trigger on pull_request so every change is fmt + clippy checked.
+#   2. Declare an explicit `permissions:` block (least privilege).
+#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy).
+#   4. Install a Rust toolchain via `dtolnay/rust-toolchain` with the
+#      `rustfmt` and `clippy` components.
+#   5. Invoke `cargo fmt --check` (any flag form) so unformatted code fails CI.
+#   6. Invoke `cargo clippy` with `-D warnings` so lints fail CI.
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/cargo-quality.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-cargo-quality-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the cargo-quality workflow YAML file (default:
+                    .github/workflows/cargo-quality.yml relative to the repo
+                    root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/cargo-quality.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. Triggered on pull_request events.
+if grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW" \
+  || grep -qE '^on:[[:space:]]*\[?.*pull_request' "$WORKFLOW"; then
+  ok "triggers on pull_request"
+else
+  fail "workflow is not triggered on pull_request"
+fi
+
+# 2. Explicit permissions block (least privilege).
+if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
+  ok "permissions block grants only contents: read"
+else
+  fail "no 'permissions: contents: read' block — least-privilege required"
+fi
+
+# 3. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
+checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
+if [[ -z "$checkout_line" ]]; then
+  fail "actions/checkout step missing — workflow cannot fetch the repo"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
+  ok "actions/checkout pinned to a numeric major"
+else
+  fail "actions/checkout is not pinned — branch refs disallowed"
+fi
+
+# 4. Rust toolchain provisioned via dtolnay/rust-toolchain with rustfmt +
+#    clippy components.
+if grep -qE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$WORKFLOW"; then
+  ok "dtolnay/rust-toolchain present"
+else
+  fail "dtolnay/rust-toolchain missing — Rust toolchain not provisioned"
+fi
+
+if grep -qE 'rustfmt' "$WORKFLOW" && grep -qE 'clippy' "$WORKFLOW"; then
+  ok "rustfmt and clippy components requested"
+else
+  fail "rustfmt and clippy components must both be requested on the toolchain"
+fi
+
+# 5. cargo fmt --check invoked (accept --check or -- --check forms).
+if grep -qE 'cargo[[:space:]]+fmt[^#]*--check' "$WORKFLOW"; then
+  ok "cargo fmt --check invoked"
+else
+  fail "cargo fmt --check is not invoked — formatting drift must fail CI"
+fi
+
+# 6. cargo clippy with -D warnings.
+if grep -qE 'cargo[[:space:]]+clippy' "$WORKFLOW" \
+  && grep -qE -- '-D[[:space:]]+warnings' "$WORKFLOW"; then
+  ok "cargo clippy invoked with -D warnings"
+else
+  fail "cargo clippy must be invoked with '-D warnings' so lints fail CI"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/cargo_quality_workflow.bats
+++ b/tests/scripts/cargo_quality_workflow.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-cargo-quality-workflow.sh — Issue #66.
+#
+# Exercises the Cargo Quality (fmt + clippy) workflow validator with synthetic
+# workflow YAML in temporary directories so behaviour (exit codes, reported
+# failures) is verified end-to-end without mutating the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-cargo-quality-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_quality_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Cargo Quality
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"triggers on pull_request"* ]]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+  [[ "$output" == *"dtolnay/rust-toolchain present"* ]]
+  [[ "$output" == *"rustfmt and clippy components requested"* ]]
+  [[ "$output" == *"cargo fmt --check invoked"* ]]
+  [[ "$output" == *"cargo clippy invoked with -D warnings"* ]]
+}
+
+@test "fails when the workflow is not triggered on pull_request" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  python3 - "$TMP_WF/cargo-quality.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not triggered on pull_request"* ]]
+}
+
+@test "fails when the permissions block is missing" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  python3 - "$TMP_WF/cargo-quality.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("permissions:\n  contents: read\n\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read'"* ]]
+}
+
+@test "fails when actions/checkout is unpinned" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@main|' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when dtolnay/rust-toolchain is missing" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak '/dtolnay\/rust-toolchain/d' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"dtolnay/rust-toolchain"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when rustfmt component is not requested" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak 's|rustfmt, clippy|clippy|' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"rustfmt and clippy"* ]]
+}
+
+@test "fails when cargo fmt --check is not invoked" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak '/cargo fmt/d' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cargo fmt --check"* ]]
+  [[ "$output" == *"not invoked"* ]]
+}
+
+@test "fails when cargo clippy is not invoked with -D warnings" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak 's|-- -D warnings||' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cargo clippy"* ]]
+  [[ "$output" == *"-D warnings"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository cargo-quality workflow satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Added a standalone Cargo Quality (fmt + clippy) GitHub Actions workflow at
`.github/workflows/cargo-quality.yml` per the workflow-sync template, with
the same hardening pattern (least-privilege permissions, pinned action
versions, NEAT-AI-core path-dependency checkout) used by the rest of the
CI suite. Adds a matching validator script and BATS tests so the workflow
cannot silently regress. Closes #66.

`ci.yml` already runs fmt and clippy, but only for PRs targeting `Develop`.
This new workflow fires on PRs against **any** branch
(`branches: ["*"]`), so feature branches and stacked PRs targeting
non-Develop bases get the same fmt + clippy gate without spinning up the
full CI graph.

The Codecov upload from the suggested template was deliberately omitted —
the repo has no `CODECOV_TOKEN` configured and adding
`codecov/codecov-action` would also require a new entry in
`scripts/check-workflow-action-versions.sh`. That should be a separate
follow-up rather than smuggled in under the fmt + clippy banner.

## Evidence

Backend / CI-only change — no UI to screenshot.

- `bats tests/scripts/cargo_quality_workflow.bats` — 11/11 pass.
- `./quality.sh < /dev/null` — full local gate passes (shellcheck,
  workflow validators including the new one, codespell, bats, cargo-deny,
  fmt, clippy, check, build, test, doc with `-D warnings`, release).
- `scripts/check-workflow-action-versions.sh` — every `uses:` reference in
  the new workflow satisfies the Node 24 policy (no new actions
  introduced).
- `scripts/check-workflow-paths.sh` — the new workflow uses the canonical
  `path: NEAT-AI-core` checkout strategy.

```mermaid
flowchart LR
    PR[PR opened against ANY branch] --> CQ[cargo-quality.yml]
    CQ --> Checkout[actions/checkout@v5]
    Checkout --> Sibling[Checkout NEAT-AI-core sibling]
    Sibling --> Toolchain[dtolnay/rust-toolchain<br/>+ rustfmt, clippy]
    Toolchain --> Fmt[cargo fmt --all -- --check]
    Fmt --> Clippy[cargo clippy --all-targets<br/>--all-features -- -D warnings]
```

## Test Plan

- [x] Added `tests/scripts/cargo_quality_workflow.bats` covering: canonical
      pass, missing `pull_request` trigger, missing permissions block,
      unpinned `actions/checkout`, missing `dtolnay/rust-toolchain`,
      missing `rustfmt`/`clippy` components, missing `cargo fmt --check`,
      missing `cargo clippy -D warnings`, missing workflow file, unknown
      flag, and end-to-end against the real `cargo-quality.yml`.
- [x] Added `scripts/check-cargo-quality-workflow.sh` — invoked from
      `quality.sh`, mirrors the structure of `check-cargo-audit-workflow.sh`.
- [x] Updated `quality.sh` to invoke the new validator alongside the
      existing workflow checks.
- [x] Updated `README.md` "Pull request automation" section to describe
      the new workflow.
- [x] Confirmed `./quality.sh < /dev/null` passes end-to-end.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-66 -->