### PR TITLE
Remove embedded NEAT-AI-core gitlink (#2201)

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.22"
+version = "0.5.23"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."


### PR DESCRIPTION
## Summary
- Removes the mode-160000 gitlink entry for `NEAT-AI-core` from the index using `git rm --cached -f NEAT-AI-core`.
- Working-tree files are not touched; only the embedded git repository pointer in this repo's index is removed.
- After this merges, every fresh clone of NEAT-AI-scorer will show no mode-160000 entries from `git ls-files --stage`.

## Why
`worker/model_fetch.sh` runs `git reset --hard origin/Develop`, which keeps re-introducing the embedded gitlink from the remote. The downstream `strip_embedded_from_index` then cleans it up locally each iteration but never pushes the cleanup back, so the upstream stays dirty and workers spam `Removing embedded git repository from index: NEAT-AI-core` on every fetch. This one-off cleanup breaks the cycle at the source. See stSoftwareAU/GRQ#2201 and stSoftwareAU/GRQ#2203.

## Verification
```
$ git ls-files --stage | awk '$1 == "160000"'
(no rows)
```

## Test Plan
- [x] `git ls-files --stage | awk '$1 == "160000"'` returns no rows on this branch.
- [ ] After merge, a fresh clone of NEAT-AI-scorer Develop reports no mode-160000 entries.
- [ ] Next worker run (e.g. GRQ-22 sloth) no longer prints `Removing embedded git repository from index: NEAT-AI-core`.

Refs stSoftwareAU/GRQ#2203
Part of stSoftwareAU/GRQ#2201

🤖 Generated with [Claude Code](https://claude.com/claude-code)