### PR TITLE
[security] supply-chain: GitHub Actions pinned to mutable refs across CI workflows (Issue #100)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -44,7 +44,7 @@ jobs:
       # to resolve the workspace. Mirrors the strategy used in ci.yml —
       # see the comment there for the path-strategy rationale.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
         with:
           components: rustfmt
 

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked

--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -45,14 +45,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       # NEAT-AI-core is a path dependency required for `cargo fmt --all`
       # and `cargo clippy` to resolve the workspace. Mirrors the strategy
       # used in ci.yml — see the comment there for the path-strategy
       # rationale.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -66,12 +66,12 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
         with:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
       #     the expected sibling without the workflow having to rewrite
       #     Cargo.toml.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -90,12 +90,12 @@ jobs:
           df -h /
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
         with:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -155,13 +155,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       # NEAT-AI-core checkout path strategy — see note in the `quality` job
       # above. Summary: in-workspace clone + sibling symlink so Cargo resolves
       # the `../../NEAT-AI-core/neat-core` path dependency on the runner.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -174,7 +174,7 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
 
       - name: Check for required files
         run: |
@@ -208,7 +208,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Check bash script syntax
         run: |
@@ -226,7 +226,7 @@ jobs:
       - name: Run ShellCheck (koalaman/shellcheck via ludeeus/action-shellcheck)
         # Pinned to a tagged release (Issue #24) — `@master` is unpinned and
         # a compromised upstream commit would silently alter CI behaviour.
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
         with:
           scandir: "."
           severity: warning
@@ -249,7 +249,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       # Configuration lives in `.codespellrc` at the repo root so CI and the
       # local preflight (`scripts/spell-check.sh`) stay in lock-step — see

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -32,7 +32,7 @@ jobs:
       GITLEAKS_SHA256: "fa0500f6b7e41d28791ebc680f5dd9899cd42b58629218a5f041efa899151a8e"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           # Full history so `origin/<base>..HEAD` resolves on every PR.
           fetch-depth: 0

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,8 +9,11 @@ name: Markdown Lint
 #   * Workflow-sync tooling looks for `markdown-lint.yml` by filename; the
 #     dedicated file keeps the gate discoverable independent of `ci.yml`.
 #
-# Action pinning policy (Issue #24, mirrored by
-# `scripts/check-workflow-action-versions.sh`):
+# Action pinning policy (Issues #24 and #100, mirrored by
+# `scripts/check-workflow-action-versions.sh`): every `uses:` reference
+# is pinned to a 40-character commit SHA with a trailing `# <version>`
+# comment so a re-tagged or compromised upstream cannot silently re-execute
+# under this workflow's privileges.
 #   * actions/checkout — SHA-pinned to v5 (Node 24).
 #   * actions/setup-node — SHA-pinned to v4 (Node 24).
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       # Path strategy for the NEAT-AI-core sibling (Issue #18):
       #   * `actions/checkout` refuses any `path:` that resolves outside
@@ -30,7 +30,7 @@ jobs:
       #     below recreates that layout on the runner so Cargo resolves the
       #     path dependency without rewriting any manifest.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -43,12 +43,12 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
 
       # Official RustSec GitHub Action — wraps cargo-audit and annotates the PR /
       # check run with any RUSTSEC advisories found in Cargo.lock.
       - name: Cargo Security Audit (rustsec/audit-check)
-        uses: rustsec/audit-check@v2
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,6 +62,6 @@ jobs:
 
       - name: Dependency review
         if: ${{ inputs.include-dependency-review && github.event_name == 'pull_request' }}
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -35,7 +35,7 @@ jobs:
       image: semgrep/semgrep:1.86.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Run Semgrep
         run: semgrep ci --config p/default

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Run ShellCheck (koalaman/shellcheck via ludeeus/action-shellcheck)
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
         with:
           scandir: "."
           severity: warning

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: Develop
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
       #     below recreates that layout on the runner so Cargo (and therefore
       #     `cargo upgrade`) resolves the path dependency.
       - name: Checkout NEAT-AI-core (path dependency for neat-core)
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
@@ -57,7 +57,7 @@ jobs:
           fi
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
 
       - name: Install cargo-edit
         run: cargo install cargo-edit
@@ -143,7 +143,7 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Restrict the commit to Cargo manifest/lock files only. The

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -38,7 +38,7 @@ jobs:
       next_version: ${{ steps.check.outputs.next_version }}
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.26"
+version = "0.5.27"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -366,17 +366,35 @@ validated by `scripts/check-dependency-review-workflow.sh` (invoked from
 `quality.sh`) and covered end-to-end by
 `tests/scripts/dependency_review_workflow.bats`.
 
-### GitHub Actions version policy (Node 24 compat)
+### GitHub Actions pinning policy (SHA pinning + Node 24 compat)
 
-GitHub is deprecating the Node 20 runtime for JavaScript actions, so the
-workflow files pin each `uses:` reference to a major that runs on Node 24
-where one exists. The policy — minimum majors, tracked Node 20 exceptions
-(`actions/dependency-review-action@v4`, `rustsec/audit-check@v2` — no Node
-24 release upstream yet), and composite/shell allow-list — is encoded in
-`scripts/check-workflow-action-versions.sh` and validated end-to-end by
-`tests/scripts/workflow_action_versions.bats`. `quality.sh` invokes the
-script so any workflow that adds an unpinned or outdated `uses:` reference
-fails the local gate before CI (Issue #24).
+Every `uses:` reference across the workflow files is pinned to a
+40-character commit SHA, with the human-readable version recorded in a
+trailing comment, e.g.
+
+```yaml
+uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
+uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
+```
+
+The SHA is the supply-chain pin (Issue #100) — it stops a compromised
+maintainer or re-tagged ref from silently re-executing under workflows
+with `contents: write` and `GITHUB_TOKEN` access. The trailing comment
+keeps bumps reviewable: the SHA changes, the version label tells the
+reviewer what the bump is. **Bump protocol:** resolve the new SHA from
+the upstream tag (`gh api repos/<owner>/<repo>/git/ref/tags/vN`), update
+the SHA and the comment in the same PR, and note the changelog highlights
+in the PR description.
+
+The same script also enforces the Node 24 deprecation policy from the
+trailing comment: minimum majors, tracked Node 20 exceptions
+(`actions/dependency-review-action@v4`, `rustsec/audit-check@v2` — no
+Node 24 release upstream yet), and a composite/shell allow-list. The
+policy lives in `scripts/check-workflow-action-versions.sh` and is
+covered end-to-end by `tests/scripts/workflow_action_versions.bats`.
+`quality.sh` invokes the script so any unpinned or outdated `uses:`
+reference fails the local gate before CI (Issues #24 and #100).
 
 ## How to bench
 

--- a/docs/pr-summary-100.md
+++ b/docs/pr-summary-100.md
@@ -1,0 +1,73 @@
+# Pin every GitHub Actions `uses:` to a 40-char SHA (Issue #100)
+
+## Summary
+
+Every `uses:` reference across `.github/workflows/*.yml` is now pinned to
+a 40-character commit SHA with the human-readable version recorded in a
+trailing `# <label>` comment, mirroring the policy already applied in
+`markdown-lint.yml`. This closes the supply-chain hole called out in
+Issue #100: a compromised maintainer or re-tagged ref could previously
+re-execute under workflows with `contents: write`, `pull-requests: write`,
+and `GITHUB_TOKEN` access (auto-format, upgrade-dependencies, security).
+
+The local gate (`scripts/check-workflow-action-versions.sh`, invoked by
+`quality.sh`) now fails any workflow that adds an unpinned `uses:` line
+or a SHA without a version comment, so the policy stays enforced for
+future PRs alongside the existing Node 24 compatibility rules.
+
+Closes #100.
+
+## Evidence
+
+CLI / config change — no UI screenshot. The validator output below covers
+the entire repo's workflow set after the fix:
+
+```
+$ ./scripts/check-workflow-action-versions.sh
+OK   .github/workflows/auto-format.yml:37: actions/checkout@93cb6efe... (v5) (>= v5, SHA-pinned)
+OK   .github/workflows/auto-format.yml:61: dtolnay/rust-toolchain@29eef336... (stable, frozen 2026-05-18) (no Node runtime — SHA-pinned)
+...
+OK   .github/workflows/security.yml:51: rustsec/audit-check@69366f33... (v2.0.0) (Node 20 exception, tracked, SHA-pinned)
+OK   .github/workflows/upgrade-dependencies.yml:146: peter-evans/create-pull-request@5f6978fa... (v8) (>= v8, SHA-pinned)
+```
+
+The supply-chain flow the SHA pin now blocks:
+
+```mermaid
+flowchart LR
+    A[Upstream maintainer compromised] --> B[Re-push tag e.g. @stable, @v8]
+    B --> C{Workflow ref}
+    C -- "@v5 / @stable (before)" --> D[Resolves to malicious SHA]
+    C -- "@<40-char-SHA> (after)" --> E[Resolves to reviewed commit]
+    D --> F[Malicious code runs under contents:write + GITHUB_TOKEN]
+    E --> G[Same reviewed code as last bump]
+```
+
+Bump protocol added to README.md (`### GitHub Actions pinning policy`):
+resolve the upstream tag → SHA with `gh api repos/<owner>/<repo>/git/ref/tags/vN`,
+update SHA + comment in the same PR, record changelog highlights in the
+PR description.
+
+## Test Plan
+
+Behavioural tests added/updated in
+`tests/scripts/workflow_action_versions.bats` (15 cases, all passing):
+
+- `passes on a SHA-pinned workflow that satisfies every policy rule` —
+  happy path with every policy class (`required`, `node20`, `no-node`).
+- `fails when an action is pinned to a version tag instead of a SHA` —
+  regression test for Issue #100 (`@v5` without SHA must FAIL).
+- `fails when an action is pinned to a branch ref instead of a SHA` —
+  regression test for the `@stable` / `@master` case explicitly called
+  out in the issue.
+- `fails when a SHA-pinned action has no trailing version comment` —
+  guards the reviewability half of the pin policy.
+- Existing Node 24 cases (older major, Node 20 exception bumped to
+  unknown major, unknown action warn, comment-line ignore, reusable
+  workflow ignore) re-expressed against the SHA-pinned fixtures.
+- `real repository workflows satisfy the Node 24 compat policy` — runs
+  the validator against the live `.github/workflows/` tree and now
+  passes.
+
+Full local gate: `./quality.sh < /dev/null` exits 0 with all 188 BATS
+cases passing and the Rust test suite green.

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -1,26 +1,42 @@
 #!/usr/bin/env bash
-# Validate GitHub Actions versions used across workflows for Node 24
-# compatibility (Issue #24).
+# Validate GitHub Actions across workflows for SHA pinning (Issue #100) and
+# Node 24 compatibility (Issue #24).
 #
 # Why this exists:
-#   * GitHub has begun deprecating the Node 20 runtime for custom actions. Any
-#     action pinned to a major version that still runs on Node 20 emits a
-#     deprecation warning on every run and will eventually stop working on
-#     hosted runners.
+#   * Supply-chain defence (Issue #100). A `uses: foo/bar@v1` line resolves
+#     to whatever commit the tag currently points at; a compromised maintainer
+#     can re-push the tag to a malicious SHA and silently re-execute under
+#     this repo's workflow privileges (`contents: write`, `GITHUB_TOKEN`).
+#     Pinning every `uses:` to a 40-character commit SHA freezes the action
+#     to a specific reviewed commit. Bumps then become explicit, reviewable
+#     changes in PRs.
+#   * Node 24 deprecation (Issue #24). Any action whose latest major still
+#     runs on Node 20 emits a deprecation warning on every CI run and will
+#     eventually stop working on hosted runners. We track this via the
+#     trailing version comment, not the SHA itself.
 #   * A hand-rolled check is lighter than dependabot-for-actions and keeps
 #     policy co-located with the rest of our CI helpers. It also lets us
 #     record explicit, auditable *exceptions* (upstream actions that have no
 #     Node 24 release yet).
 #
-# Policy encoded below (in `lookup_policy`):
-#   * `required:<N>` — action MUST be pinned to at least major version N. If
-#     a workflow references an older major (or a non-numeric ref like
-#     `master`/`main`), the script fails.
+# Required form: every `uses:` line MUST look like
+#
+#     uses: owner/repo@<40-char-hex-sha>  # <version-or-ref label>
+#
+# The 40-char SHA is the supply-chain pin. The trailing `# <label>` records
+# the human-readable upstream version (e.g. `v5`, `v8.1.0`,
+# `stable, frozen 2026-05-18`) so reviewers can spot drift at a glance and
+# bumps stay auditable. The label is also what the Node 24 policy below
+# validates against.
+#
+# Policy encoded below (in `lookup_policy`), keyed on the label:
+#   * `required:<N>` — action MUST track at least major version N. The label
+#     must start with `v<M>` where M >= N (or be `vM.x.y` etc.).
 #   * `node20:<N>` — action's latest stable major still uses Node 20. The
-#     workflow must stay on exactly major N until upstream ships a Node 24
-#     release. Each exception is documented inline.
+#     label must be exactly `v<N>` (or `v<N>.x.y`) until upstream ships a
+#     Node 24 release. Each exception is documented inline.
 #   * `no-node` — composite/shell action that does not ship a Node runtime.
-#     Allowed to use non-semver refs (e.g. `@stable`).
+#     Any descriptive label is permitted (e.g. `stable, frozen YYYY-MM-DD`).
 #   * (no match) — unknown action, warn but do not fail. New actions should
 #     be added to the policy explicitly so they get audited.
 #
@@ -39,8 +55,8 @@ Options:
                     .github/workflows relative to the repo root).
   -h, --help        Show this message.
 
-Exits 0 when every `uses:` reference satisfies the Node 24 compatibility
-policy. Exits non-zero with a descriptive message otherwise.
+Exits 0 when every `uses:` reference is SHA-pinned and satisfies the Node 24
+compatibility policy. Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
@@ -101,7 +117,10 @@ lookup_policy() {
 }
 
 # Scan a single workflow file and emit tab-separated records:
-#   <file>\t<line>\t<action>\t<ref>
+#   <file>\t<line>\t<action>\t<ref>\t<comment>
+# `<comment>` is the trailing `# ...` text (empty when absent). The
+# comment is where reviewers — and this script — read the human-readable
+# version label that backs the SHA pin.
 scan_workflow() {
   local file="$1"
   python3 - "$file" <<'PY'
@@ -109,37 +128,38 @@ import re
 import sys
 
 path = sys.argv[1]
-pattern = re.compile(r"^\s*(?:-\s*)?uses:\s*([^@\s]+)@([^\s#]+)")
+pattern = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*([^@\s]+)@(\S+?)(?:\s+#\s*(.*?))?\s*$"
+)
 with open(path, "r", encoding="utf-8") as fh:
     for lineno, raw in enumerate(fh, start=1):
         # Skip comment lines so policy examples in comments do not trigger.
         stripped = raw.lstrip()
         if stripped.startswith("#"):
             continue
-        match = pattern.match(raw)
+        match = pattern.match(raw.rstrip("\n"))
         if not match:
             continue
-        action, ref = match.group(1), match.group(2)
+        action, ref, comment = match.group(1), match.group(2), (match.group(3) or "")
         # Reusable workflow calls like `./.github/workflows/security.yml`
         # do not carry a version; skip them.
         if action.startswith("./"):
             continue
-        print(f"{path}\t{lineno}\t{action}\t{ref}")
+        print(f"{path}\t{lineno}\t{action}\t{ref}\t{comment}")
 PY
 }
 
-# Parse the major version from a ref like "v5", "v5.0.1", "5", or "master".
-# Sets MAJOR to the parsed integer, or empty when the ref has no numeric
-# major component (branch ref).
-parse_major() {
-  local ref="$1"
-  MAJOR=""
-  local trimmed="${ref#v}"
-  local digits="${trimmed%%[^0-9]*}"
-  if [[ -n "$digits" ]]; then
-    MAJOR="$digits"
+# Extract a vN-style major from a label like "v5", "v5.0.1", or
+# "v8.x.y". Returns empty when the label does not start with `v<digits>`.
+parse_label_major() {
+  local label="$1"
+  LABEL_MAJOR=""
+  if [[ "$label" =~ ^v([0-9]+) ]]; then
+    LABEL_MAJOR="${BASH_REMATCH[1]}"
   fi
 }
+
+SHA_RE='^[0-9a-f]{40}$'
 
 EXIT_CODE=0
 FOUND_ANY=0
@@ -151,40 +171,55 @@ while IFS= read -r workflow; do
   findings="$(scan_workflow "$workflow")"
   [[ -z "$findings" ]] && continue
 
-  while IFS=$'\t' read -r file lineno action ref; do
+  while IFS=$'\t' read -r file lineno action ref comment; do
     [[ -z "${action:-}" ]] && continue
 
     policy="$(lookup_policy "$action")"
-    parse_major "$ref"
-    major="$MAJOR"
+
+    # Supply-chain gate: every `uses:` must be SHA-pinned (Issue #100).
+    if ! [[ "$ref" =~ $SHA_RE ]]; then
+      echo "FAIL $file:$lineno: $action@$ref — not SHA-pinned; pin to a 40-character commit SHA with a trailing '# <version>' comment (Issue #100)." >&2
+      EXIT_CODE=1
+      continue
+    fi
+
+    # SHA-pinned: validate the trailing comment against the Node 24 policy.
+    if [[ -z "$comment" ]]; then
+      echo "FAIL $file:$lineno: $action@$ref — SHA-pinned but missing trailing '# <version>' comment; required for reviewability (Issue #100)." >&2
+      EXIT_CODE=1
+      continue
+    fi
+
+    parse_label_major "$comment"
+    major="$LABEL_MAJOR"
 
     case "$policy" in
       required:*)
         want="${policy#required:}"
         if [[ -z "$major" ]]; then
-          echo "FAIL $file:$lineno: $action@$ref — branch ref disallowed; pin to v$want or newer (Node 24 compat)." >&2
+          echo "FAIL $file:$lineno: $action@$ref ($comment) — version comment must start with v$want or newer (Node 24 compat)." >&2
           EXIT_CODE=1
         elif (( major < want )); then
-          echo "FAIL $file:$lineno: $action@$ref — requires @v$want or newer (Node 24 compat)." >&2
+          echo "FAIL $file:$lineno: $action@$ref ($comment) — requires v$want or newer (Node 24 compat)." >&2
           EXIT_CODE=1
         else
-          echo "OK   $file:$lineno: $action@$ref (>= v$want)"
+          echo "OK   $file:$lineno: $action@$ref ($comment) (>= v$want, SHA-pinned)"
         fi
         ;;
       node20:*)
         want="${policy#node20:}"
         if [[ -z "$major" || "$major" != "$want" ]]; then
-          echo "FAIL $file:$lineno: $action@$ref — tracked Node 20 exception must stay on @v$want until upstream ships a Node 24 release." >&2
+          echo "FAIL $file:$lineno: $action@$ref ($comment) — tracked Node 20 exception must stay on v$want until upstream ships a Node 24 release." >&2
           EXIT_CODE=1
         else
-          echo "OK   $file:$lineno: $action@$ref (Node 20 exception, tracked)"
+          echo "OK   $file:$lineno: $action@$ref ($comment) (Node 20 exception, tracked, SHA-pinned)"
         fi
         ;;
       no-node)
-        echo "OK   $file:$lineno: $action@$ref (no Node runtime — policy not applicable)"
+        echo "OK   $file:$lineno: $action@$ref ($comment) (no Node runtime — SHA-pinned)"
         ;;
       "")
