### PR TITLE
[security] supply-chain: Semgrep container pinned by tag rather than digest (Issue #102)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,14 +10,21 @@ name: Semgrep
 #   container path simply runs the CLI directly inside the pinned image
 #   instead of through the action wrapper.
 #
-# Why pin the container tag?
-#   * Reproducibility — a given PR always runs the same scanner version,
+# Why pin the container by digest?
+#   * Reproducibility — a given PR always runs the same scanner build,
 #     so rule updates never silently change PR-gating behaviour.
+#   * Supply-chain hygiene — Docker tags are mutable (an attacker who
+#     compromises the `semgrep/semgrep` namespace could re-push the tag
+#     to point at a malicious image). The `sha256:` digest is immutable
+#     and prevents that silent substitution (Issue #102).
 #   * Transparency — bumping Semgrep is an explicit, reviewable change to
-#     the `image:` tag below.
+#     both the digest and the trailing version-label comment below.
 #
-# Bump protocol: lift the tag and record the upstream changelog highlights
-# in the PR that does the bump.
+# Bump protocol: look up the upstream digest for the new release
+# (`docker buildx imagetools inspect semgrep/semgrep:<version>` or the
+# Docker Hub tag page), update the digest AND the version-label comment
+# in lockstep, and record the upstream changelog highlights in the PR
+# that does the bump.
 
 on:
   pull_request:
@@ -32,7 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Pinned Semgrep release. Equivalent to `uses: semgrep/semgrep-action@v1`.
-      image: semgrep/semgrep:1.86.0
+      # Digest pin: semgrep/semgrep v1.86.0 multi-arch manifest, frozen
+      # 2026-05-18. Docker tags are mutable; the sha256 digest is not
+      # (Issue #102).
+      image: semgrep/semgrep@sha256:a9ea2d5621c29d815d90c2a3b2f9571da8972ef4ff855c9e4902681730240e35
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5

--- a/docs/pr-summary-102.md
+++ b/docs/pr-summary-102.md
@@ -1,0 +1,62 @@
+# PR Summary — Issue #102
+
+## Summary
+
+Pinned the Semgrep SAST scanner container by immutable `sha256` digest
+instead of the mutable `1.86.0` Docker tag, eliminating the silent
+tag-repush attack vector flagged in the issue. The validator
+(`scripts/check-semgrep-workflow.sh`) is updated to enforce the new
+digest-only rule so any future regression to a tag pin fails CI, and
+the workflow header now documents the digest-bump protocol alongside
+the existing version-label conventions. Closes #102.
+
+## Evidence
+
+This is a CLI/workflow change with no UI surface, so the evidence is
+the test results and the resulting workflow YAML.
+
+* `bats tests/scripts/semgrep_workflow.bats` — 16/16 tests pass,
+  including two new cases (`fails when the container image is pinned
+  to a mutable tag (issue #102)` and `fails when the container image
+  digest is malformed`) plus the existing `real repository semgrep
+  workflow satisfies every rule` end-to-end gate.
+* `./quality.sh` — full local gate passes (shellcheck, all workflow
+  validators, every bats suite, cargo-deny, fmt, clippy, check, build,
+  test, doc, release).
+
+The new policy enforced by the validator:
+
+```mermaid
+flowchart LR
+    A["image: semgrep/semgrep<br/>(bare)"] --> X[FAIL: not pinned by digest]
+    B["image: semgrep/semgrep:latest"] --> X
+    C["image: semgrep/semgrep:1.86.0<br/>(mutable tag)"] --> X
+    D["image: semgrep/semgrep@sha256:&lt;64-hex&gt;"] --> Y[PASS]
+    E["image: semgrep/semgrep@sha256:short"] --> X
+```
+
+Pinned digest (multi-arch manifest, frozen 2026-05-18, looked up via
+Docker Hub for the v1.86.0 tag):
+
+```yaml
+image: semgrep/semgrep@sha256:a9ea2d5621c29d815d90c2a3b2f9571da8972ef4ff855c9e4902681730240e35
+```
+
+## Test Plan
+
+* Updated `tests/scripts/semgrep_workflow.bats`:
+  * `write_container_workflow` fixture now emits a digest-pinned image
+    so positive cases reflect the new policy.
+  * `passes on the container fixture` now asserts on the
+    "pinned by digest" OK message.
+  * `fails when the container image is unpinned (no tag)` →
+    renamed to "no digest" with the same intent.
+  * Added `fails when the container image is pinned to a mutable tag
+    (issue #102)` — drives the rule introduced by this PR.
+  * Added `fails when the container image digest is malformed` —
+    guards against an invalid hex digest sneaking past the regex.
+  * `:latest` and "no semgrep entry point" cases continue to fail
+    as before (untouched intent).
+* `real repository semgrep workflow satisfies every rule` exercises
+  the actual shipped `.github/workflows/semgrep.yml` against the
+  updated validator.

--- a/scripts/check-semgrep-workflow.sh
+++ b/scripts/check-semgrep-workflow.sh
@@ -2,9 +2,11 @@
 # Validate the Semgrep SAST scanning workflow (Issue #47).
 #
 # Two configurations are accepted as functionally equivalent:
-#   1. The official container approach — `container: image: semgrep/semgrep:<tag>`
+#   1. The official container approach — `container: image: semgrep/semgrep@sha256:<digest>`
 #      with an explicit `semgrep ci|scan --config <ruleset>` invocation. This
-#      is upstream's recommended PR-scan path.
+#      is upstream's recommended PR-scan path. Pin by digest, not tag —
+#      Docker tags are mutable; only the `sha256:<64-hex>` digest is immutable
+#      (Issue #102).
 #   2. The `semgrep/semgrep-action@vN` GitHub Action — pinned to a numeric
 #      major version so behaviour is reproducible.
 #
@@ -14,8 +16,9 @@
 #   * Pass `SEMGREP_APP_TOKEN` from repo secrets so findings can be posted
 #     to the Semgrep app dashboard. The token is consumed by both the
 #     container CLI (`semgrep ci`) and `semgrep/semgrep-action`.
-#   * Pin the entry point. Container tags must NOT be bare (`semgrep/semgrep`)
-#     or `:latest`; the action ref must NOT be `master`/`main`.
+#   * Pin the entry point. Container images MUST use a `@sha256:<64-hex>`
+#     digest; bare names, `:latest`, and version tags are all rejected.
+#     The action ref must NOT be `master`/`main`.
 #   * Carry a comment block documenting the rationale and why the
 #     container path is equivalent to `semgrep/semgrep-action`.
 #
@@ -98,12 +101,17 @@ container_line="$(grep -nE '^[[:space:]]+image:[[:space:]]*semgrep/semgrep' "$WO
 action_line="$(grep -nE 'uses:[[:space:]]*semgrep/semgrep-action@' "$WORKFLOW" || true)"
 
 if [[ -n "$container_line" ]]; then
-  # Container path. Tag must not be bare or :latest.
-  if echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep:[A-Za-z0-9._-]+' \
+  # Container path. Image MUST be pinned by an immutable sha256 digest —
+  # Docker tags are mutable so `:1.86.0` (or any tag) is not a real pin
+  # (Issue #102). Reject bare names, `:latest`, version tags, and malformed
+  # digests; only `semgrep/semgrep@sha256:<64-lowercase-hex>` passes.
+  if echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep@sha256:[0-9a-f]{64}([[:space:]]|$)'; then
+    ok "Semgrep container image is pinned by digest (semgrep/semgrep@sha256:<digest>)"
+  elif echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep:[A-Za-z0-9._-]+' \
     && ! echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep:latest'; then
-    ok "Semgrep container image is pinned (semgrep/semgrep:<tag>)"
+    fail "Semgrep container image is not pinned by digest — Docker tags are mutable; use semgrep/semgrep@sha256:<64-hex> (Issue #102)"
   else
-    fail "Semgrep container image is not pinned — use semgrep/semgrep:<version>, not bare or :latest"
+    fail "Semgrep container image is not pinned by digest — use semgrep/semgrep@sha256:<64-hex>, not bare or :latest"
   fi
 elif [[ -n "$action_line" ]]; then
   # Action path. Ref must be a vN-style pin (numeric major component).

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -17,16 +17,20 @@ teardown() {
   rm -rf "$TMP_WF"
 }
 
+# Placeholder digest used by the synthetic fixtures below. The validator only
+# checks the digest shape (sha256:<64-hex>), so any 64-hex string is fine.
+FIXTURE_DIGEST="sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
 # Canonical hardened workflow using the container path. Failure tests mutate
 # this fixture to drop or break one rule at a time.
 write_container_workflow() {
   local file="$1"
-  cat >"$file" <<'EOF'
+  cat >"$file" <<EOF
 name: Semgrep
 
 # Semgrep SAST scanning. We use the official semgrep/semgrep container as
 # the equivalent of the semgrep/semgrep-action GitHub Action — both consume
-# SEMGREP_APP_TOKEN and run `semgrep ci`. The container path is upstream's
+# SEMGREP_APP_TOKEN and run \`semgrep ci\`. The container path is upstream's
 # recommended PR-scan integration.
 
 on:
@@ -41,7 +45,8 @@ jobs:
     name: Semgrep SAST Scanning
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.86.0
+      # Semgrep v1.86.0, frozen 2026-05-18.
+      image: semgrep/semgrep@${FIXTURE_DIGEST}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -49,7 +54,7 @@ jobs:
       - name: Run Semgrep
         run: semgrep ci --config p/default
         env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_APP_TOKEN: \${{ secrets.SEMGREP_APP_TOKEN }}
 EOF
 }
 
@@ -86,7 +91,7 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"triggers on pull_request"* ]]
   [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"Semgrep container image is pinned"* ]]
