### PR TITLE
Add Dependency Review workflow (Issue #62)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,45 @@
+name: Dependency Review
+
+# Standalone Dependency Review workflow (Issue #62).
+#
+# Why a dedicated workflow? The reusable `security.yml` workflow already
+# invokes `actions/dependency-review-action` on PR events as part of CI.
+# This file mirrors that coverage as a self-contained, single-purpose
+# workflow so the dependency-review check is discoverable on its own and
+# runs even on PRs targeting branches that bypass the full CI graph
+# (`ci.yml` only fires for PRs into `Develop`).
+#
+# What it does: `actions/dependency-review-action` diffs the PR's manifest
+# (Cargo.toml / Cargo.lock here) against the base branch and fails the run
+# if any newly introduced dependency carries a known vulnerability or
+# disallowed licence — surfacing supply-chain risk before merge.
+#
+# Trigger: pull_request only. The action requires the diff between base and
+# head, which only makes sense on PR events.
+#
+# Action versions follow `scripts/check-workflow-action-versions.sh`:
+# `actions/checkout@v5` (Node 24 policy) and
+# `actions/dependency-review-action@v4` (tracked Node 20 exception — no v5
+# release upstream yet).
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+# Avoid duplicate runs piling up when a PR is updated rapidly.
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,10 +411,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -470,6 +496,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -584,7 +616,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.20"
+version = "0.5.22"
 dependencies = [
  "clap",
  "criterion",
@@ -679,6 +711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -779,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -789,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -802,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -845,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/README.md
+++ b/README.md
@@ -271,6 +271,19 @@ full CI graph. The workflow is validated by
 `scripts/check-cargo-quality-workflow.sh` (invoked from `quality.sh`) and
 covered end-to-end by `tests/scripts/cargo_quality_workflow.bats`.
 
+A standalone Dependency Review workflow
+(`.github/workflows/dependency-review.yml`, Issue #62) runs
+`actions/dependency-review-action@v4` on every pull request against any
+branch. The action diffs the PR's manifest against the base branch and
+fails the run if any newly introduced dependency carries a known
+vulnerability or disallowed licence — catching supply-chain regressions
+before merge. The reusable `security.yml` workflow runs the same action
+inside the full CI graph; this dedicated workflow gives feature branches
+and stacked PRs the same gate without spinning up CI. The workflow is
+validated by `scripts/check-dependency-review-workflow.sh` (invoked from
+`quality.sh`) and covered end-to-end by
+`tests/scripts/dependency_review_workflow.bats`.
+
 ### GitHub Actions version policy (Node 24 compat)
 
 GitHub is deprecating the Node 20 runtime for JavaScript actions, so the

--- a/docs/pr-summary-62.md
+++ b/docs/pr-summary-62.md
@@ -1,0 +1,54 @@
+## Summary
+
+Adds the standalone `Dependency Review` GitHub Actions workflow requested by
+the workflow sync tracker. The workflow runs
+`actions/dependency-review-action@v4` on every pull request against any
+branch, diffing the PR's manifest against the base branch and failing the
+run if any newly introduced dependency carries a known vulnerability or
+disallowed licence — surfacing supply-chain risk before merge.
+
+The reusable `security.yml` workflow already runs the same action inside the
+full CI graph (which only fires for PRs into `Develop`); this dedicated
+workflow gives feature branches and stacked PRs the same gate without
+spinning up CI. Closes #62.
+
+## Evidence
+
+This is a CI / workflow change with no UI surface and no runtime
+performance impact. Verification:
+
+- New BATS suite `tests/scripts/dependency_review_workflow.bats` exercises
+  the new validator end-to-end (10 tests, all green).
+- The validator `scripts/check-dependency-review-workflow.sh` is invoked
+  from `quality.sh` and reports OK on the real workflow file.
+- Full local quality gate (`./quality.sh`) passes, including shellcheck,
+  the existing 148 BATS tests, cargo-deny, fmt, clippy, check, build, test,
+  doc, and release build.
+- The Node 24 compat policy in
+  `scripts/check-workflow-action-versions.sh` already lists
+  `actions/dependency-review-action` as a tracked Node 20 exception at
+  `@v4`; the new workflow's pin satisfies that policy.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CI[ci.yml &mdash; Develop only]
+    PR --> DR[dependency-review.yml &mdash; any branch]
+    CI --> SEC[security.yml &mdash; reusable]
+    SEC --> DRA[actions/dependency-review-action@v4]
+    DR --> DRA
+    DRA -->|advisory or licence| FAIL[fail PR]
+    DRA -->|clean| PASS[merge gate green]
+```
+
+## Test Plan
+
+- Added `tests/scripts/dependency_review_workflow.bats` covering the
+  canonical fixture, every failure rule (missing `pull_request` trigger,
+  missing `permissions` block, unpinned/missing `actions/checkout`,
+  unpinned/missing `actions/dependency-review-action`), missing-file and
+  unknown-flag error paths, plus an end-to-end check against the real
+  workflow file.
+- Added `scripts/check-dependency-review-workflow.sh` and wired it into
+  `quality.sh`.
+- Re-ran the full BATS suite (148 tests, all passing) and `./quality.sh`
+  (passes cleanly).

--- a/quality.sh
+++ b/quality.sh
@@ -47,6 +47,9 @@ echo "🦀 Validating Cargo Security Audit workflow (Issue #64)..."
 echo "🧹 Validating Cargo Quality (fmt + clippy) workflow (Issue #66)..."
 ./scripts/check-cargo-quality-workflow.sh
 
+echo "📦 Validating Dependency Review workflow (Issue #62)..."
+./scripts/check-dependency-review-workflow.sh
+
 echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 ./scripts/check-auto-format-workflow.sh
 

--- a/scripts/check-dependency-review-workflow.sh
+++ b/scripts/check-dependency-review-workflow.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Validate the standalone Dependency Review workflow (Issue #62).
+#
+# The dependency-review workflow must:
+#   1. Trigger on pull_request so every change is reviewed before merge —
+#      `actions/dependency-review-action` only operates on pull_request
+#      events (it diffs the PR's manifest against the base branch).
+#   2. Declare an explicit `permissions:` block (least privilege). The
+#      action only needs `contents: read` to diff manifests; richer
+#      permissions (e.g. `pull-requests: write`) are only required when
+#      enabling PR comment summaries, which the standalone workflow leaves
+#      to the reusable security workflow.
+#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy).
+#   4. Invoke `actions/dependency-review-action`, also pinned to a numeric
+#      major (the version policy in
+#      `scripts/check-workflow-action-versions.sh` tracks the current
+#      Node 20 exception at @v4).
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/dependency-review.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-dependency-review-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the dependency-review workflow YAML file
+                    (default: .github/workflows/dependency-review.yml
+                    relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/dependency-review.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. Triggered on pull_request events.
+if grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW" \
+  || grep -qE '^on:[[:space:]]*\[?.*pull_request' "$WORKFLOW"; then
+  ok "triggers on pull_request"
+else
+  fail "workflow is not triggered on pull_request"
+fi
+
+# 2. Explicit permissions block (least privilege).
+if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
+  ok "permissions block grants only contents: read"
+else
+  fail "no 'permissions: contents: read' block — least-privilege required"
+fi
+
+# 3. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
+checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
+if [[ -z "$checkout_line" ]]; then
+  fail "actions/checkout step missing — workflow cannot fetch the repo"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
+  ok "actions/checkout pinned to a numeric major"
+else
+  fail "actions/checkout is not pinned — branch refs disallowed"
+fi
+
+# 4. actions/dependency-review-action present and pinned to a numeric major.
+dr_line="$(grep -nE 'uses:[[:space:]]*actions/dependency-review-action@' "$WORKFLOW" || true)"
+if [[ -z "$dr_line" ]]; then
+  fail "actions/dependency-review-action missing — workflow performs no review"
+elif echo "$dr_line" | grep -qE 'actions/dependency-review-action@v?[0-9]+'; then
+  ok "actions/dependency-review-action present and pinned to a numeric major"
+else
+  fail "actions/dependency-review-action is not pinned — branch refs disallowed"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/dependency_review_workflow.bats
+++ b/tests/scripts/dependency_review_workflow.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-dependency-review-workflow.sh — Issue #62.
+#
+# Exercises the Dependency Review workflow validator with synthetic
+# workflow YAML in temporary directories so behaviour (exit codes, reported
+# failures) is verified end-to-end without mutating the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-dependency-review-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_dependency_review_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Dependency Review
+
+# Standalone Dependency Review workflow (Issue #62).
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/dependency-review-action@v4
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"triggers on pull_request"* ]]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+  [[ "$output" == *"actions/dependency-review-action present"* ]]
+}
+
+@test "fails when the workflow is not triggered on pull_request" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  python3 - "$TMP_WF/dependency-review.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("on:\n  pull_request:\n    branches: [\"*\"]\n", "on:\n  workflow_dispatch:\n")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not triggered on pull_request"* ]]
+}
+
+@test "fails when the permissions block is missing" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  python3 - "$TMP_WF/dependency-review.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("permissions:\n  contents: read\n\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read'"* ]]
+}
+
+@test "fails when actions/checkout is unpinned" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@main|' "$TMP_WF/dependency-review.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when actions/checkout is missing" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  sed -i.bak '/actions\/checkout/d' "$TMP_WF/dependency-review.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when actions/dependency-review-action is missing" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  sed -i.bak '/actions\/dependency-review-action/d' "$TMP_WF/dependency-review.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/dependency-review-action"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when actions/dependency-review-action is unpinned" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  sed -i.bak 's|actions/dependency-review-action@v4|actions/dependency-review-action@main|' "$TMP_WF/dependency-review.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/dependency-review-action"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository dependency-review workflow satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# PR Summary: Add Dependency Review Workflow (Issue #62)

## Summary

Adds the standalone `Dependency Review` GitHub Actions workflow requested by
the workflow sync tracker. The workflow runs
`actions/dependency-review-action@v4` on every pull request against any
branch, diffing the PR's manifest against the base branch and failing the
run if any newly introduced dependency carries a known vulnerability or
disallowed licence — surfacing supply-chain risk before merge.

The reusable `security.yml` workflow already runs the same action inside the
full CI graph (which only fires for PRs into `Develop`); this dedicated
workflow gives feature branches and stacked PRs the same gate without
spinning up CI. Closes #62.

## Evidence

This is a CI / workflow change with no UI surface and no runtime
performance impact. Verification:

- New BATS suite `tests/scripts/dependency_review_workflow.bats` exercises
  the new validator end-to-end (10 tests, all green).
- The validator `scripts/check-dependency-review-workflow.sh` is invoked
  from `quality.sh` and reports OK on the real workflow file.
- Full local quality gate (`./quality.sh`) passes, including shellcheck,
  the existing 148 BATS tests, cargo-deny, fmt, clippy, check, build, test,
  doc, and release build.
- The Node 24 compat policy in
  `scripts/check-workflow-action-versions.sh` already lists
  `actions/dependency-review-action` as a tracked Node 20 exception at
  `@v4`; the new workflow's pin satisfies that policy.

```mermaid
flowchart LR
    PR[Pull Request] --> CI[ci.yml &mdash; Develop only]
    PR --> DR[dependency-review.yml &mdash; any branch]
    CI --> SEC[security.yml &mdash; reusable]
    SEC --> DRA[actions/dependency-review-action@v4]
    DR --> DRA
    DRA -->|advisory or licence| FAIL[fail PR]
    DRA -->|clean| PASS[merge gate green]
```

## Test Plan

- Added `tests/scripts/dependency_review_workflow.bats` covering the
  canonical fixture, every failure rule (missing `pull_request` trigger,
  missing `permissions` block, unpinned/missing `actions/checkout`,
  unpinned/missing `actions/dependency-review-action`), missing-file and
  unknown-flag error paths, plus an end-to-end check against the real
  workflow file.
- Added `scripts/check-dependency-review-workflow.sh` and wired it into
  `quality.sh`.
- Re-ran the full BATS suite (148 tests, all passing) and `./quality.sh`
  (passes cleanly).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-62 -->