-        echo "WARN $file:$lineno: $action@$ref — not in policy tables; review and add to check-workflow-action-versions.sh."
+        echo "WARN $file:$lineno: $action@$ref ($comment) — not in policy tables; review and add to check-workflow-action-versions.sh."
         ;;
     esac
   done <<< "$findings"

--- a/tests/scripts/workflow_action_versions.bats
+++ b/tests/scripts/workflow_action_versions.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# Tests for scripts/check-workflow-action-versions.sh — Issue #24.
+# Tests for scripts/check-workflow-action-versions.sh — Issues #24 and #100.
 #
 # Drives the validator with synthetic workflow YAML in a temp directory so
 # policy behaviour (exit codes, reported failures) is verified end-to-end
@@ -17,12 +17,50 @@ teardown() {
   rm -rf "$TMP_WF"
 }
 
-# A minimal compliant workflow — every action referenced satisfies the
-# current policy. Individual failure tests rewrite a single line to break
-# exactly one rule at a time.
+# Forty-character placeholder SHAs used by the synthetic fixtures below.
+# The validator only checks the SHA shape (40 lowercase hex chars), so any
+# distinct hex string is acceptable for the unit tests.
+SHA_CHECKOUT="1111111111111111111111111111111111111111"
+SHA_CACHE="2222222222222222222222222222222222222222"
+SHA_TOOLCHAIN="3333333333333333333333333333333333333333"
+SHA_SHELLCHECK="4444444444444444444444444444444444444444"
+SHA_PR="5555555555555555555555555555555555555555"
+SHA_DEPREV="6666666666666666666666666666666666666666"
+SHA_AUDIT="7777777777777777777777777777777777777777"
+
+# A minimal compliant workflow — every action SHA-pinned with the version
+# label in the trailing comment. Individual failure tests rewrite a single
+# line to break exactly one rule at a time.
 write_compliant_workflow() {
   local file="$1"
-  cat >"$file" <<'EOF'
+  cat >"$file" <<EOF
+name: Example
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${SHA_CHECKOUT}  # v5
+      - uses: actions/cache@${SHA_CACHE}  # v5
+      - uses: dtolnay/rust-toolchain@${SHA_TOOLCHAIN}  # stable, frozen 2026-05-18
+      - uses: ludeeus/action-shellcheck@${SHA_SHELLCHECK}  # v2.0.0
+      - uses: peter-evans/create-pull-request@${SHA_PR}  # v8
+      - uses: actions/dependency-review-action@${SHA_DEPREV}  # v4.9.0
+      - uses: rustsec/audit-check@${SHA_AUDIT}  # v2.0.0
+EOF
+}
+
+@test "passes on a SHA-pinned workflow that satisfies every policy rule" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"actions/checkout@${SHA_CHECKOUT}"* ]]
+  [[ "$output" == *"SHA-pinned"* ]]
+  [[ "$output" == *"Node 20 exception, tracked"* ]]
+}
+
+@test "fails when an action is pinned to a version tag instead of a SHA" {
+  cat >"$TMP_WF/example.yml" <<'EOF'
 name: Example
 on: [push]
 jobs:
@@ -30,105 +68,110 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/cache@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: ludeeus/action-shellcheck@2.0.0
-      - uses: peter-evans/create-pull-request@v8
-      - uses: actions/dependency-review-action@v4
-      - uses: rustsec/audit-check@v2
 EOF
-}
-
-@test "passes on a workflow that satisfies every policy rule" {
-  write_compliant_workflow "$TMP_WF/example.yml"
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"actions/checkout@v5"* ]]
-  [[ "$output" == *"actions/cache@v5"* ]]
-  [[ "$output" == *"peter-evans/create-pull-request@v8"* ]]
-  [[ "$output" == *"ludeeus/action-shellcheck@2.0.0"* ]]
-  [[ "$output" == *"Node 20 exception, tracked"* ]]
+  [[ "$output" == *"not SHA-pinned"* ]]
 }
 