+  [[ "$output" == *"Semgrep container image is pinned by digest"* ]]
   [[ "$output" == *"semgrep CLI invocation present"* ]]
   [[ "$output" == *"explicit --config"* ]]
   [[ "$output" == *"SEMGREP_APP_TOKEN sourced from secrets"* ]]
@@ -134,9 +139,9 @@ PY
   [[ "$output" == *"no 'permissions: contents: read'"* ]]
 }
 
-@test "fails when the container image is unpinned (no tag)" {
+@test "fails when the container image is unpinned (no digest)" {
   write_container_workflow "$TMP_WF/semgrep.yml"
-  sed -i.bak 's|semgrep/semgrep:1.86.0|semgrep/semgrep|' "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep@${FIXTURE_DIGEST}|semgrep/semgrep|" "$TMP_WF/semgrep.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"container image is not pinned"* ]]
@@ -144,10 +149,26 @@ PY
 
 @test "fails when the container image is pinned to :latest" {
   write_container_workflow "$TMP_WF/semgrep.yml"
-  sed -i.bak 's|semgrep/semgrep:1.86.0|semgrep/semgrep:latest|' "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep@${FIXTURE_DIGEST}|semgrep/semgrep:latest|" "$TMP_WF/semgrep.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"container image is not pinned"* ]]
+}
+
+@test "fails when the container image is pinned to a mutable tag (issue #102)" {
+  write_container_workflow "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep@${FIXTURE_DIGEST}|semgrep/semgrep:1.86.0|" "$TMP_WF/semgrep.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"container image is not pinned by digest"* ]]
+}
+
+@test "fails when the container image digest is malformed" {
+  write_container_workflow "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|@${FIXTURE_DIGEST}|@sha256:notavalidhex|" "$TMP_WF/semgrep.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"container image is not pinned by digest"* ]]
 }
 
 @test "fails when no semgrep entry point is present" {


### PR DESCRIPTION
# PR Summary — Issue #102

## Summary

Pinned the Semgrep SAST scanner container by immutable `sha256` digest
instead of the mutable `1.86.0` Docker tag, eliminating the silent
tag-repush attack vector flagged in the issue. The validator
(`scripts/check-semgrep-workflow.sh`) is updated to enforce the new
digest-only rule so any future regression to a tag pin fails CI, and
the workflow header now documents the digest-bump protocol alongside
the existing version-label conventions. Closes #102.

## Evidence

This is a CLI/workflow change with no UI surface, so the evidence is
the test results and the resulting workflow YAML.

* `bats tests/scripts/semgrep_workflow.bats` — 16/16 tests pass,
  including two new cases (`fails when the container image is pinned
  to a mutable tag (issue #102)` and `fails when the container image
  digest is malformed`) plus the existing `real repository semgrep
  workflow satisfies every rule` end-to-end gate.
* `./quality.sh` — full local gate passes (shellcheck, all workflow
  validators, every bats suite, cargo-deny, fmt, clippy, check, build,
  test, doc, release).

The new policy enforced by the validator:

```mermaid
flowchart LR
    A["image: semgrep/semgrep<br/>(bare)"] --> X[FAIL: not pinned by digest]
    B["image: semgrep/semgrep:latest"] --> X
    C["image: semgrep/semgrep:1.86.0<br/>(mutable tag)"] --> X
    D["image: semgrep/semgrep@sha256:&lt;64-hex&gt;"] --> Y[PASS]
    E["image: semgrep/semgrep@sha256:short"] --> X
```

Pinned digest (multi-arch manifest, frozen 2026-05-18, looked up via
Docker Hub for the v1.86.0 tag):

```yaml
image: semgrep/semgrep@sha256:a9ea2d5621c29d815d90c2a3b2f9571da8972ef4ff855c9e4902681730240e35
```

## Test Plan

* Updated `tests/scripts/semgrep_workflow.bats`:
  * `write_container_workflow` fixture now emits a digest-pinned image
    so positive cases reflect the new policy.
  * `passes on the container fixture` now asserts on the
    "pinned by digest" OK message.
  * `fails when the container image is unpinned (no tag)` →
    renamed to "no digest" with the same intent.
  * Added `fails when the container image is pinned to a mutable tag
    (issue #102)` — drives the rule introduced by this PR.
  * Added `fails when the container image digest is malformed` —
    guards against an invalid hex digest sneaking past the regex.
  * `:latest` and "no semgrep entry point" cases continue to fail
    as before (untouched intent).
* `real repository semgrep workflow satisfies every rule` exercises
  the actual shipped `.github/workflows/semgrep.yml` against the
  updated validator.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-102 -->