### PR TITLE
Add Markdown Lint workflow (Issue #63)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,48 @@
+name: Markdown Lint
+
+# Standalone Markdown Lint workflow (Issue #63).
+#
+# Why this exists:
+#   * The repository ships a `.markdownlint-cli2.yaml` config but had no CI
+#     job enforcing it. This workflow runs `markdownlint-cli2` against every
+#     pull request so style regressions in README/docs surface before merge.
+#   * Workflow-sync tooling looks for `markdown-lint.yml` by filename; the
+#     dedicated file keeps the gate discoverable independent of `ci.yml`.
+#
+# Action pinning policy (Issue #24, mirrored by
+# `scripts/check-workflow-action-versions.sh`):
+#   * actions/checkout — `@v5` (Node 24).
+#   * actions/setup-node — `@v4` (Node 24).
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+# Avoid stacking duplicate runs on rapid pushes; PR runs are deduped per branch.
+concurrency:
+  group: markdown-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdownlint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2

--- a/docs/pr-summary-63.md
+++ b/docs/pr-summary-63.md
@@ -1,0 +1,60 @@
+## Summary
+
+Adds the standalone Markdown Lint GitHub Actions workflow requested by workflow-sync tooling. The workflow installs `markdownlint-cli2` and runs it against the existing `.markdownlint-cli2.yaml` config on every pull request and on pushes to `main`/`master`. Closes #63.
+
+To match the repo's existing convention (every workflow has a paired validator + bats suite + `quality.sh` hook), this PR also adds:
+
+- `scripts/check-markdown-lint-workflow.sh` — validates the workflow's triggers, least-privilege permissions, action pins, and that `markdownlint-cli2` is both installed and invoked.
+- `tests/scripts/markdown_lint_workflow.bats` — 11 bats tests exercising the validator with synthetic fixtures.
+- A new `quality.sh` step that runs the validator alongside the other workflow gates.
+- `actions/setup-node` is now in the Node 24 policy table (`required:4`) so the new workflow does not trip the unknown-action warning.
+
+The optional Deno-based Mermaid validation block from the issue template is omitted — `worker/deno/mod.ts` does not exist in this Rust-only repo, so the conditional block would always skip.
+
+## Evidence
+
+CLI gate (no UI to screenshot):
+
+```text
+$ ./scripts/check-markdown-lint-workflow.sh
+OK   .../markdown-lint.yml: triggers on pull_request
+OK   .../markdown-lint.yml: permissions block grants only contents: read
+OK   .../markdown-lint.yml: actions/checkout pinned to a numeric major
+OK   .../markdown-lint.yml: actions/setup-node pinned to a numeric major
+OK   .../markdown-lint.yml: markdownlint-cli2 install step present
+OK   .../markdown-lint.yml: markdownlint-cli2 invoked
+
+$ bats tests/scripts/markdown_lint_workflow.bats
+1..11
+ok 1 passes on the canonical fixture
+ok 2 fails when the workflow is not triggered on pull_request
+ok 3 fails when the permissions block is missing
+ok 4 fails when actions/checkout is unpinned
+ok 5 fails when actions/setup-node is unpinned
+ok 6 fails when actions/setup-node step is missing
+ok 7 fails when markdownlint-cli2 install step is missing
+ok 8 fails when markdownlint-cli2 is not invoked
+ok 9 reports an error when the workflow file does not exist
+ok 10 unknown flag prints usage and exits non-zero
+ok 11 real repository markdown-lint workflow satisfies every rule
+```
+
+Full bats suite (`bats tests/scripts/`) — 169 tests pass, none fail.
+
+```mermaid
+flowchart LR
+    PR[Pull request opened] --> WF[markdown-lint.yml]
+    WF --> CO[actions/checkout@v5]
+    CO --> SN[actions/setup-node@v4]
+    SN --> IN[npm install -g markdownlint-cli2]
+    IN --> RUN[markdownlint-cli2]
+    RUN --> RES{Lint clean?}
+    RES -- yes --> PASS[ Job passes]
+    RES -- no --> FAIL[ Job fails — block merge]
+```
+
+## Test Plan
+
+- Added `tests/scripts/markdown_lint_workflow.bats` (11 cases) covering the canonical workflow plus targeted failure modes for each rule the validator enforces.
+- Verified `scripts/check-workflow-action-versions.sh` still passes after adding `actions/setup-node` to the policy (`bats tests/scripts/workflow_action_versions.bats`).
+- Ran the full `tests/scripts/` bats suite — 169 / 169 pass.

--- a/quality.sh
+++ b/quality.sh
@@ -50,6 +50,9 @@ echo "🧹 Validating Cargo Quality (fmt + clippy) workflow (Issue #66)..."
 echo "🐚 Validating standalone ShellCheck Lint workflow (Issue #67)..."
 ./scripts/check-shellcheck-workflow.sh
 
+echo "📝 Validating Markdown Lint workflow (Issue #63)..."
+./scripts/check-markdown-lint-workflow.sh
+
 echo "📦 Validating Dependency Review workflow (Issue #62)..."
 ./scripts/check-dependency-review-workflow.sh
 

--- a/scripts/check-markdown-lint-workflow.sh
+++ b/scripts/check-markdown-lint-workflow.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Validate the standalone Markdown Lint workflow (Issue #63).
+#
+# The markdown-lint workflow must:
+#   1. Trigger on pull_request so every change is linted before merge.
+#   2. Declare an explicit `permissions:` block (least privilege —
+#      `contents: read` is sufficient because markdownlint only reads source).
+#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy —
+#      see scripts/check-workflow-action-versions.sh).
+#   4. Provision Node via `actions/setup-node` pinned to a numeric major.
+#   5. Install and invoke `markdownlint-cli2` so the lint gate actually runs.
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/markdown-lint.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-markdown-lint-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the markdown-lint workflow YAML file (default:
+                    .github/workflows/markdown-lint.yml relative to the repo
+                    root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/markdown-lint.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. Triggered on pull_request events.
+if grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW" \
+  || grep -qE '^on:[[:space:]]*\[?.*pull_request' "$WORKFLOW"; then
+  ok "triggers on pull_request"
+else
+  fail "workflow is not triggered on pull_request"
+fi
+
+# 2. Explicit permissions block (least privilege).
+if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
+  ok "permissions block grants only contents: read"
+else
+  fail "no 'permissions: contents: read' block — least-privilege required"
+fi
+
+# 3. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
+checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
+if [[ -z "$checkout_line" ]]; then
+  fail "actions/checkout step missing — workflow cannot fetch the repo"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
+  ok "actions/checkout pinned to a numeric major"
+else
+  fail "actions/checkout is not pinned — branch refs disallowed"
+fi
+
+# 4. actions/setup-node pinned to a numeric major (vN). Branch refs disallowed.
+setup_node_line="$(grep -nE 'uses:[[:space:]]*actions/setup-node@' "$WORKFLOW" || true)"
+if [[ -z "$setup_node_line" ]]; then
+  fail "actions/setup-node step missing — Node toolchain not provisioned"
+elif echo "$setup_node_line" | grep -qE 'actions/setup-node@v?[0-9]+'; then
+  ok "actions/setup-node pinned to a numeric major"
+else
+  fail "actions/setup-node is not pinned — branch refs disallowed"
+fi
+
+# 5. markdownlint-cli2 must be installed AND invoked. Two separate checks so
+#    a missing install or a missing run surfaces as a distinct failure.
+if grep -qE 'npm[[:space:]]+install[[:space:]].*markdownlint-cli2' "$WORKFLOW"; then
+  ok "markdownlint-cli2 install step present"
+else
+  fail "markdownlint-cli2 install step missing — gate cannot run without the binary"
+fi
+
+if grep -qE '^[[:space:]]+(- )?run:[[:space:]]*markdownlint-cli2' "$WORKFLOW"; then
+  ok "markdownlint-cli2 invoked"
+else
+  fail "markdownlint-cli2 is not invoked — no 'run: markdownlint-cli2' step found"
+fi
+
+exit "$EXIT_CODE"

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -83,6 +83,7 @@ lookup_policy() {
   case "$action" in
     actions/checkout)                 echo "required:5" ;;
     actions/cache)                    echo "required:5" ;;
+    actions/setup-node)               echo "required:4" ;;
     peter-evans/create-pull-request)  echo "required:8" ;;
     ludeeus/action-shellcheck)        echo "required:2" ;;
     # actions/dependency-review-action: action.yml declares `using: node20`

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-markdown-lint-workflow.sh — Issue #63.
+#
+# Exercises the standalone Markdown Lint workflow validator with synthetic
+# workflow YAML in temporary directories so behaviour (exit codes, reported
+# failures) is verified end-to-end without mutating the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-markdown-lint-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_markdown_lint_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"triggers on pull_request"* ]]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+  [[ "$output" == *"actions/setup-node pinned"* ]]
+  [[ "$output" == *"markdownlint-cli2 install step present"* ]]
+  [[ "$output" == *"markdownlint-cli2 invoked"* ]]
+}
+
+@test "fails when the workflow is not triggered on pull_request" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  python3 - "$TMP_WF/markdown-lint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not triggered on pull_request"* ]]
+}
+
+@test "fails when the permissions block is missing" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  python3 - "$TMP_WF/markdown-lint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("permissions:\n  contents: read\n\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read'"* ]]
+}
+
+@test "fails when actions/checkout is unpinned" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@main|' "$TMP_WF/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when actions/setup-node is unpinned" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  sed -i.bak 's|actions/setup-node@v4|actions/setup-node@main|' "$TMP_WF/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/setup-node"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when actions/setup-node step is missing" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  sed -i.bak '/actions\/setup-node/d' "$TMP_WF/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/setup-node"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when markdownlint-cli2 install step is missing" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  sed -i.bak '/npm install -g markdownlint-cli2/d' "$TMP_WF/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"install step missing"* ]]
+}
+
+@test "fails when markdownlint-cli2 is not invoked" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  python3 - "$TMP_WF/markdown-lint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("      - name: Run markdownlint-cli2\n        run: markdownlint-cli2\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not invoked"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository markdown-lint workflow satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Adds the standalone Markdown Lint GitHub Actions workflow requested by workflow-sync tooling. The workflow installs `markdownlint-cli2` and runs it against the existing `.markdownlint-cli2.yaml` config on every pull request and on pushes to `main`/`master`. Closes #63.