-@test "fails when actions/checkout is older than v5" {
-  write_compliant_workflow "$TMP_WF/example.yml"
-  sed -i.bak 's|actions/checkout@v5|actions/checkout@v4|' "$TMP_WF/example.yml"
+@test "fails when an action is pinned to a branch ref instead of a SHA" {
+  cat >"$TMP_WF/example.yml" <<'EOF'
+name: Example
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+EOF
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"actions/checkout@v4"* ]]
-  [[ "$output" == *"requires @v5 or newer"* ]]
+  [[ "$output" == *"dtolnay/rust-toolchain@stable"* ]]
+  [[ "$output" == *"not SHA-pinned"* ]]
 }
 
-@test "fails when actions/cache is older than v5" {
-  write_compliant_workflow "$TMP_WF/example.yml"
-  sed -i.bak 's|actions/cache@v5|actions/cache@v4|' "$TMP_WF/example.yml"
+@test "fails when a SHA-pinned action has no trailing version comment" {
+  cat >"$TMP_WF/example.yml" <<EOF
+name: Example
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${SHA_CHECKOUT}
+EOF
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"actions/cache@v4"* ]]
-  [[ "$output" == *"requires @v5 or newer"* ]]
+  [[ "$output" == *"missing trailing"* ]]
 }
 
