### PR TITLE
feat(scorer): add --cost <NAME> CLI flag with hard-error on unknown cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,49 @@ The JSON output adds `gpuKernel: "forward_mse_batched"` plus
 `gpuInflightChunks` and `gpuDispatchCount` diagnostic counters when the
 GPU directory path runs.
 
+### Cost function selector (Issue #120)
+
+The `--cost <NAME>` flag selects which built-in loss function the scorer
+will dispatch when scoring a creature. Names match the TypeScript
+`BUILT_IN_COST_NAMES` strings exactly (see
+[`NEAT-AI/src/Costs.ts`](https://github.com/stSoftwareAU/NEAT-AI/blob/Develop/src/Costs.ts))
+so callers can pass `NeatOptions.costName` through unchanged.
+
+| Value               | Meaning                                |
+|---------------------|----------------------------------------|
+| `MSE` (**default**) | Mean Squared Error                      |
+| `MAE`               | Mean Absolute Error                     |
+| `MAPE`              | Mean Absolute Percentage Error          |
+| `MSLE`              | Mean Squared Logarithmic Error          |
+| `HINGE`             | Hinge loss                              |
+| `CROSS_ENTROPY`     | Cross-entropy                           |
+| `CATEGORICAL_ERROR` | Categorical (top-1 mismatch) error      |
+
+```text
+rust_scorer --cost MSE <creature.json> <training_data_dir>   # default; unchanged behaviour
+rust_scorer --cost MAE <creature.json> <training_data_dir>   # parses; runs MSE pending #119-3
+rust_scorer --cost FOO <creature.json> <training_data_dir>   # exits non-zero — unknown cost
+```
+
+Unknown values are rejected by `clap` with a non-zero exit and a stderr
+message listing the supported set. There is **no** `NEAT_SCORER_COST`
+environment-variable override — KISS, the CLI flag is the only knob.
+
+This change is the foundational plumbing only; **every cost selection
+still computes MSE** until dispatch wiring lands in the follow-up issue
+(`#119-3`). The CLI surface is published now so downstream callers
+(`NEAT-AI` passing `costName` to the binary) can build against a stable
+contract.
+
+```mermaid
+flowchart LR
+    CLI[--cost NAME] --> Parse[clap ValueEnum]
+    Parse --> Valid{Valid name?}
+    Valid -->|yes| CostKind[CostKind enum]
+    Valid -->|no| Err[stderr + exit 2]
+    CostKind --> Scorer[passed to scoring entry points]
+```
+
 ### Stdin input mode
 
 For restricted worker/sandbox environments where writing a temp file may fail
@@ -203,32 +246,31 @@ graph TD
     Explore[NEAT-AI-Explore] -->|reads| Snapshot
 ```
 
-## Why MSE-only?
+## Cost dispatch (Issue #120 + #119-3)
 
-The CLI scores creatures with **mean squared error** only — there is no `--cost` flag
-and no runtime dispatch across loss functions.
+The CLI now accepts a `--cost <NAME>` flag listing every TypeScript
+`BUILT_IN_COST_NAMES` value, but the **scoring calculation itself is still
+MSE** until the dispatch wiring lands in `#119-3`. Until then:
 
 - **Fused fast path is MSE.** The forward-only path calls
   `neat_core::loss::mse_sum_batch_packed` directly so error accumulation stays
   inside the same SIMD-friendly pass that reads packed `[inputs..., targets...]`
   records. The non-fused recurrent path (`forwardOnly: false`) uses
   `neat_core::mse_mean_record` to match the TypeScript `MSE.calculate()` mean.
-- **Scope matches today's callers.** NEAT-AI `Develop` invokes this binary with
-  the fixed positional contract `<creature.json> <data_dir>` (see `AGENTS.md`)
-  and never requests a non-MSE score. `GROWTH_COST` and the fitness formula in
-  `scoring.rs` are defined against MSE.
-- **`neat-core` still exposes the full set.** The sibling crate already ships
-  fused batch variants for MAE, cross-entropy, MAPE, MSLE, and hinge
+- **`neat-core` exposes the full set.** The sibling crate already ships fused
+  batch variants for MAE, cross-entropy, MAPE, MSLE, and hinge
   (`neat_core::loss::{mae,cross_entropy,mape,msle,hinge}_sum_batch_packed`).
-  Re-adding a `--cost` dispatch would be CLI wiring plus tests — no new math —
-  but until a downstream caller needs it, keeping the surface area small wins
-  on KISS grounds and preserves the stable positional CLI contract.
+  `#119-3` wires those into the scorer; this PR (`#120`) is the foundational
+  plumbing only — a stable CLI contract for `NeatOptions.costName`
+  pass-through, validated with `clap::ValueEnum` so unknown costs hard-error
+  with a non-zero exit.
+- **Why split the work.** Landing the CLI surface first lets NEAT-AI roll out
+  the `costName` flag end-to-end (pipe through the binary, exercise the
+  reject-unknown path) without waiting on the dispatch refactor; `#119-3`
+  then becomes a pure-internals change.
 
-If a downstream caller ever needs non-MSE scoring at this boundary, the
-existing fused batch-packed losses in `neat-core` are the drop-in entry points;
-see the in-tree `rust_scorer/` experiment on
-[`milestone/pure-rust-scorer-experiment`](https://github.com/stSoftwareAU/NEAT-AI/blob/milestone/pure-rust-scorer-experiment/rust_scorer/src/cost.rs)
-for the six-way dispatch pattern.
+See the [Cost function selector](#cost-function-selector-issue-120) section
+above for the supported names and CLI surface.
 
 ## CI
 

--- a/docs/archive/pr-summaries/pr-summary-120.md
+++ b/docs/archive/pr-summaries/pr-summary-120.md
@@ -1,0 +1,72 @@
+## Summary
+
+Added a `--cost <NAME>` CLI flag to `rust_scorer` that accepts the seven
+NEAT-AI built-in cost names exactly as they appear in the TypeScript
+`BUILT_IN_COST_NAMES` tuple (`MSE`, `MAE`, `MAPE`, `MSLE`, `HINGE`,
+`CROSS_ENTROPY`, `CATEGORICAL_ERROR`) and hard-errors on anything else via
+`clap::ValueEnum`. The default is `MSE`, which preserves the current
+scoring behaviour byte-for-byte. The resolved `CostKind` is plumbed through
+every scoring entry point (`score_from_json`, `score_from_creature_dir`,
+`score_from_creature_dir_gpu`) as a parameter so the CLI contract is
+stable; **the calculation itself is unchanged** — the MSE path keeps calling
+`mse_sum_batch_packed`. Dispatch wiring lands in the follow-up issue
+(`#119-3`). There is no `NEAT_SCORER_COST` environment-variable override
+(KISS, as the issue brief requires).
+
+Closes #120.
+
+## Evidence
+
+Pure CLI/library change with no UI to screenshot. Verified by:
+
+- 7 new unit tests in `rust_scorer/src/cost.rs` exercising the `CostKind`
+  enum and `from_cli` validation helper (accept every TS name, reject
+  unknown/case-mismatch/empty, default to MSE, clap round-trip).
+- 3 new unit tests in `rust_scorer/src/main.rs` proving the `--cost` flag
+  is parsed by `clap` (every value accepted, default is `MSE`, unknown
+  rejected with a stderr message listing the supported set).
+- 5 new end-to-end smoke tests in `rust_scorer/tests/scorer_smoke.rs`
+  driving the compiled binary against the identity fixture:
+  - `--cost MSE` matches the default scoring output exactly.
+  - `--cost MAE` parses and runs (still computing MSE) — proves the flag
+    is wired without changing the calculation.
+  - Every built-in cost name is accepted by the binary.
+  - `--cost FOO` exits non-zero with a stderr message naming the
+    supported set.
+  - `--help` lists `--cost` and every supported value.
+  - `NEAT_SCORER_COST` env var is ignored (KISS contract).
+- Full `./quality.sh` passes (shellcheck, cargo-deny, fmt, clippy, check,
+  build, all tests, doc with `-D warnings`, release build).
+
+```mermaid
+flowchart LR
+    CLI[--cost NAME] --> Parse[clap ValueEnum]
+    Parse --> Valid{Valid name?}
+    Valid -->|yes| CostKind[CostKind enum]
+    Valid -->|no| Err[stderr + exit 2]
+    CostKind --> Scorer[score_from_json /<br/>score_from_creature_dir /<br/>score_from_creature_dir_gpu]
+```
+
+## Test Plan
+
+- [x] `cargo test -p rust_scorer` — 70+ tests pass, including the new
+  unit tests in `cost.rs` and `main.rs` and the new smoke tests in
+  `tests/scorer_smoke.rs`.
+- [x] `./quality.sh` passes locally on macOS (shellcheck, cargo-deny,
+  fmt, clippy, check, build, test, doc, release).
+- [x] `rust_scorer --help` lists `--cost <NAME>` and the seven supported
+  values.
+- [x] `rust_scorer --cost FOO …` exits non-zero with a stderr message
+  listing the supported set.
+
+Tests added or modified:
+
+- `rust_scorer/src/cost.rs` — new module; 7 unit tests for `CostKind` /
+  `from_cli` validation.
+- `rust_scorer/src/main.rs` — 3 new unit tests for the `--cost` clap
+  surface; existing tests updated to populate the new `cost` field on
+  the `Cli` struct.
+- `rust_scorer/tests/scorer_smoke.rs` — 5 new end-to-end smoke tests
+  covering every acceptance criterion in the issue.
+- `rust_scorer/benches/scoring.rs` — pass `CostKind::default()` to the
+  scoring entry points whose signatures gained the new parameter.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.28"
+version = "0.5.29"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/benches/scoring.rs
+++ b/rust_scorer/benches/scoring.rs
@@ -45,6 +45,7 @@ use neat_core::training_data::{TrainingDataConfig, find_bin_files};
 
 use std::sync::Arc;
 
+use rust_scorer::cost::CostKind;
 use rust_scorer::gpu::{GpuBackendLabel, GpuMode, resolve_backend, select_adapter};
 use rust_scorer::multi_score::{score_from_creature_dir, score_from_creature_dir_gpu};
 use rust_scorer::stream_score::accumulate_mse_sum_forward_only_fused;
@@ -251,9 +252,13 @@ fn bench_score_from_creature_dir(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("creatures", n), &sub_dir, |b, dir| {
             b.iter(|| {
-                let result =
-                    score_from_creature_dir(dir, &fix.data_dir, GpuBackendLabel::CpuFallback)
-                        .expect("multi-creature score");
+                let result = score_from_creature_dir(
+                    dir,
+                    &fix.data_dir,
+                    GpuBackendLabel::CpuFallback,
+                    CostKind::default(),
+                )
+                .expect("multi-creature score");
                 black_box(result);
             });
         });
@@ -376,9 +381,15 @@ fn bench_gpu_score_from_creature_dir(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("creatures", n), &sub_dir, |b, dir| {
             let ctx = ctx.clone();
             b.iter(|| {
-                let result =
-                    score_from_creature_dir_gpu(dir, &fix.data_dir, backend, ctx.clone(), 2)
-                        .expect("gpu multi-creature score");
+                let result = score_from_creature_dir_gpu(
+                    dir,
+                    &fix.data_dir,
+                    backend,
+                    ctx.clone(),
+                    2,
+                    CostKind::default(),
+                )
+                .expect("gpu multi-creature score");
                 black_box(result);
             });
         });
@@ -440,6 +451,7 @@ fn bench_gpu_pipelining_toggle(c: &mut Criterion) {
                         backend,
                         ctx.clone(),
                         inflight,
+                        CostKind::default(),
                     )
                     .expect("gpu multi-creature score");
                     black_box(result);

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -1,0 +1,212 @@
+//! Cost-function selector for `rust_scorer` (Issue #120).
+//!
+//! Adds a `--cost <NAME>` CLI flag that accepts the seven NEAT-AI built-in
+//! cost names exactly as they appear in the TypeScript `BUILT_IN_COST_NAMES`
+//! tuple (see `NEAT-AI/src/Costs.ts`). The flag defaults to `MSE`, which
+//! preserves the current scoring behaviour — actual dispatch onto the new
+//! cost kinds lands in the follow-up issue (#119-3); this change is the
+//! foundational plumbing only.
+//!
+//! KISS: there is **no** environment-variable override. Unknown values are
+//! rejected at the clap layer with a non-zero exit and a stderr message
+//! listing the supported set.
+
+use clap::ValueEnum;
+
+/// Built-in NEAT-AI cost function selector.
+///
+/// The rendered names must match the TypeScript `BUILT_IN_COST_NAMES`
+/// strings exactly so callers can pass `costName` through unchanged from
+/// the upstream config (`NeatOptions.costName`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum CostKind {
+    /// Mean Squared Error — current (and default) scoring path.
+    #[default]
+    #[value(name = "MSE")]
+    Mse,
+    /// Mean Absolute Error.
+    #[value(name = "MAE")]
+    Mae,
+    /// Mean Absolute Percentage Error.
+    #[value(name = "MAPE")]
+    Mape,
+    /// Mean Squared Logarithmic Error.
+    #[value(name = "MSLE")]
+    Msle,
+    /// Hinge loss (margin classifiers).
+    #[value(name = "HINGE")]
+    Hinge,
+    /// Cross-entropy (probabilistic classifiers).
+    #[value(name = "CROSS_ENTROPY")]
+    CrossEntropy,
+    /// Categorical error (multi-class top-1 mismatch).
+    #[value(name = "CATEGORICAL_ERROR")]
+    CategoricalError,
+}
+
+impl CostKind {
+    /// Stable serialised label as a `&'static str`. Matches the TypeScript
+    /// `BUILT_IN_COST_NAMES` strings exactly.
+    // Consumed by tests, benches, and the follow-up dispatch wiring in
+    // #119-3. Suppressed for the `bin "rust_scorer"` compile where the
+    // CLI binary itself only reads the variant, not its rendered label.
+    #[allow(dead_code)]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mse => "MSE",
+            Self::Mae => "MAE",
+            Self::Mape => "MAPE",
+            Self::Msle => "MSLE",
+            Self::Hinge => "HINGE",
+            Self::CrossEntropy => "CROSS_ENTROPY",
+            Self::CategoricalError => "CATEGORICAL_ERROR",
+        }
+    }
+
+    /// Validate a raw CLI string and return the matching [`CostKind`].
+    ///
+    /// Centralises validation so unit tests can exercise the accept/reject
+    /// logic without going through clap's argv parser. The error message
+    /// lists every supported name in the TypeScript order to match the
+    /// `--help` output.
+    // Consumed by unit tests and downstream callers (`NeatOptions.costName`
+    // pass-through, dispatch landing in #119-3); the bin target itself
+    // relies on clap, not this helper.
+    #[allow(dead_code)]
+    pub fn from_cli(raw: &str) -> Result<Self, String> {
+        // Exact-match parsing — the TypeScript names are upper-case, so we
+        // do not normalise case. This keeps the CLI contract aligned with
+        // what `NeatOptions.costName` will pass through.
+        for variant in Self::value_variants() {
+            if variant.as_str() == raw {
+                return Ok(*variant);
+            }
+        }
+        Err(format!(
+            "Invalid cost '{raw}': expected one of {}",
+            supported_list(),
+        ))
+    }
+}
+
+/// Comma-separated list of supported cost names in TypeScript order
+/// (matches `BUILT_IN_COST_NAMES`). Used to build the error message
+/// returned by [`CostKind::from_cli`] when a value is rejected.
+#[allow(dead_code)]
+fn supported_list() -> String {
+    CostKind::value_variants()
+        .iter()
+        .map(|v| v.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::ValueEnum;
+
+    /// Every TypeScript `BUILT_IN_COST_NAMES` entry must parse via `from_cli`.
+    /// This pins the CLI contract against the upstream cost-name set.
+    #[test]
+    fn from_cli_accepts_every_built_in_cost_name() {
+        for name in [
+            "MSE",
+            "MAE",
+            "MAPE",
+            "MSLE",
+            "HINGE",
+            "CROSS_ENTROPY",
+            "CATEGORICAL_ERROR",
+        ] {
+            let parsed = CostKind::from_cli(name)
+                .unwrap_or_else(|e| panic!("expected '{name}' to parse, got error: {e}"));
+            assert_eq!(parsed.as_str(), name);
+        }
+    }
+
+    /// Unknown cost names must be rejected with a helpful message listing
+    /// the supported set.
+    #[test]
+    fn from_cli_rejects_unknown_cost_name() {
+        let err = CostKind::from_cli("FOO").expect_err("FOO must be rejected");
+        assert!(
+            err.contains("FOO"),
+            "error must echo the bad value, got: {err}"
+        );
+        for name in [
+            "MSE",
+            "MAE",
+            "MAPE",
+            "MSLE",
+            "HINGE",
+            "CROSS_ENTROPY",
+            "CATEGORICAL_ERROR",
+        ] {
+            assert!(
+                err.contains(name),
+                "error must list supported cost '{name}', got: {err}"
+            );
+        }
+    }
+
+    /// Case-mismatched names must be rejected — the TS `BUILT_IN_COST_NAMES`
+    /// strings are upper-case and the CLI contract is exact.
+    #[test]
+    fn from_cli_rejects_case_mismatch() {
+        assert!(CostKind::from_cli("mse").is_err());
+        assert!(CostKind::from_cli("Cross_Entropy").is_err());
+    }
+
+    /// Empty input is not a valid cost name.
+    #[test]
+    fn from_cli_rejects_empty_string() {
+        assert!(CostKind::from_cli("").is_err());
+    }
+
+    /// The default must be MSE so the historical scoring behaviour is
+    /// preserved when callers omit `--cost`.
+    #[test]
+    fn default_is_mse() {
+        assert_eq!(CostKind::default(), CostKind::Mse);
+        assert_eq!(CostKind::default().as_str(), "MSE");
+    }
+
+    /// Every variant must round-trip through clap's `ValueEnum` using the
+    /// rendered name (case-sensitive — `ignore_case = false`).
+    #[test]
+    fn clap_value_enum_round_trips_every_variant() {
+        for variant in CostKind::value_variants() {
+            let possible = variant
+                .to_possible_value()
+                .expect("every variant must have a possible value");
+            let name = possible.get_name();
+            let parsed = CostKind::from_str(name, false)
+                .unwrap_or_else(|e| panic!("clap could not parse '{name}': {e}"));
+            assert_eq!(parsed, *variant);
+        }
+    }
+
+    /// Issue #120 explicitly forbids an environment-variable override.
+    /// Encode that contract by asserting the env var is ignored: the
+    /// `from_cli` helper takes only the raw CLI value and never reads
+    /// process state, so setting `NEAT_SCORER_COST` cannot influence
+    /// validation.
+    #[test]
+    fn from_cli_ignores_env_var_override() {
+        // Safety: tests run in-process; setting an env var is benign here
+        // because `from_cli` never reads `std::env`.
+        // SAFETY: single-threaded test scope, no other reader observes the var.
+        unsafe {
+            std::env::set_var("NEAT_SCORER_COST", "MAE");
+        }
+        // The helper still rejects unknown values regardless of env state.
+        assert!(CostKind::from_cli("FOO").is_err());
+        // And it still returns exactly what the CLI string says.
+        assert_eq!(CostKind::from_cli("MSE").unwrap(), CostKind::Mse);
+        // SAFETY: single-threaded test scope, no other reader observes the var.
+        unsafe {
+            std::env::remove_var("NEAT_SCORER_COST");
+        }
+    }
+}

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 //! Issue #36 — Criterion benchmark infrastructure.
 
+pub mod cost;
 pub mod gpu;
 pub mod multi_score;
 pub mod read_tuning;

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -10,6 +10,7 @@
 //!
 //! Issue #1967 - Build Rust CLI scorer application.
 
+mod cost;
 mod gpu;
 mod multi_score;
 mod read_tuning;
@@ -29,6 +30,7 @@ use neat_core::training_data::{TrainingDataConfig, TrainingDataIterator, find_bi
 
 use std::sync::Arc;
 
+use crate::cost::CostKind;
 use crate::gpu::{GpuBackendLabel, GpuMode, ScoringPath, auto_should_use_gpu};
 use crate::multi_score::{score_from_creature_dir, score_from_creature_dir_gpu};
 use crate::read_tuning::{training_read_backend_label, training_read_target_bytes_from_env};
@@ -70,6 +72,19 @@ struct Cli {
     /// Falls back to the `NEAT_SCORER_GPU` env var when not provided.
     #[arg(long, value_enum, value_name = "MODE")]
     gpu: Option<GpuMode>,
+
+    /// Built-in cost function (Issue #120).
+    ///
+    /// Names match the TypeScript `BUILT_IN_COST_NAMES` strings exactly —
+    /// see `NEAT-AI/src/Costs.ts`. Defaults to `MSE`, preserving the
+    /// historical scoring behaviour. There is **no** environment-variable
+    /// override (KISS); unknown values are rejected by clap with a
+    /// non-zero exit and a stderr message listing the supported set.
+    ///
+    /// Dispatch onto the new cost kinds lands in the follow-up issue
+    /// (#119-3); for now every cost selection still computes MSE.
+    #[arg(long, value_enum, value_name = "NAME", default_value_t = CostKind::default())]
+    cost: CostKind,
 
     /// Positional arguments.
     ///
@@ -169,8 +184,13 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         // (#81 closed as a negative result — no GPU kernel ships for this
         // path). The reported `gpuBackend` reflects what actually ran, so
         // it is `cpu-fallback` here regardless of `gpu_backend` resolution.
-        return score_from_json(&creature_json, &data_path, GpuBackendLabel::CpuFallback)
-            .map(RunOutput::Single);
+        return score_from_json(
+            &creature_json,
+            &data_path,
+            GpuBackendLabel::CpuFallback,
+            cli.cost,
+        )
+        .map(RunOutput::Single);
     }
 
     if cli.args.len() != 2 {
@@ -187,7 +207,14 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         if want_gpu_for_path(ScoringPath::CreatureDirectory)
             && let Some(ctx) = gpu_ctx.clone()
         {
-            match score_from_creature_dir_gpu(creature_path, data_path, gpu_backend, ctx, 2) {
+            match score_from_creature_dir_gpu(
+                creature_path,
+                data_path,
+                gpu_backend,
+                ctx,
+                2,
+                cli.cost,
+            ) {
                 Ok(r) => return Ok(RunOutput::Multi(r)),
                 Err(e) => {
                     // `--gpu on` is a hard requirement — surface the error.
@@ -204,8 +231,13 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         // could not host the creature set, or the path is not GPU-default),
         // or the mode is Off. Report `cpu-fallback` so `gpuBackend` reflects
         // what actually ran (Issue #83).
-        score_from_creature_dir(creature_path, data_path, GpuBackendLabel::CpuFallback)
-            .map(RunOutput::Multi)
+        score_from_creature_dir(
+            creature_path,
+            data_path,
+            GpuBackendLabel::CpuFallback,
+            cli.cost,
+        )
+        .map(RunOutput::Multi)
     } else {
         let creature_json = fs::read_to_string(creature_path).map_err(|e| {
             format!(
@@ -215,8 +247,13 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         })?;
         // See note in the `--creature-stdin` branch — single-creature path
         // always reports `cpu-fallback`.
-        score_from_json(&creature_json, data_path, GpuBackendLabel::CpuFallback)
-            .map(RunOutput::Single)
+        score_from_json(
+            &creature_json,
+            data_path,
+            GpuBackendLabel::CpuFallback,
+            cli.cost,
+        )
+        .map(RunOutput::Single)
     }
 }
 
@@ -224,6 +261,11 @@ fn score_from_json(
     creature_json: &str,
     data_path: &Path,
     gpu_backend: GpuBackendLabel,
+    // Issue #120 — resolved cost selector. Dispatch lands in #119-3;
+    // the parameter is accepted now so the CLI contract is stable and
+    // every scoring entry point has a uniform signature. The MSE path
+    // continues to call `mse_sum_batch_packed` regardless of the value.
+    _cost: CostKind,
 ) -> Result<ScoreResult, String> {
     let started = Instant::now();
     let creature = parse_creature_json(creature_json)?;
@@ -463,6 +505,7 @@ mod tests {
         Cli {
             creature_stdin: false,
             gpu: None,
+            cost: CostKind::default(),
             args: vec![creature.to_path_buf(), data.to_path_buf()],
         }
     }
@@ -676,7 +719,13 @@ mod tests {
         write_training_data(&data_dir, &[(vec![0.5], vec![0.5])]);
 
         let file_result = run_single(&cli_for(&creature_path, &data_dir)).unwrap();
-        let stdin_result = score_from_json(&json, &data_dir, GpuBackendLabel::CpuFallback).unwrap();
+        let stdin_result = score_from_json(
+            &json,
+            &data_dir,
+            GpuBackendLabel::CpuFallback,
+            CostKind::default(),
+        )
+        .unwrap();
 
         assert!((file_result.score - stdin_result.score).abs() < 1e-12);
         assert!((file_result.error - stdin_result.error).abs() < 1e-12);
@@ -692,6 +741,7 @@ mod tests {
         let cli = Cli {
             creature_stdin: true,
             gpu: None,
+            cost: CostKind::default(),
             args: vec![PathBuf::from("/tmp/creature.json"), PathBuf::from("/tmp")],
         };
         let err = resolve_inputs(&cli).expect_err("extra positional args should fail");
@@ -707,6 +757,7 @@ mod tests {
         let cli = Cli {
             creature_stdin: false,
             gpu: None,
+            cost: CostKind::default(),
             args: vec![PathBuf::from("/tmp")],
         };
         let err = resolve_inputs(&cli).expect_err("single positional arg should fail");
@@ -724,8 +775,13 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("data");
         fs::create_dir(&data_dir).unwrap();
-        let err = score_from_json("not json", &data_dir, GpuBackendLabel::CpuFallback)
-            .expect_err("invalid JSON should fail");
+        let err = score_from_json(
+            "not json",
+            &data_dir,
+            GpuBackendLabel::CpuFallback,
+            CostKind::default(),
+        )
+        .expect_err("invalid JSON should fail");
         assert!(!err.is_empty());
     }
 
@@ -815,7 +871,78 @@ mod tests {
         let json = make_creature_json(1, 1, &[], &[("input-0", "output-0", 1.0)], Some("4.0.0"));
         write_training_data(&data_dir, &[(vec![0.5], vec![0.5])]);
 
-        let result = score_from_json(&json, &data_dir, GpuBackendLabel::CpuFallback).unwrap();
+        let result = score_from_json(
+            &json,
+            &data_dir,
+            GpuBackendLabel::CpuFallback,
+            CostKind::default(),
+        )
+        .unwrap();
         assert_eq!(result.gpu_backend, GpuBackendLabel::CpuFallback);
+    }
+
+    /// Issue #120: clap must accept every TS `BUILT_IN_COST_NAMES` value
+    /// via `--cost` and store the corresponding `CostKind`.
+    #[test]
+    fn test_cli_parses_every_built_in_cost_name() {
+        use clap::Parser;
+
+        let cases = [
+            ("MSE", CostKind::Mse),
+            ("MAE", CostKind::Mae),
+            ("MAPE", CostKind::Mape),
+            ("MSLE", CostKind::Msle),
+            ("HINGE", CostKind::Hinge),
+            ("CROSS_ENTROPY", CostKind::CrossEntropy),
+            ("CATEGORICAL_ERROR", CostKind::CategoricalError),
+        ];
+        for (name, expected) in cases {
+            let parsed = Cli::try_parse_from([
+                "rust_scorer",
+                "--cost",
+                name,
+                "/tmp/creature.json",
+                "/tmp/data",
+            ])
+            .unwrap_or_else(|e| panic!("clap rejected --cost {name}: {e}"));
+            assert_eq!(parsed.cost, expected);
+        }
+    }
+
+    /// Issue #120: omitting `--cost` must default to MSE so historical
+    /// scoring behaviour is preserved.
+    #[test]
+    fn test_cli_default_cost_is_mse() {
+        use clap::Parser;
+        let parsed =
+            Cli::try_parse_from(["rust_scorer", "/tmp/creature.json", "/tmp/data"]).unwrap();
+        assert_eq!(parsed.cost, CostKind::Mse);
+    }
+
+    /// Issue #120: unknown cost names must be rejected at the clap layer
+    /// with a non-zero exit. The error message must mention the supported
+    /// set so users can recover.
+    #[test]
+    fn test_cli_rejects_unknown_cost_name() {
+        use clap::Parser;
+        let err = Cli::try_parse_from([
+            "rust_scorer",
+            "--cost",
+            "FOO",
+            "/tmp/creature.json",
+            "/tmp/data",
+        ])
+        .expect_err("unknown cost must be rejected");
+        let rendered = err.to_string();
+        // clap renders an error like "invalid value 'FOO' for '--cost <NAME>'
+        // [possible values: MSE, MAE, ...]".
+        assert!(
+            rendered.contains("FOO"),
+            "error must echo bad value, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("MSE") && rendered.contains("CROSS_ENTROPY"),
+            "error must list supported costs, got: {rendered}"
+        );
     }
 }

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -36,6 +36,7 @@ use neat_core::training_bin_stream::for_each_read_chunk;
 use neat_core::training_data::{TrainingDataConfig, find_bin_files};
 use rayon::prelude::*;
 
+use crate::cost::CostKind;
 use crate::gpu::forward_mse_batched::BatchedRunner;
 use crate::gpu::{GpuBackendLabel, GpuContext};
 use crate::read_tuning::{training_read_backend_label, training_read_target_bytes_from_env};
@@ -246,6 +247,10 @@ pub fn score_from_creature_dir(
     creatures_dir: &Path,
     data_path: &Path,
     gpu_backend: GpuBackendLabel,
+    // Issue #120 — resolved cost selector; dispatch lands in #119-3. Held
+    // here so the CPU directory entry point has the same signature as the
+    // single-creature and GPU paths.
+    _cost: CostKind,
 ) -> Result<BTreeMap<String, ScoreResult>, String> {
     let started = Instant::now();
     let loaded = load_creatures_from_dir(creatures_dir)?;
@@ -536,6 +541,9 @@ pub fn score_from_creature_dir_gpu(
     gpu_backend: GpuBackendLabel,
     ctx: Arc<GpuContext>,
     inflight_chunks: usize,
+    // Issue #120 — resolved cost selector; dispatch lands in #119-3. The
+    // GPU `forward_mse_batched` kernel keeps computing MSE for now.
+    _cost: CostKind,
 ) -> Result<BTreeMap<String, ScoreResult>, String> {
     let started = Instant::now();
     let loaded = load_creatures_from_dir(creatures_dir)?;

--- a/rust_scorer/tests/scorer_smoke.rs
+++ b/rust_scorer/tests/scorer_smoke.rs
@@ -550,3 +550,232 @@ fn scorer_binary_directory_mode_matches_single_mode_results() {
         );
     }
 }
+
+/// Issue #120: `--cost MSE` must run identically to the current default
+/// (no `--cost` flag) — score, error, and record count must match exactly.
+/// Pins the "MSE preserves historical behaviour" acceptance criterion.
+#[test]
+fn scorer_binary_cost_mse_matches_default() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    let baseline = Command::new(bin)
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer (baseline)");
+    assert!(
+        baseline.status.success(),
+        "baseline exited with status {:?}\nstderr:\n{}",
+        baseline.status.code(),
+        String::from_utf8_lossy(&baseline.stderr),
+    );
+    let baseline_stdout = String::from_utf8(baseline.stdout).expect("stdout is utf-8");
+    let baseline_json: serde_json::Value =
+        serde_json::from_str(&baseline_stdout).expect("baseline stdout is JSON");
+
+    let with_mse = Command::new(bin)
+        .arg("--cost")
+        .arg("MSE")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer (--cost MSE)");
+    assert!(
+        with_mse.status.success(),
+        "--cost MSE exited with status {:?}\nstderr:\n{}",
+        with_mse.status.code(),
+        String::from_utf8_lossy(&with_mse.stderr),
+    );
+    let mse_stdout = String::from_utf8(with_mse.stdout).expect("stdout is utf-8");
+    let mse_json: serde_json::Value =
+        serde_json::from_str(&mse_stdout).expect("--cost MSE stdout is JSON");
+
+    assert_eq!(
+        baseline_json.get("error"),
+        mse_json.get("error"),
+        "--cost MSE must match the default scoring path"
+    );
+    assert_eq!(
+        baseline_json.get("score"),
+        mse_json.get("score"),
+        "--cost MSE must match the default scoring path"
+    );
+    assert_eq!(
+        baseline_json.get("recordCount"),
+        mse_json.get("recordCount"),
+    );
+}
+
+/// Issue #120: `--cost MAE` must parse cleanly and still compute MSE for now
+/// (dispatch lands in #119-3). Asserts the binary exits 0 and emits the
+/// same numeric result as MSE — proves the plumbing accepts the flag and
+/// has not changed the calculation yet.
+#[test]
+fn scorer_binary_cost_mae_parses_and_runs_as_mse() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    let baseline = Command::new(bin)
+        .arg("--cost")
+        .arg("MSE")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer (--cost MSE)");
+    assert!(baseline.status.success());
+    let baseline_json: serde_json::Value =
+        serde_json::from_slice(&baseline.stdout).expect("baseline stdout is JSON");
+
+    let with_mae = Command::new(bin)
+        .arg("--cost")
+        .arg("MAE")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer (--cost MAE)");
+    assert!(
+        with_mae.status.success(),
+        "--cost MAE exited with status {:?}\nstderr:\n{}",
+        with_mae.status.code(),
+        String::from_utf8_lossy(&with_mae.stderr),
+    );
+    let mae_json: serde_json::Value =
+        serde_json::from_slice(&with_mae.stdout).expect("--cost MAE stdout is JSON");
+
+    // Identical numeric result: dispatch lands in #119-3, this PR only
+    // wires the CLI surface.
+    assert_eq!(baseline_json.get("error"), mae_json.get("error"));
+    assert_eq!(baseline_json.get("score"), mae_json.get("score"));
+}
+
+/// Issue #120: every built-in cost name must parse and run cleanly
+/// (still computing MSE until #119-3 lands).
+#[test]
+fn scorer_binary_accepts_every_built_in_cost_name() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    for name in [
+        "MSE",
+        "MAE",
+        "MAPE",
+        "MSLE",
+        "HINGE",
+        "CROSS_ENTROPY",
+        "CATEGORICAL_ERROR",
+    ] {
+        let out = Command::new(bin)
+            .arg("--cost")
+            .arg(name)
+            .arg(&creature)
+            .arg(data_dir.path())
+            .output()
+            .unwrap_or_else(|e| panic!("failed to spawn rust_scorer for cost {name}: {e}"));
+        assert!(
+            out.status.success(),
+            "--cost {name} exited with status {:?}\nstderr:\n{}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+}
+
+/// Issue #120: an unknown `--cost` value must produce a non-zero exit
+/// and a stderr message naming the supported set. Pins the "hard-error
+/// on unknown cost" acceptance criterion.
+#[test]
+fn scorer_binary_rejects_unknown_cost() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    let out = Command::new(bin)
+        .arg("--cost")
+        .arg("FOO")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer");
+    assert!(
+        !out.status.success(),
+        "--cost FOO must exit non-zero, got status {:?}",
+        out.status.code(),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FOO"),
+        "stderr must echo bad value, got: {stderr}"
+    );
+    // clap renders "[possible values: MSE, MAE, ...]"; assert the
+    // supported set is mentioned.
+    assert!(
+        stderr.contains("MSE") && stderr.contains("CROSS_ENTROPY"),
+        "stderr must list supported costs, got: {stderr}"
+    );
+}
+
+/// Issue #120: `--help` must document the `--cost` flag and its supported
+/// values so callers can discover them without reading source.
+#[test]
+fn scorer_binary_help_lists_cost_flag_and_values() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let out = Command::new(bin)
+        .arg("--help")
+        .output()
+        .expect("failed to spawn rust_scorer --help");
+    assert!(
+        out.status.success(),
+        "--help exited with status {:?}",
+        out.status.code()
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--cost"),
+        "--help must mention --cost, got:\n{stdout}"
+    );
+    for name in [
+        "MSE",
+        "MAE",
+        "MAPE",
+        "MSLE",
+        "HINGE",
+        "CROSS_ENTROPY",
+        "CATEGORICAL_ERROR",
+    ] {
+        assert!(
+            stdout.contains(name),
+            "--help must list supported cost '{name}', got:\n{stdout}"
+        );
+    }
+}
+
+/// Issue #120 explicitly forbids a `NEAT_SCORER_COST` env-var override
+/// (KISS — the CLI flag is the only knob). Pin that contract by setting
+/// the env var to an invalid value and asserting the binary still runs
+/// using the default (`MSE`) — i.e. the env var is ignored.
+#[test]
+fn scorer_binary_ignores_neat_scorer_cost_env_var() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    let out = Command::new(bin)
+        // If this env var had any effect, "FOO" would either be picked up
+        // (impossible — not a valid CostKind) or trigger a parse error.
+        // The binary must ignore it and use the default.
+        .env("NEAT_SCORER_COST", "FOO")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer");
+    assert!(
+        out.status.success(),
+        "binary must ignore NEAT_SCORER_COST, got status {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}


### PR DESCRIPTION
## Summary

Added a `--cost <NAME>` CLI flag to `rust_scorer` that accepts the seven
NEAT-AI built-in cost names exactly as they appear in the TypeScript
`BUILT_IN_COST_NAMES` tuple (`MSE`, `MAE`, `MAPE`, `MSLE`, `HINGE`,
`CROSS_ENTROPY`, `CATEGORICAL_ERROR`) and hard-errors on anything else via
`clap::ValueEnum`. The default is `MSE`, which preserves the current
scoring behaviour byte-for-byte. The resolved `CostKind` is plumbed through
every scoring entry point (`score_from_json`, `score_from_creature_dir`,
`score_from_creature_dir_gpu`) as a parameter so the CLI contract is
stable; **the calculation itself is unchanged** — the MSE path keeps calling
`mse_sum_batch_packed`. Dispatch wiring lands in the follow-up issue
(`#119-3`). There is no `NEAT_SCORER_COST` environment-variable override
(KISS, as the issue brief requires).

Closes #120.

## Evidence

Pure CLI/library change with no UI to screenshot. Verified by:

- 7 new unit tests in `rust_scorer/src/cost.rs` exercising the `CostKind`
  enum and `from_cli` validation helper (accept every TS name, reject
  unknown/case-mismatch/empty, default to MSE, clap round-trip).
- 3 new unit tests in `rust_scorer/src/main.rs` proving the `--cost` flag
  is parsed by `clap` (every value accepted, default is `MSE`, unknown
  rejected with a stderr message listing the supported set).
- 5 new end-to-end smoke tests in `rust_scorer/tests/scorer_smoke.rs`
  driving the compiled binary against the identity fixture:
  - `--cost MSE` matches the default scoring output exactly.
  - `--cost MAE` parses and runs (still computing MSE) — proves the flag
    is wired without changing the calculation.
  - Every built-in cost name is accepted by the binary.
  - `--cost FOO` exits non-zero with a stderr message naming the
    supported set.
  - `--help` lists `--cost` and every supported value.
  - `NEAT_SCORER_COST` env var is ignored (KISS contract).
- Full `./quality.sh` passes (shellcheck, cargo-deny, fmt, clippy, check,
  build, all tests, doc with `-D warnings`, release build).

```mermaid
flowchart LR
    CLI[--cost NAME] --> Parse[clap ValueEnum]
    Parse --> Valid{Valid name?}
    Valid -->|yes| CostKind[CostKind enum]
    Valid -->|no| Err[stderr + exit 2]
    CostKind --> Scorer[score_from_json /<br/>score_from_creature_dir /<br/>score_from_creature_dir_gpu]
```

## Test Plan

- [x] `cargo test -p rust_scorer` — 70+ tests pass, including the new
  unit tests in `cost.rs` and `main.rs` and the new smoke tests in
  `tests/scorer_smoke.rs`.
- [x] `./quality.sh` passes locally on macOS (shellcheck, cargo-deny,
  fmt, clippy, check, build, test, doc, release).
- [x] `rust_scorer --help` lists `--cost <NAME>` and the seven supported
  values.
- [x] `rust_scorer --cost FOO …` exits non-zero with a stderr message
  listing the supported set.

Tests added or modified:

- `rust_scorer/src/cost.rs` — new module; 7 unit tests for `CostKind` /
  `from_cli` validation.
- `rust_scorer/src/main.rs` — 3 new unit tests for the `--cost` clap
  surface; existing tests updated to populate the new `cost` field on
  the `Cli` struct.
- `rust_scorer/tests/scorer_smoke.rs` — 5 new end-to-end smoke tests
  covering every acceptance criterion in the issue.
- `rust_scorer/benches/scoring.rs` — pass `CostKind::default()` to the
  scoring entry points whose signatures gained the new parameter.