To match the repo's existing convention (every workflow has a paired validator + bats suite + `quality.sh` hook), this PR also adds:

- `scripts/check-markdown-lint-workflow.sh` — validates the workflow's triggers, least-privilege permissions, action pins, and that `markdownlint-cli2` is both installed and invoked.
- `tests/scripts/markdown_lint_workflow.bats` — 11 bats tests exercising the validator with synthetic fixtures.
- A new `quality.sh` step that runs the validator alongside the other workflow gates.
- `actions/setup-node` is now in the Node 24 policy table (`required:4`) so the new workflow does not trip the unknown-action warning.

The optional Deno-based Mermaid validation block from the issue template is omitted — `worker/deno/mod.ts` does not exist in this Rust-only repo, so the conditional block would always skip.

## Evidence

CLI gate (no UI to screenshot):

```text
$ ./scripts/check-markdown-lint-workflow.sh
OK   .../markdown-lint.yml: triggers on pull_request
OK   .../markdown-lint.yml: permissions block grants only contents: read
OK   .../markdown-lint.yml: actions/checkout pinned to a numeric major
OK   .../markdown-lint.yml: actions/setup-node pinned to a numeric major
OK   .../markdown-lint.yml: markdownlint-cli2 install step present
OK   .../markdown-lint.yml: markdownlint-cli2 invoked

$ bats tests/scripts/markdown_lint_workflow.bats
1..11
ok 1 passes on the canonical fixture
ok 2 fails when the workflow is not triggered on pull_request
ok 3 fails when the permissions block is missing
ok 4 fails when actions/checkout is unpinned
ok 5 fails when actions/setup-node is unpinned
ok 6 fails when actions/setup-node step is missing
ok 7 fails when markdownlint-cli2 install step is missing
ok 8 fails when markdownlint-cli2 is not invoked
ok 9 reports an error when the workflow file does not exist
ok 10 unknown flag prints usage and exits non-zero
ok 11 real repository markdown-lint workflow satisfies every rule
```

Full bats suite (`bats tests/scripts/`) — 169 tests pass, none fail.

```mermaid
flowchart LR
    PR[Pull request opened] --> WF[markdown-lint.yml]
    WF --> CO[actions/checkout@v5]
    CO --> SN[actions/setup-node@v4]
    SN --> IN[npm install -g markdownlint-cli2]
    IN --> RUN[markdownlint-cli2]
    RUN --> RES{Lint clean?}
    RES -- yes --> PASS[ Job passes]
    RES -- no --> FAIL[ Job fails — block merge]
```

## Test Plan

- Added `tests/scripts/markdown_lint_workflow.bats` (11 cases) covering the canonical workflow plus targeted failure modes for each rule the validator enforces.
- Verified `scripts/check-workflow-action-versions.sh` still passes after adding `actions/setup-node` to the policy (`bats tests/scripts/workflow_action_versions.bats`).
- Ran the full `tests/scripts/` bats suite — 169 / 169 pass.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-63 -->