-@test "fails when peter-evans/create-pull-request is older than v8" {
+@test "fails when actions/checkout version comment is older than v5" {
   write_compliant_workflow "$TMP_WF/example.yml"
-  sed -i.bak 's|peter-evans/create-pull-request@v8|peter-evans/create-pull-request@v7|' "$TMP_WF/example.yml"
+  sed -i.bak "s|actions/checkout@${SHA_CHECKOUT}  # v5|actions/checkout@${SHA_CHECKOUT}  # v4|" "$TMP_WF/example.yml"
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"peter-evans/create-pull-request@v7"* ]]
-  [[ "$output" == *"requires @v8 or newer"* ]]
+  [[ "$output" == *"requires v5 or newer"* ]]
 }
 
-@test "fails when ludeeus/action-shellcheck uses a branch ref" {
+@test "fails when actions/cache version comment is older than v5" {
   write_compliant_workflow "$TMP_WF/example.yml"
-  sed -i.bak 's|ludeeus/action-shellcheck@2.0.0|ludeeus/action-shellcheck@master|' "$TMP_WF/example.yml"
+  sed -i.bak "s|actions/cache@${SHA_CACHE}  # v5|actions/cache@${SHA_CACHE}  # v4|" "$TMP_WF/example.yml"
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"ludeeus/action-shellcheck@master"* ]]
-  [[ "$output" == *"branch ref disallowed"* ]]
+  [[ "$output" == *"requires v5 or newer"* ]]
+}
+
+@test "fails when peter-evans/create-pull-request comment is older than v8" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  sed -i.bak "s|peter-evans/create-pull-request@${SHA_PR}  # v8|peter-evans/create-pull-request@${SHA_PR}  # v7|" "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires v8 or newer"* ]]
 }
 
 @test "fails when a Node 20 exception is bumped to an unknown major" {
   write_compliant_workflow "$TMP_WF/example.yml"
   # rustsec/audit-check has no v3 yet — enforcing "stay on v2" surfaces the
   # accidental bump so someone can verify the new major before we adopt it.
-  sed -i.bak 's|rustsec/audit-check@v2|rustsec/audit-check@v3|' "$TMP_WF/example.yml"
+  sed -i.bak "s|rustsec/audit-check@${SHA_AUDIT}  # v2.0.0|rustsec/audit-check@${SHA_AUDIT}  # v3.0.0|" "$TMP_WF/example.yml"
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"rustsec/audit-check@v3"* ]]
   [[ "$output" == *"tracked Node 20 exception"* ]]
 }
 
