### PR TITLE
[security] memory-safety: unsafe unpack_f32s_le guarded only by debug_assert_eq! (Issue #103)

### DIFF
--- a/docs/pr-summary-103.md
+++ b/docs/pr-summary-103.md
@@ -1,0 +1,51 @@
+## Summary
+
+Hardens the two `unpack_f32s_le` helpers in `rust_scorer` so the length
+precondition guarding their `unsafe` raw-pointer loops is enforced in
+**both debug and release** builds. The previous `debug_assert_eq!` was
+compiled out in release, so a malformed `.bin` chunk whose byte length
+was not exactly `n * 4` would have driven an out-of-bounds read inside
+the unsafe block. Replaced with a runtime `assert_eq!` that panics with
+a clear diagnostic before any unsafe pointer arithmetic runs. Closes #103.
+
+## Evidence
+
+This is a backend/CLI safety fix with no web interface — evidence is the
+test suite. Three new unit tests per file (six total) lock in the
+behaviour:
+
+- `unpack_f32s_le_decodes_exact_length_buffer` — happy path: correct
+  length decodes the expected `f32`s.
+- `unpack_f32s_le_rejects_short_buffer_in_release` — `src.len() < n * 4`
+  triggers a deterministic panic instead of an OOB read.
+- `unpack_f32s_le_rejects_oversize_buffer` — `src.len() > n * 4` is
+  also rejected (the invariant is equality, not just lower-bound).
+
+Both `#[should_panic]` tests assert on the panic message prefix, so they
+verify the new runtime check is what triggers (not some downstream
+allocator fault).
+
+Full `./quality.sh` run passes:
+
+- shellcheck, cargo-deny, `fmt --check`, clippy, check, build, test,
+  rustdoc with `-D warnings`, release build — all green.
+- New tests visible under `multi_score::tests::unpack_f32s_le_*` and
+  `stream_score::tests::unpack_f32s_le_*`.
+
+```mermaid
+flowchart LR
+    A[".bin chunk<br/>len != n*4"] --> B{unpack_f32s_le}
+    B -->|before #103: debug only| C["release: enter unsafe loop<br/>OOB read"]
+    B -->|after #103: always| D["assert_eq! panics<br/>before unsafe block"]
+```
+
+## Test Plan
+
+- Added `unpack_f32s_le_decodes_exact_length_buffer` in
+  `rust_scorer/src/stream_score.rs` and `rust_scorer/src/multi_score.rs`.
+- Added `unpack_f32s_le_rejects_short_buffer_in_release` (both files,
+  `#[should_panic]`) — regression test for #103.
+- Added `unpack_f32s_le_rejects_oversize_buffer` (both files,
+  `#[should_panic]`) — edge case.
+- Verified `./quality.sh < /dev/null` passes end-to-end (60 lib tests,
+  5 directory-mode TDD tests, 3 GPU parity tests, 10 scorer smoke tests).

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -72,8 +72,21 @@ fn reserve_unpack_capacity(buf: &mut Vec<f32>, n: usize) {
     }
 }
 
