### PR TITLE
Add ShellCheck Lint workflow (Issue #67)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,38 @@
+name: ShellCheck
+
+# Standalone ShellCheck Lint workflow (Issue #67).
+#
+# A duplicate `shell-checks` job already runs inside .github/workflows/ci.yml
+# alongside `bash -n` syntax checks and the bats helper-test suite. The
+# standalone workflow exists so workflow-sync tooling can detect a dedicated
+# `shellcheck.yml` by filename — branch protection should continue to gate on
+# the `ci-required` aggregator from ci.yml, not on this standalone job.
+#
+# Action pinning policy (Issue #24):
+#   * actions/checkout — numeric major (Node 24 compat).
+#   * ludeeus/action-shellcheck — tagged release, NOT @master. A compromised
+#     upstream commit on @master would silently alter CI behaviour.
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Run ShellCheck (koalaman/shellcheck via ludeeus/action-shellcheck)
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: "."
+          severity: warning
+          ignore_paths: "target .git"
+        env:
+          SHELLCHECK_OPTS: -s bash

--- a/README.md
+++ b/README.md
@@ -271,6 +271,16 @@ full CI graph. The workflow is validated by
 `scripts/check-cargo-quality-workflow.sh` (invoked from `quality.sh`) and
 covered end-to-end by `tests/scripts/cargo_quality_workflow.bats`.
 
+A standalone ShellCheck Lint workflow (`.github/workflows/shellcheck.yml`,
+Issue #67) runs `ludeeus/action-shellcheck@2.0.0` on every pull request
+against any branch (`branches: ["*"]`). `ci.yml`'s `shell-checks` job runs
+the same action inside the full CI graph; this dedicated workflow lets
+workflow-sync tooling discover a dedicated `shellcheck.yml` by filename
+without disturbing the existing branch-protection aggregator. The workflow
+is validated by `scripts/check-shellcheck-workflow.sh` (invoked from
+`quality.sh`) and covered end-to-end by
+`tests/scripts/shellcheck_workflow.bats`.
+
 A standalone Dependency Review workflow
 (`.github/workflows/dependency-review.yml`, Issue #62) runs
 `actions/dependency-review-action@v4` on every pull request against any

--- a/docs/pr-summary-67.md
+++ b/docs/pr-summary-67.md
@@ -1,0 +1,60 @@
+## Summary
+
+Add a standalone ShellCheck Lint workflow (`.github/workflows/shellcheck.yml`)
+so workflow-sync tooling can discover a dedicated `shellcheck.yml` by
+filename. ShellCheck already runs as the `shell-checks` job inside `ci.yml`;
+this dedicated workflow gives feature branches and stacked PRs the same
+shell-lint gate without spinning up the full CI graph, mirroring the existing
+pattern used for `cargo-quality.yml`, `cargo-audit.yml`, and
+`dependency-review.yml`. Closes #67.
+
+The action pinning policy (Issue #24) is enforced: `actions/checkout@v5`
+(numeric major) and `ludeeus/action-shellcheck@2.0.0` (tagged release — the
+suggested `@master` ref from the issue template is rejected by the validator
+because a compromised upstream commit on `master` would silently alter CI
+behaviour). `severity:` is declared explicitly so the gate stays
+deterministic across upstream default changes.
+
+The validator hooks into `quality.sh` so the workflow's hardening cannot
+silently regress.
+
+## Evidence
+
+This is a CI-only change (no UI, no runtime code). Verified end-to-end via:
+
+- `bats tests/scripts/shellcheck_workflow.bats` — 10/10 pass.
+- `./scripts/check-shellcheck-workflow.sh` — every rule reports OK.
+- `./scripts/check-workflow-action-versions.sh` — both pinned actions in the
+  new workflow satisfy the Node 24 compatibility policy.
+- `./scripts/check-ci-job-graph.sh` — existing `ci.yml` graph still validates
+  (no jobs were moved out of `ci.yml`, so branch protection on `ci-required`
+  is undisturbed).
+- `./quality.sh` — full local gate passes (shellcheck, cargo-deny, fmt,
+  clippy, check, build, test, doc with `-D warnings`, release build).
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CI[ci.yml<br/>shell-checks job]
+    PR --> Standalone[shellcheck.yml<br/>standalone job]
+    CI --> Aggregator[ci-required<br/>branch protection]
+    Standalone -.dedicated gate.-> PR
+```
+
+## Test Plan
+
+- Added `tests/scripts/shellcheck_workflow.bats` (10 cases) covering:
+  - canonical fixture passes,
+  - missing `pull_request` trigger fails,
+  - missing `permissions: contents: read` fails,
+  - unpinned `actions/checkout` (e.g. `@main`) fails,
+  - `ludeeus/action-shellcheck@master` fails,
+  - missing `ludeeus/action-shellcheck` step fails,
+  - missing `severity:` fails,
+  - missing workflow file reports an error,
+  - unknown CLI flag prints usage and exits non-zero,
+  - the real repository workflow satisfies every rule.
+- Added `scripts/check-shellcheck-workflow.sh` and wired it into `quality.sh`
+  so any future regression in the standalone workflow's hardening fails the
+  local gate.
+- README updated to document the new workflow alongside the other standalone
+  per-tool workflows.

--- a/quality.sh
+++ b/quality.sh
@@ -47,6 +47,9 @@ echo "🦀 Validating Cargo Security Audit workflow (Issue #64)..."
 echo "🧹 Validating Cargo Quality (fmt + clippy) workflow (Issue #66)..."
 ./scripts/check-cargo-quality-workflow.sh
 
+echo "🐚 Validating standalone ShellCheck Lint workflow (Issue #67)..."
+./scripts/check-shellcheck-workflow.sh
+
 echo "📦 Validating Dependency Review workflow (Issue #62)..."
 ./scripts/check-dependency-review-workflow.sh
 

--- a/scripts/check-shellcheck-workflow.sh
+++ b/scripts/check-shellcheck-workflow.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Validate the standalone ShellCheck Lint workflow (Issue #67).
+#
+# The shellcheck workflow must:
+#   1. Trigger on pull_request so every change is shell-linted before merge.
+#   2. Declare an explicit `permissions:` block (least privilege —
+#      `contents: read` is sufficient because shellcheck only reads source).
+#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy —
+#      see scripts/check-workflow-action-versions.sh).
+#   4. Invoke ShellCheck via `ludeeus/action-shellcheck` pinned to a numeric
+#      release (NOT `@master` — branch refs are forbidden by Issue #24
+#      because a compromised upstream commit would silently alter CI
+#      behaviour).
+#   5. Declare an explicit `severity:` value so the gate is deterministic
+#      across upstream default changes.
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/shellcheck.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-shellcheck-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the shellcheck workflow YAML file (default:
+                    .github/workflows/shellcheck.yml relative to the repo
+                    root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/shellcheck.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. Triggered on pull_request events.
+if grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW" \
+  || grep -qE '^on:[[:space:]]*\[?.*pull_request' "$WORKFLOW"; then
+  ok "triggers on pull_request"
+else
+  fail "workflow is not triggered on pull_request"
+fi
+
+# 2. Explicit permissions block (least privilege).
+if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
+  ok "permissions block grants only contents: read"
+else
+  fail "no 'permissions: contents: read' block — least-privilege required"
+fi
+
+# 3. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
+checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
+if [[ -z "$checkout_line" ]]; then
+  fail "actions/checkout step missing — workflow cannot fetch the repo"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
+  ok "actions/checkout pinned to a numeric major"
+else
+  fail "actions/checkout is not pinned — branch refs disallowed"
+fi
+
+# 4. ludeeus/action-shellcheck pinned to a numeric version. The suggested
+#    `@master` ref in the issue template is rejected here — supply-chain
+#    hygiene (Issue #24) requires a tagged release.
+shellcheck_line="$(grep -nE 'uses:[[:space:]]*ludeeus/action-shellcheck@' "$WORKFLOW" || true)"
+if [[ -z "$shellcheck_line" ]]; then
+  fail "ludeeus/action-shellcheck step missing — shellcheck is not invoked"
+elif echo "$shellcheck_line" | grep -qE 'ludeeus/action-shellcheck@v?[0-9]+'; then
+  ok "ludeeus/action-shellcheck pinned to a numeric release"
+else
+  fail "ludeeus/action-shellcheck is not pinned — @master and other branch refs disallowed"
+fi
+
+# 5. Severity is declared explicitly so the gate is deterministic.
+if grep -qE '^[[:space:]]+severity:[[:space:]]*[A-Za-z]+' "$WORKFLOW"; then
+  ok "severity declared explicitly"
+else
+  fail "severity not declared — must set 'severity:' explicitly for deterministic gating"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/shellcheck_workflow.bats
+++ b/tests/scripts/shellcheck_workflow.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-shellcheck-workflow.sh — Issue #67.
+#
+# Exercises the standalone ShellCheck Lint workflow validator with synthetic
+# workflow YAML in temporary directories so behaviour (exit codes, reported
+# failures) is verified end-to-end without mutating the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-shellcheck-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_shellcheck_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: ShellCheck
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: "."
+          severity: warning
+          ignore_paths: "target .git"
+        env:
+          SHELLCHECK_OPTS: -s bash
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_shellcheck_workflow "$TMP_WF/shellcheck.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/shellcheck.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"triggers on pull_request"* ]]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+  [[ "$output" == *"ludeeus/action-shellcheck pinned"* ]]
+  [[ "$output" == *"severity"* ]]
+}
+
+@test "fails when the workflow is not triggered on pull_request" {
+  write_shellcheck_workflow "$TMP_WF/shellcheck.yml"
+  python3 - "$TMP_WF/shellcheck.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/shellcheck.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not triggered on pull_request"* ]]
+}
+
+@test "fails when the permissions block is missing" {
+  write_shellcheck_workflow "$TMP_WF/shellcheck.yml"
+  python3 - "$TMP_WF/shellcheck.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("permissions:\n  contents: read\n\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/shellcheck.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read'"* ]]
+}
+
+@test "fails when actions/checkout is unpinned" {
+  write_shellcheck_workflow "$TMP_WF/shellcheck.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@main|' "$TMP_WF/shellcheck.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/shellcheck.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when ludeeus/action-shellcheck pins to @master" {
+  write_shellcheck_workflow "$TMP_WF/shellcheck.yml"
+  sed -i.bak 's|ludeeus/action-shellcheck@2.0.0|ludeeus/action-shellcheck@master|' "$TMP_WF/shellcheck.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/shellcheck.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ludeeus/action-shellcheck"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when ludeeus/action-shellcheck step is missing" {
+  write_shellcheck_workflow "$TMP_WF/shellcheck.yml"
+  sed -i.bak '/ludeeus\/action-shellcheck/d' "$TMP_WF/shellcheck.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/shellcheck.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ludeeus/action-shellcheck"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when severity is not declared" {
+  write_shellcheck_workflow "$TMP_WF/shellcheck.yml"
+  sed -i.bak '/severity:/d' "$TMP_WF/shellcheck.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/shellcheck.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"severity"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository shellcheck workflow satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Add a standalone ShellCheck Lint workflow (`.github/workflows/shellcheck.yml`)
so workflow-sync tooling can discover a dedicated `shellcheck.yml` by
filename. ShellCheck already runs as the `shell-checks` job inside `ci.yml`;
this dedicated workflow gives feature branches and stacked PRs the same
shell-lint gate without spinning up the full CI graph, mirroring the existing
pattern used for `cargo-quality.yml`, `cargo-audit.yml`, and
`dependency-review.yml`. Closes #67.

The action pinning policy (Issue #24) is enforced: `actions/checkout@v5`
(numeric major) and `ludeeus/action-shellcheck@2.0.0` (tagged release — the
suggested `@master` ref from the issue template is rejected by the validator
because a compromised upstream commit on `master` would silently alter CI
behaviour). `severity:` is declared explicitly so the gate stays
deterministic across upstream default changes.

The validator hooks into `quality.sh` so the workflow's hardening cannot
silently regress.

## Evidence

This is a CI-only change (no UI, no runtime code). Verified end-to-end via:

- `bats tests/scripts/shellcheck_workflow.bats` — 10/10 pass.
- `./scripts/check-shellcheck-workflow.sh` — every rule reports OK.
- `./scripts/check-workflow-action-versions.sh` — both pinned actions in the
  new workflow satisfy the Node 24 compatibility policy.
- `./scripts/check-ci-job-graph.sh` — existing `ci.yml` graph still validates
  (no jobs were moved out of `ci.yml`, so branch protection on `ci-required`
  is undisturbed).
- `./quality.sh` — full local gate passes (shellcheck, cargo-deny, fmt,
  clippy, check, build, test, doc with `-D warnings`, release build).

```mermaid
flowchart LR
    PR[Pull Request] --> CI[ci.yml<br/>shell-checks job]
    PR --> Standalone[shellcheck.yml<br/>standalone job]
    CI --> Aggregator[ci-required<br/>branch protection]
    Standalone -.dedicated gate.-> PR
```

## Test Plan

- Added `tests/scripts/shellcheck_workflow.bats` (10 cases) covering:
  - canonical fixture passes,
  - missing `pull_request` trigger fails,
  - missing `permissions: contents: read` fails,
  - unpinned `actions/checkout` (e.g. `@main`) fails,
  - `ludeeus/action-shellcheck@master` fails,
  - missing `ludeeus/action-shellcheck` step fails,
  - missing `severity:` fails,
  - missing workflow file reports an error,
  - unknown CLI flag prints usage and exits non-zero,
  - the real repository workflow satisfies every rule.
- Added `scripts/check-shellcheck-workflow.sh` and wired it into `quality.sh`
  so any future regression in the standalone workflow's hardening fails the
  local gate.
- README updated to document the new workflow alongside the other standalone
  per-tool workflows.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-67 -->