-@test "warns but does not fail on an unknown action" {
-  cat >"$TMP_WF/example.yml" <<'EOF'
+@test "warns but does not fail on an unknown SHA-pinned action" {
+  cat >"$TMP_WF/example.yml" <<EOF
 name: Example
 on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: some-random/action@v1
+      - uses: some-random/action@${SHA_CHECKOUT}  # v1
 EOF
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -eq 0 ]
   [[ "$output" == *"WARN"* ]]
-  [[ "$output" == *"some-random/action@v1"* ]]
+  [[ "$output" == *"some-random/action"* ]]
   [[ "$output" == *"not in policy tables"* ]]
 }
 
 @test "ignores uses lines that live inside YAML comments" {
-  cat >"$TMP_WF/example.yml" <<'EOF'
+  cat >"$TMP_WF/example.yml" <<EOF
 name: Example
 on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      # Historical note: we used to rely on `uses: actions/checkout@v4`.
-      - uses: actions/checkout@v5
+      # Historical note: we used to rely on \`uses: actions/checkout@v4\`.
+      - uses: actions/checkout@${SHA_CHECKOUT}  # v5
 EOF
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -eq 0 ]
   [[ "$output" != *"actions/checkout@v4"* ]]
-  [[ "$output" == *"actions/checkout@v5"* ]]
+  [[ "$output" == *"actions/checkout@${SHA_CHECKOUT}"* ]]
 }
 
 @test "ignores reusable-workflow calls (./.github/workflows/*.yml)" {


### PR DESCRIPTION
# Pin every GitHub Actions `uses:` to a 40-char SHA (Issue #100)

## Summary

Every `uses:` reference across `.github/workflows/*.yml` is now pinned to
a 40-character commit SHA with the human-readable version recorded in a
trailing `# <label>` comment, mirroring the policy already applied in
`markdown-lint.yml`. This closes the supply-chain hole called out in
Issue #100: a compromised maintainer or re-tagged ref could previously
re-execute under workflows with `contents: write`, `pull-requests: write`,
and `GITHUB_TOKEN` access (auto-format, upgrade-dependencies, security).

The local gate (`scripts/check-workflow-action-versions.sh`, invoked by
`quality.sh`) now fails any workflow that adds an unpinned `uses:` line
or a SHA without a version comment, so the policy stays enforced for
future PRs alongside the existing Node 24 compatibility rules.

Closes #100.

## Evidence

CLI / config change — no UI screenshot. The validator output below covers
the entire repo's workflow set after the fix:

```text
$ ./scripts/check-workflow-action-versions.sh
OK   .github/workflows/auto-format.yml:37: actions/checkout@93cb6efe... (v5) (>= v5, SHA-pinned)
OK   .github/workflows/auto-format.yml:61: dtolnay/rust-toolchain@29eef336... (stable, frozen 2026-05-18) (no Node runtime — SHA-pinned)
...
OK   .github/workflows/security.yml:51: rustsec/audit-check@69366f33... (v2.0.0) (Node 20 exception, tracked, SHA-pinned)
OK   .github/workflows/upgrade-dependencies.yml:146: peter-evans/create-pull-request@5f6978fa... (v8) (>= v8, SHA-pinned)
```

The supply-chain flow the SHA pin now blocks:

```mermaid
flowchart LR
    A[Upstream maintainer compromised] --> B[Re-push tag e.g. @stable, @v8]
    B --> C{Workflow ref}
    C -- "@v5 / @stable (before)" --> D[Resolves to malicious SHA]
    C -- "@<40-char-SHA> (after)" --> E[Resolves to reviewed commit]
    D --> F[Malicious code runs under contents:write + GITHUB_TOKEN]
    E --> G[Same reviewed code as last bump]
```

Bump protocol added to README.md (`### GitHub Actions pinning policy`):
resolve the upstream tag → SHA with `gh api repos/<owner>/<repo>/git/ref/tags/vN`,
update SHA + comment in the same PR, record changelog highlights in the
PR description.

## Test Plan

Behavioural tests added/updated in
`tests/scripts/workflow_action_versions.bats` (15 cases, all passing):

- `passes on a SHA-pinned workflow that satisfies every policy rule` —
  happy path with every policy class (`required`, `node20`, `no-node`).
- `fails when an action is pinned to a version tag instead of a SHA` —
  regression test for Issue #100 (`@v5` without SHA must FAIL).
- `fails when an action is pinned to a branch ref instead of a SHA` —
  regression test for the `@stable` / `@master` case explicitly called
  out in the issue.
- `fails when a SHA-pinned action has no trailing version comment` —
  guards the reviewability half of the pin policy.
- Existing Node 24 cases (older major, Node 20 exception bumped to
  unknown major, unknown action warn, comment-line ignore, reusable
  workflow ignore) re-expressed against the SHA-pinned fixtures.
- `real repository workflows satisfy the Node 24 compat policy` — runs
  the validator against the live `.github/workflows/` tree and now
  passes.

Full local gate: `./quality.sh < /dev/null` exits 0 with all 188 BATS
cases passing and the Rust test suite green.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-100 -->