+/// Decode little-endian `f32` bytes.
+///
+/// # Panics
+/// Panics if `src.len() != n * 4`. This runtime check runs in both debug and
+/// release builds because the `little` branch performs raw pointer arithmetic
+/// that relies on the length invariant — a malformed `.bin` chunk must not be
+/// allowed to drive an out-of-bounds read (Issue #103).
 fn unpack_f32s_le(src: &[u8], dst: &mut Vec<f32>, n: usize) {
-    debug_assert_eq!(src.len(), n * 4);
+    assert_eq!(
+        src.len(),
+        n * 4,
+        "unpack_f32s_le: src.len() ({}) != n * 4 ({})",
+        src.len(),
+        n * 4
+    );
     dst.clear();
     reserve_unpack_capacity(dst, n);
 
@@ -820,6 +833,36 @@ fn run_io_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unpack_f32s_le_decodes_exact_length_buffer() {
+        // Two little-endian f32s: 3.5 and 0.0.
+        let mut src = Vec::new();
+        src.extend_from_slice(&3.5_f32.to_le_bytes());
+        src.extend_from_slice(&0.0_f32.to_le_bytes());
+        let mut dst = Vec::new();
+        unpack_f32s_le(&src, &mut dst, 2);
+        assert_eq!(dst, vec![3.5_f32, 0.0_f32]);
+    }
+
+    #[test]
+    #[should_panic(expected = "unpack_f32s_le: src.len()")]
+    fn unpack_f32s_le_rejects_short_buffer_in_release() {
+        // Length 7 with n=2 means src.len() != n*4 (=8). Must panic in
+        // both debug and release builds (Issue #103) — never enter the
+        // unsafe loop with a short slice.
+        let src = vec![0u8; 7];
+        let mut dst = Vec::new();
+        unpack_f32s_le(&src, &mut dst, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "unpack_f32s_le: src.len()")]
+    fn unpack_f32s_le_rejects_oversize_buffer() {
+        let src = vec![0u8; 9];
+        let mut dst = Vec::new();
+        unpack_f32s_le(&src, &mut dst, 2);
+    }
 
     #[test]
     fn workers_per_creature_one_per_when_population_meets_threads() {

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -95,11 +95,19 @@ fn reserve_unpack_capacity(buf: &mut Vec<f32>, n: usize) {
 /// Decode little-endian `f32` bytes. On little-endian hosts, one unaligned `u32`
 /// load per float; otherwise `from_le_bytes`.
 ///
-/// # Safety (`little` branch)
-/// Caller must ensure `src.len() == n * 4` and `buf` has capacity ≥ `n` before
-/// the unsafe `set_len` / writes.
+/// # Panics
+/// Panics if `src.len() != n * 4`. This check runs in both debug and release
+/// builds because the `little` branch performs raw pointer arithmetic that
+/// relies on the length invariant — a malformed `.bin` chunk must not be
+/// allowed to drive an out-of-bounds read (Issue #103).
 fn unpack_f32s_le(src: &[u8], dst: &mut Vec<f32>, n: usize) {
-    debug_assert_eq!(src.len(), n * 4);
+    assert_eq!(
+        src.len(),
+        n * 4,
+        "unpack_f32s_le: src.len() ({}) != n * 4 ({})",
+        src.len(),
+        n * 4
+    );
     dst.clear();
     reserve_unpack_capacity(dst, n);
 
@@ -366,7 +374,37 @@ pub fn accumulate_mse_sum_forward_only_fused(
 
 #[cfg(test)]
 mod tests {
-    use super::partition_packed_records;
+    use super::{partition_packed_records, unpack_f32s_le};
+
+    #[test]
+    fn unpack_f32s_le_decodes_exact_length_buffer() {
+        // Two little-endian f32s: 1.0 and -2.5.
+        let mut src = Vec::new();
+        src.extend_from_slice(&1.0_f32.to_le_bytes());
+        src.extend_from_slice(&(-2.5_f32).to_le_bytes());
+        let mut dst = Vec::new();
+        unpack_f32s_le(&src, &mut dst, 2);
+        assert_eq!(dst, vec![1.0_f32, -2.5_f32]);
+    }
+
+    #[test]
+    #[should_panic(expected = "unpack_f32s_le: src.len()")]
+    fn unpack_f32s_le_rejects_short_buffer_in_release() {
+        // Length 7 with n=2 means src.len() != n*4 (=8). Must panic in
+        // both debug and release builds (Issue #103) — never enter the
+        // unsafe loop with a short slice.
+        let src = vec![0u8; 7];
+        let mut dst = Vec::new();
+        unpack_f32s_le(&src, &mut dst, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "unpack_f32s_le: src.len()")]
+    fn unpack_f32s_le_rejects_oversize_buffer() {
+        let src = vec![0u8; 9];
+        let mut dst = Vec::new();
+        unpack_f32s_le(&src, &mut dst, 2);
+    }
 
     #[test]
     fn partition_packed_records_covers_all_and_balances() {


### PR DESCRIPTION
## Summary

Hardens the two `unpack_f32s_le` helpers in `rust_scorer` so the length
precondition guarding their `unsafe` raw-pointer loops is enforced in
**both debug and release** builds. The previous `debug_assert_eq!` was
compiled out in release, so a malformed `.bin` chunk whose byte length
was not exactly `n * 4` would have driven an out-of-bounds read inside
the unsafe block. Replaced with a runtime `assert_eq!` that panics with
a clear diagnostic before any unsafe pointer arithmetic runs. Closes #103.

## Evidence

This is a backend/CLI safety fix with no web interface — evidence is the
test suite. Three new unit tests per file (six total) lock in the
behaviour:

- `unpack_f32s_le_decodes_exact_length_buffer` — happy path: correct
  length decodes the expected `f32`s.
- `unpack_f32s_le_rejects_short_buffer_in_release` — `src.len() < n * 4`
  triggers a deterministic panic instead of an OOB read.
- `unpack_f32s_le_rejects_oversize_buffer` — `src.len() > n * 4` is
  also rejected (the invariant is equality, not just lower-bound).

Both `#[should_panic]` tests assert on the panic message prefix, so they
verify the new runtime check is what triggers (not some downstream
allocator fault).

Full `./quality.sh` run passes:

- shellcheck, cargo-deny, `fmt --check`, clippy, check, build, test,
  rustdoc with `-D warnings`, release build — all green.
- New tests visible under `multi_score::tests::unpack_f32s_le_*` and
  `stream_score::tests::unpack_f32s_le_*`.

```mermaid
flowchart LR
    A[".bin chunk<br/>len != n*4"] --> B{unpack_f32s_le}
    B -->|before #103: debug only| C["release: enter unsafe loop<br/>OOB read"]
    B -->|after #103: always| D["assert_eq! panics<br/>before unsafe block"]
```

## Test Plan

- Added `unpack_f32s_le_decodes_exact_length_buffer` in
  `rust_scorer/src/stream_score.rs` and `rust_scorer/src/multi_score.rs`.
- Added `unpack_f32s_le_rejects_short_buffer_in_release` (both files,
  `#[should_panic]`) — regression test for #103.
- Added `unpack_f32s_le_rejects_oversize_buffer` (both files,
  `#[should_panic]`) — edge case.
- Verified `./quality.sh < /dev/null` passes end-to-end (60 lib tests,
  5 directory-mode TDD tests, 3 GPU parity tests, 10 scorer smoke tests).



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-103 -->