### PR TITLE
feat(scorer): wire CostKind dispatch through stream_score and multi_score

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.28"
+version = "0.5.29"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-121.md
+++ b/docs/archive/pr-summaries/pr-summary-121.md
@@ -1,0 +1,115 @@
+# Wire CostKind dispatch through stream_score and multi_score (Closes #121)
+
+## Summary
+
+Issue #121 wires the `--cost <NAME>` selector added in #120 through to the
+per-chunk loss accumulator so the fused single-creature path
+(`stream_score.rs`) and the directory/batch path (`multi_score.rs`) actually
+compute the requested NEAT-AI built-in cost instead of always running MSE.
+
+- New `accumulate_cost_sum(kind, net, chunk, input_size, num_outputs, forward_only)`
+  in `rust_scorer::cost` dispatches a packed `[inputs..., targets...]`
+  chunk to the matching `neat_core::loss::*_sum_batch_packed` helper. MSE,
+  MAE, MAPE, MSLE, HINGE, and CROSS_ENTROPY all route here.
+- `accumulate_mse_sum_forward_only_fused` is renamed to
+  `accumulate_cost_sum_forward_only_fused` and now takes a `CostKind`. The
+  multi-creature directory path threads `CostKind` through to the same
+  dispatch site.
+- CATEGORICAL_ERROR is a hard runtime error referencing
+  `stSoftwareAU/NEAT-AI-core#88` — the underlying
+  `categorical_error_sum_batch_packed` helper has not yet landed in
+  `neat-core` (the issue is open). Once it merges, the dispatch is a
+  one-line change.
+- GPU dispatch is gated: `auto_should_use_gpu` now also takes the
+  `CostKind`, returning `false` for any cost other than MSE.
+  `--gpu on --cost X != MSE` hard-errors at the CLI layer; `--gpu auto`
+  silently falls back to the CPU pipeline.
+- `ScoreResult` gains a `costName: String` field (serialised as
+  `"costName"`) populated from the resolved `CostKind`, so the TS bridge
+  can confirm which loss was actually applied.
+- The recurrent (non-`forwardOnly`) single-creature path now also routes
+  through `accumulate_cost_sum`, packing one record at a time and
+  passing `forward_only = false` so the helper resets network state per
+  record (matching the old hand-rolled loop).
+
+Closes #121.
+
+## Evidence
+
+Pure backend/CLI change — no UI to screenshot. Verified via the full
+quality gate:
+
+- `./quality.sh` passes cleanly (shellcheck, fmt, clippy with
+  `-D warnings`, cargo-deny, build, all tests, rustdoc, release build).
+- 75 unit tests pass (rust_scorer lib + bin), 20 smoke tests, 5
+  directory-mode TDD tests, 3 GPU parity tests.
+
+### Dispatch flow
+
+```mermaid
+flowchart LR
+    Cli["--cost CostKind"] --> Validate{forwardOnly?}
+    Validate -- "yes" --> Fused["accumulate_cost_sum_forward_only_fused"]
+    Validate -- "no" --> PerRecord["per-record packed buffer"]
+    Fused --> Dispatch{accumulate_cost_sum}
+    PerRecord --> Dispatch
+    Dispatch -- "MSE" --> MSE["mse_sum_batch_packed"]
+    Dispatch -- "MAE" --> MAE["mae_sum_batch_packed"]
+    Dispatch -- "MAPE" --> MAPE["mape_sum_batch_packed"]
+    Dispatch -- "MSLE" --> MSLE["msle_sum_batch_packed"]
+    Dispatch -- "HINGE" --> HINGE["hinge_sum_batch_packed"]
+    Dispatch -- "CROSS_ENTROPY" --> CE["cross_entropy_sum_batch_packed"]
+    Dispatch -- "CATEGORICAL_ERROR" --> Blocked["Err: requires NEAT-AI-core#88"]
+    MSE --> GPU{cost == MSE?}
+    GPU -- "yes" --> GpuKernel["forward_mse_batched"]
+    GPU -- "no" --> CpuOnly["CPU fallback"]
+```
+
+## Test Plan
+
+New tests added:
+
+- `rust_scorer/src/cost.rs`:
+  - `gpu_supported_only_for_mse` — locks the GPU-cost predicate to MSE.
+  - `accumulate_cost_sum_categorical_error_is_blocked` — asserts
+    CATEGORICAL_ERROR returns an `Err` mentioning `#88`.
+  - `accumulate_cost_sum_mse_matches_direct_helper` — MSE dispatch
+    numerically equals `mse_sum_batch_packed` directly (regression
+    check on existing fixtures).
+  - `accumulate_cost_sum_mae_diverges_from_mse` — proves MAE takes a
+    different code path from MSE for `|diff| > 1`.
+- `rust_scorer/src/gpu/mod.rs`:
+  - `auto_should_use_gpu_directory_falls_back_to_cpu_for_non_mse_costs`
+    — every non-MSE variant forces CPU fallback under Auto.
+- `rust_scorer/tests/scorer_smoke.rs`:
+  - `scorer_binary_accepts_every_dispatchable_built_in_cost_name` —
+    end-to-end runs MSE, MAE, MAPE, MSLE, HINGE on the identity
+    fixture and asserts each echoes `costName=<NAME>` (CE is exercised
+    separately because the fixture has negative targets).
+  - `scorer_binary_cost_cross_entropy_runs_on_probabilistic_fixture` —
+    builds a `[0, 1]`-target fixture and asserts CE runs cleanly with
+    `costName=CROSS_ENTROPY` and a non-negative error.
+  - `scorer_binary_categorical_error_is_blocked_with_helpful_message`
+    — stderr names CATEGORICAL_ERROR and references issue #88.
+  - `scorer_binary_gpu_on_with_non_mse_cost_errors` — `--gpu on --cost
+    MAE` exits non-zero with a clear message.
+  - `scorer_binary_gpu_auto_with_non_mse_cost_runs_on_cpu` — auto +
+    non-MSE silently falls back to CPU and reports
+    `gpuBackend=cpu-fallback`.
+  - `scorer_binary_cost_mae_runs_through_dispatch` (replaces the older
+    `..._parses_and_runs_as_mse`) — the identity fixture has zero
+    error under both MSE and MAE, but the JSON now also asserts the
+    `costName` field round-trips MAE through dispatch.
+
+Existing tests updated:
+
+- `scorer_binary_accepts_every_built_in_cost_name` renamed to
+  `..._accepts_every_dispatchable_built_in_cost_name` and narrowed to
+  the regression-friendly costs; CE and CATEGORICAL_ERROR have
+  dedicated tests above. Business-logic shift: dispatch is real now,
+  so the test must use a fixture appropriate to each cost.
+- `scorer_binary_cost_mae_parses_and_runs_as_mse` renamed to
+  `scorer_binary_cost_mae_runs_through_dispatch` — the assertion that
+  MAE silently equals MSE was tied to the placeholder dispatch.
+
+`./quality.sh < /dev/null` passes cleanly.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.29"
+version = "0.5.30"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/benches/scoring.rs
+++ b/rust_scorer/benches/scoring.rs
@@ -4,7 +4,7 @@
 //! synthetic creature(s) and `.bin` corpus are paid for **once per process**:
 //!
 //! * `score_from_json_fused` — forward-only fused path, exercised through
-//!   [`rust_scorer::stream_score::accumulate_mse_sum_forward_only_fused`] (the
+//!   [`rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused`] (the
 //!   same hot path the CLI runs in default mode).
 //! * `score_from_creature_dir` — directory mode at `N=10` and `N=50` creatures,
 //!   exercised through [`rust_scorer::multi_score::score_from_creature_dir`].
@@ -48,7 +48,7 @@ use std::sync::Arc;
 use rust_scorer::cost::CostKind;
 use rust_scorer::gpu::{GpuBackendLabel, GpuMode, resolve_backend, select_adapter};
 use rust_scorer::multi_score::{score_from_creature_dir, score_from_creature_dir_gpu};
-use rust_scorer::stream_score::accumulate_mse_sum_forward_only_fused;
+use rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused;
 
 use tempfile::TempDir;
 
@@ -212,9 +212,14 @@ fn bench_score_from_json_fused(c: &mut Criterion) {
         b.iter_batched(
             || compile_creature(&creature).expect("compile"),
             |mut net| {
-                let r =
-                    accumulate_mse_sum_forward_only_fused(&bin_files, &config, &creature, &mut net)
-                        .expect("fused MSE accumulate");
+                let r = accumulate_cost_sum_forward_only_fused(
+                    CostKind::Mse,
+                    &bin_files,
+                    &config,
+                    &creature,
+                    &mut net,
+                )
+                .expect("fused MSE accumulate");
                 black_box(r);
             },
             BatchSize::PerIteration,

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -1,17 +1,19 @@
-//! Cost-function selector for `rust_scorer` (Issue #120).
+//! Cost-function selector for `rust_scorer` (Issues #120, #121).
 //!
 //! Adds a `--cost <NAME>` CLI flag that accepts the seven NEAT-AI built-in
 //! cost names exactly as they appear in the TypeScript `BUILT_IN_COST_NAMES`
 //! tuple (see `NEAT-AI/src/Costs.ts`). The flag defaults to `MSE`, which
-//! preserves the current scoring behaviour — actual dispatch onto the new
-//! cost kinds lands in the follow-up issue (#119-3); this change is the
-//! foundational plumbing only.
+//! preserves the current scoring behaviour. Issue #121 wires the selector
+//! through to the per-chunk dispatch helper [`accumulate_cost_sum`] so the
+//! fused/streaming CPU paths in `stream_score.rs` and `multi_score.rs`
+//! actually compute the requested loss.
 //!
 //! KISS: there is **no** environment-variable override. Unknown values are
 //! rejected at the clap layer with a non-zero exit and a stderr message
 //! listing the supported set.
 
 use clap::ValueEnum;
+use neat_core::network::CompiledNetwork;
 
 /// Built-in NEAT-AI cost function selector.
 ///
@@ -46,11 +48,8 @@ pub enum CostKind {
 
 impl CostKind {
     /// Stable serialised label as a `&'static str`. Matches the TypeScript
-    /// `BUILT_IN_COST_NAMES` strings exactly.
-    // Consumed by tests, benches, and the follow-up dispatch wiring in
-    // #119-3. Suppressed for the `bin "rust_scorer"` compile where the
-    // CLI binary itself only reads the variant, not its rendered label.
-    #[allow(dead_code)]
+    /// `BUILT_IN_COST_NAMES` strings exactly. Used both by tests/benches and
+    /// by Issue #121's `costName` JSON field on `ScoreResult`.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Mse => "MSE",
@@ -87,6 +86,69 @@ impl CostKind {
             supported_list(),
         ))
     }
+}
+
+impl CostKind {
+    /// Issue #121: which costs the GPU `forward_mse_batched` kernel can
+    /// service. Only [`CostKind::Mse`] today — every other cost forces a
+    /// CPU fallback (or a hard error under `--gpu on`).
+    pub const fn gpu_supported(self) -> bool {
+        matches!(self, Self::Mse)
+    }
+}
+
+/// Issue #121 — per-chunk cost dispatch.
+///
+/// Routes a packed `[inputs..., targets...]` chunk to the matching
+/// `*_sum_batch_packed` helper in `neat_core::loss`. The fused streaming
+/// path and the multi-creature directory path both call into this single
+/// dispatch site so adding a future cost is a one-line change here.
+///
+/// Returns `Ok(sum)` — the un-normalised loss sum over every record in
+/// `chunk` — or `Err(message)` when the requested cost is not yet wired
+/// (currently [`CostKind::CategoricalError`], which depends on
+/// `stSoftwareAU/NEAT-AI-core#88` to land first).
+pub fn accumulate_cost_sum(
+    kind: CostKind,
+    network: &mut CompiledNetwork,
+    chunk: &[f32],
+    input_size: usize,
+    num_outputs: usize,
+    forward_only: bool,
+) -> Result<f64, String> {
+    use neat_core::loss;
+    Ok(match kind {
+        CostKind::Mse => {
+            loss::mse_sum_batch_packed(network, chunk, input_size, num_outputs, forward_only)
+        }
+        CostKind::Mae => {
+            loss::mae_sum_batch_packed(network, chunk, input_size, num_outputs, forward_only)
+        }
+        CostKind::Mape => {
+            loss::mape_sum_batch_packed(network, chunk, input_size, num_outputs, forward_only)
+        }
+        CostKind::Msle => {
+            loss::msle_sum_batch_packed(network, chunk, input_size, num_outputs, forward_only)
+        }
+        CostKind::Hinge => {
+            loss::hinge_sum_batch_packed(network, chunk, input_size, num_outputs, forward_only)
+        }
+        CostKind::CrossEntropy => loss::cross_entropy_sum_batch_packed(
+            network,
+            chunk,
+            input_size,
+            num_outputs,
+            forward_only,
+        ),
+        CostKind::CategoricalError => {
+            return Err(
+                "CATEGORICAL_ERROR dispatch is blocked on stSoftwareAU/NEAT-AI-core#88 \
+                 (categorical_error_sum_batch_packed) — rerun with a different --cost \
+                 until that helper lands in neat-core"
+                    .to_string(),
+            );
+        }
+    })
 }
 
 /// Comma-separated list of supported cost names in TypeScript order
@@ -185,6 +247,116 @@ mod tests {
                 .unwrap_or_else(|e| panic!("clap could not parse '{name}': {e}"));
             assert_eq!(parsed, *variant);
         }
+    }
+
+    /// Issue #121: only MSE is GPU-supported today; every other cost must
+    /// run on CPU. Locks the predicate so a future kernel that supports
+    /// more costs has an obvious one-line update + test failure.
+    #[test]
+    fn gpu_supported_only_for_mse() {
+        assert!(CostKind::Mse.gpu_supported());
+        for v in [
+            CostKind::Mae,
+            CostKind::Mape,
+            CostKind::Msle,
+            CostKind::Hinge,
+            CostKind::CrossEntropy,
+            CostKind::CategoricalError,
+        ] {
+            assert!(
+                !v.gpu_supported(),
+                "{} must not be GPU-supported until a new kernel ships",
+                v.as_str()
+            );
+        }
+    }
+
+    /// Issue #121: `CATEGORICAL_ERROR` is currently blocked on the missing
+    /// `categorical_error_sum_batch_packed` upstream in NEAT-AI-core#88.
+    /// Dispatching it must return a clear, actionable error string — not
+    /// panic, not silently compute MSE. Locks that behaviour so once #88
+    /// lands the helper can be swapped in without touching call sites.
+    #[test]
+    fn accumulate_cost_sum_categorical_error_is_blocked() {
+        use neat_core::creature::{compile_creature, parse_creature_json};
+        // Minimal forwardOnly identity creature.
+        let json = r#"{"input":1,"output":1,"forwardOnly":true,"neurons":[
+            {"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}
+        ],"synapses":[
+            {"fromUUID":"input-0","toUUID":"output-0","weight":1.0}
+        ]}"#;
+        let creature = parse_creature_json(json).unwrap();
+        let mut net = compile_creature(&creature).unwrap();
+        let chunk = vec![0.5_f32, 0.5_f32];
+        let err = accumulate_cost_sum(CostKind::CategoricalError, &mut net, &chunk, 1, 1, true)
+            .expect_err("categorical error must be blocked");
+        assert!(
+            err.contains("CATEGORICAL_ERROR") && err.contains("#88"),
+            "error should mention CATEGORICAL_ERROR and #88, got: {err}"
+        );
+    }
+
+    /// Issue #121: dispatching `MSE` via `accumulate_cost_sum` must match
+    /// what `mse_sum_batch_packed` would have produced from the previous
+    /// hard-coded call site, so the existing MSE-only behaviour is
+    /// numerically preserved.
+    #[test]
+    fn accumulate_cost_sum_mse_matches_direct_helper() {
+        use neat_core::creature::{compile_creature, parse_creature_json};
+        use neat_core::loss::mse_sum_batch_packed;
+        let json = r#"{"input":1,"output":1,"forwardOnly":true,"neurons":[
+            {"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}
+        ],"synapses":[
+            {"fromUUID":"input-0","toUUID":"output-0","weight":1.0}
+        ]}"#;
+        let creature = parse_creature_json(json).unwrap();
+        // Two records, [inputs, targets] packed: predict input == target after
+        // identity activation, so MSE here is 0.
+        let chunk = vec![0.5_f32, 0.5_f32, -0.25_f32, -0.25_f32];
+
+        let mut net_a = compile_creature(&creature).unwrap();
+        let direct = mse_sum_batch_packed(&mut net_a, &chunk, 1, 1, true);
+        let mut net_b = compile_creature(&creature).unwrap();
+        let via_dispatch =
+            accumulate_cost_sum(CostKind::Mse, &mut net_b, &chunk, 1, 1, true).unwrap();
+        assert!(
+            (direct - via_dispatch).abs() < 1e-12,
+            "dispatch must match direct mse_sum_batch_packed (direct={direct}, dispatch={via_dispatch})"
+        );
+    }
+
+    /// Issue #121: dispatching `MAE` must call the matching helper. The
+    /// identity creature plus a deliberately mismatched target produces a
+    /// finite, positive sum that MSE alone cannot reproduce — so this also
+    /// asserts that MSE and MAE do not collapse to the same code path.
+    #[test]
+    fn accumulate_cost_sum_mae_diverges_from_mse() {
+        use neat_core::creature::{compile_creature, parse_creature_json};
+        let json = r#"{"input":1,"output":1,"forwardOnly":true,"neurons":[
+            {"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}
+        ],"synapses":[
+            {"fromUUID":"input-0","toUUID":"output-0","weight":1.0}
+        ]}"#;
+        let creature = parse_creature_json(json).unwrap();
+        // Inputs of 2.0 (predicted 2.0 after identity), target 0.5 → |diff|=1.5,
+        // diff^2=2.25 — MAE and MSE must differ.
+        let chunk = vec![2.0_f32, 0.5_f32];
+
+        let mut net_mse = compile_creature(&creature).unwrap();
+        let mse = accumulate_cost_sum(CostKind::Mse, &mut net_mse, &chunk, 1, 1, true).unwrap();
+        let mut net_mae = compile_creature(&creature).unwrap();
+        let mae = accumulate_cost_sum(CostKind::Mae, &mut net_mae, &chunk, 1, 1, true).unwrap();
+        assert!(
+            mse > 0.0 && mae > 0.0,
+            "both should be positive: mse={mse}, mae={mae}"
+        );
+        assert!(
+            (mse - mae).abs() > 1e-6,
+            "MSE and MAE must take different code paths (mse={mse}, mae={mae})"
+        );
+        // MAE(0.5)=1.5, MSE(0.5)=2.25 — confirm shape rather than exact equality
+        // (the helpers may normalise by num_outputs internally).
+        assert!(mse > mae, "for |diff|=1.5 > 1, MSE > MAE");
     }
 
     /// Issue #120 explicitly forbids an environment-variable override.

--- a/rust_scorer/src/gpu/mod.rs
+++ b/rust_scorer/src/gpu/mod.rs
@@ -186,7 +186,7 @@ pub enum ScoringPath {
 }
 
 /// Whether [`GpuMode::Auto`] should pick the GPU pipeline for the given
-/// scoring path.
+/// scoring path **and cost kind** (Issue #121).
 ///
 /// This is the codified ship/skip decision from Issue #83 — call sites in
 /// `main.rs` consult it instead of hard-coding "directory ⇒ GPU,
@@ -197,11 +197,18 @@ pub enum ScoringPath {
 /// Returns `true` only when:
 /// 1. The bench evidence supports GPU at `BENCH_SCORING_BYTES=200000000`
 ///    being ≥ 3 % faster than CPU+PGO for the path, **and**
-/// 2. The CPU↔GPU parity tolerance from #81 holds for the kernel.
+/// 2. The CPU↔GPU parity tolerance from #81 holds for the kernel, **and**
+/// 3. The requested cost is one the GPU kernel actually implements
+///    ([`crate::cost::CostKind::gpu_supported`] — currently MSE only).
 ///
 /// `false` for every path means "no GPU paths shipped as default" — i.e. the
 /// negative-result outcome from the Performance Task Workflow.
-pub fn auto_should_use_gpu(path: ScoringPath) -> bool {
+pub fn auto_should_use_gpu(path: ScoringPath, cost: crate::cost::CostKind) -> bool {
+    // Issue #121: the GPU `forward_mse_batched` kernel only computes MSE.
+    // Any other cost forces a silent CPU fallback under Auto.
+    if !cost.gpu_supported() {
+        return false;
+    }
     match path {
         // #81 — negative result. CPU+PGO wins on the single-creature path.
         ScoringPath::SingleCreature => false,
@@ -349,14 +356,41 @@ mod tests {
         // Issue #81 closed as a negative result — single-creature GPU lost
         // to CPU+PGO at the issue-target corpus size, so Auto must keep this
         // path on CPU.
-        assert!(!auto_should_use_gpu(ScoringPath::SingleCreature));
+        assert!(!auto_should_use_gpu(
+            ScoringPath::SingleCreature,
+            crate::cost::CostKind::Mse
+        ));
     }
 
     #[test]
     fn auto_should_use_gpu_directory_uses_gpu() {
         // Issue #82 — multi-creature batched dispatch at N=50 / 200 MB beat
         // CPU+PGO by ≥ 30 % on Apple Silicon Metal, well above the 3 % bar.
-        assert!(auto_should_use_gpu(ScoringPath::CreatureDirectory));
+        assert!(auto_should_use_gpu(
+            ScoringPath::CreatureDirectory,
+            crate::cost::CostKind::Mse
+        ));
+    }
+
+    /// Issue #121: Auto must keep the directory path on CPU when the
+    /// requested cost is not one the GPU kernel implements — today that
+    /// means every cost except MSE forces CPU fallback.
+    #[test]
+    fn auto_should_use_gpu_directory_falls_back_to_cpu_for_non_mse_costs() {
+        for cost in [
+            crate::cost::CostKind::Mae,
+            crate::cost::CostKind::Mape,
+            crate::cost::CostKind::Msle,
+            crate::cost::CostKind::Hinge,
+            crate::cost::CostKind::CrossEntropy,
+            crate::cost::CostKind::CategoricalError,
+        ] {
+            assert!(
+                !auto_should_use_gpu(ScoringPath::CreatureDirectory, cost),
+                "Auto must fall back to CPU for non-MSE cost {} until a kernel ships",
+                cost.as_str()
+            );
+        }
     }
 
     #[test]

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -134,7 +134,11 @@ fn resolve_inputs(cli: &Cli) -> Result<(String, PathBuf), String> {
 }
 
 enum RunOutput {
-    Single(ScoreResult),
+    // Issue #121: `ScoreResult` now also carries `cost_name: String`. The
+    // total variant size crossed clippy's `large_enum_variant` threshold,
+    // so box the single-creature payload — `Multi` is already a `BTreeMap`
+    // (one heap pointer) and stays small.
+    Single(Box<ScoreResult>),
     Multi(BTreeMap<String, ScoreResult>),
 }
 
@@ -166,15 +170,29 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         },
     };
 
+    // Issue #121: `--gpu on --cost X != MSE` is a hard error — the GPU kernel
+    // only knows how to compute MSE today, so silently downgrading would
+    // produce a wrong scoring result. `--gpu auto` (the default) falls back
+    // to CPU instead; `--gpu off` never touches the GPU and is fine.
+    if matches!(mode, GpuMode::On) && !cli.cost.gpu_supported() {
+        return Err(format!(
+            "GPU kernel not implemented for cost {}: forward_mse_batched only handles MSE \
+             (use --gpu auto to silently fall back to CPU, or --gpu off to skip GPU detection)",
+            cli.cost.as_str()
+        ));
+    }
+
     // Issue #83 — codified ship/skip decision. `auto_should_use_gpu` is the
     // single source of truth for which paths default to GPU under Auto mode;
     // `On` bypasses it (the user explicitly demanded GPU even where bench
     // evidence does not support it), `Off` skipped GPU detection above.
+    // Issue #121 extends the predicate with the resolved cost so non-MSE
+    // costs under `--gpu auto` route to the CPU path.
     let want_gpu_for_path = |path: ScoringPath| -> bool {
         match mode {
             GpuMode::Off => false,
             GpuMode::On => true,
-            GpuMode::Auto => auto_should_use_gpu(path),
+            GpuMode::Auto => auto_should_use_gpu(path, cli.cost),
         }
     };
 
@@ -190,7 +208,7 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
             GpuBackendLabel::CpuFallback,
             cli.cost,
         )
-        .map(RunOutput::Single);
+        .map(|r| RunOutput::Single(Box::new(r)));
     }
 
     if cli.args.len() != 2 {
@@ -253,7 +271,7 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
             GpuBackendLabel::CpuFallback,
             cli.cost,
         )
-        .map(RunOutput::Single)
+        .map(|r| RunOutput::Single(Box::new(r)))
     }
 }
 
@@ -261,11 +279,10 @@ fn score_from_json(
     creature_json: &str,
     data_path: &Path,
     gpu_backend: GpuBackendLabel,
-    // Issue #120 — resolved cost selector. Dispatch lands in #119-3;
-    // the parameter is accepted now so the CLI contract is stable and
-    // every scoring entry point has a uniform signature. The MSE path
-    // continues to call `mse_sum_batch_packed` regardless of the value.
-    _cost: CostKind,
+    // Issue #121 — resolved cost selector. Dispatched through the fused
+    // streaming path for `forwardOnly` creatures and through a per-record
+    // `accumulate_cost_sum` call for recurrent creatures.
+    cost: CostKind,
 ) -> Result<ScoreResult, String> {
     let started = Instant::now();
     let creature = parse_creature_json(creature_json)?;
@@ -315,8 +332,9 @@ fn score_from_json(
 
     let (total_error, record_count, parallel_activation_batches, max_activation_batch_records) =
         if use_fused_stream {
-            let (mse_sum, count, parallel_batches, max_batch, clone_secs) =
-                stream_score::accumulate_mse_sum_forward_only_fused(
+            let (loss_sum, count, parallel_batches, max_batch, clone_secs) =
+                stream_score::accumulate_cost_sum_forward_only_fused(
+                    cost,
                     &bin_files,
                     &config,
                     &creature,
@@ -327,35 +345,35 @@ fn score_from_json(
             }
             // Per-worker clones run inside the fused accumulator; bundle them into compile time.
             compile_time_secs += clone_secs;
-            (mse_sum, count, parallel_batches, max_batch)
+            (loss_sum, count, parallel_batches, max_batch)
         } else {
+            // Recurrent / non-forward-only path. Issue #121: dispatch the
+            // requested cost on a per-record packed buffer so every supported
+            // CostKind works here too. The `forward_only = false` arg to
+            // `accumulate_cost_sum` makes the underlying helper reset the
+            // network state per record, matching the explicit `reset_state()`
+            // the old MSE-only loop used to call.
             let mut iter = TrainingDataIterator::new(data_path, config.clone())
                 .map_err(|e| format!("Failed to open training data iterator: {e}"))?;
             let mut total_error = 0.0_f64;
             let mut record_count: usize = 0;
-            let mut output_buf = vec![0.0_f32; num_outputs];
-            let inv_outputs = if num_outputs > 0 {
-                1.0_f64 / num_outputs as f64
-            } else {
-                0.0
-            };
+            let mut packed: Vec<f32> = Vec::with_capacity(creature.input + num_outputs);
 
             while let Some(record) = iter
                 .next_record()
                 .map_err(|e| format!("Failed reading training record: {e}"))?
             {
-                network.reset_state();
-                let outputs = network.activate(&record.inputs, num_outputs);
-                output_buf.copy_from_slice(&outputs);
-                // Per-record MSE = mean over outputs of (target - output)^2.
-                // Computed inline to keep the recurrent loop independent of
-                // `mse_mean_record`'s packed/batched signature in NEAT-AI-core.
-                let mut sq_sum = 0.0_f64;
-                for (target, predicted) in record.outputs.iter().zip(output_buf.iter()) {
-                    let diff = (*target - *predicted) as f64;
-                    sq_sum += diff * diff;
-                }
-                total_error += sq_sum * inv_outputs;
+                packed.clear();
+                packed.extend_from_slice(&record.inputs);
+                packed.extend_from_slice(&record.outputs);
+                total_error += cost::accumulate_cost_sum(
+                    cost,
+                    &mut network,
+                    &packed,
+                    creature.input,
+                    num_outputs,
+                    false,
+                )?;
                 record_count += 1;
             }
 
@@ -407,6 +425,7 @@ fn score_from_json(
         gpu_kernel: None,
         gpu_inflight_chunks: None,
         gpu_dispatch_count: None,
+        cost_name: cost.as_str().to_string(),
     })
 }
 
@@ -436,7 +455,7 @@ mod tests {
     use super::*;
     fn run_single(cli: &Cli) -> Result<ScoreResult, String> {
         match run(cli)? {
-            RunOutput::Single(result) => Ok(result),
+            RunOutput::Single(result) => Ok(*result),
             RunOutput::Multi(_) => Err("Expected single-creature output".to_string()),
         }
     }
@@ -679,6 +698,7 @@ mod tests {
             gpu_kernel: None,
             gpu_inflight_chunks: None,
             gpu_dispatch_count: None,
+            cost_name: "MSE".to_string(),
         };
         let json = serde_json::to_string_pretty(&result).unwrap();
         // Verify camelCase keys in output
@@ -701,6 +721,13 @@ mod tests {
         assert!(json.contains("\"parallelActivationBatches\""));
         assert!(json.contains("\"maxActivationBatchRecords\""));
         assert!(json.contains("\"compileTimeSecs\""));
+        // Issue #121: costName must be serialised so the TS bridge can
+        // confirm the resolved cost.
+        assert!(
+            json.contains("\"costName\""),
+            "expected costName in JSON, got: {json}"
+        );
+        assert!(json.contains("\"MSE\""), "expected costName value 'MSE'");
     }
 
     /// Stdin mode must yield the same `ScoreResult` as the default file mode.

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -30,13 +30,12 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use neat_core::creature::{CreatureExport, compile_creature, parse_creature_json};
-use neat_core::loss::mse_sum_batch_packed;
 use neat_core::network::CompiledNetwork;
 use neat_core::training_bin_stream::for_each_read_chunk;
 use neat_core::training_data::{TrainingDataConfig, find_bin_files};
 use rayon::prelude::*;
 
-use crate::cost::CostKind;
+use crate::cost::{CostKind, accumulate_cost_sum};
 use crate::gpu::forward_mse_batched::BatchedRunner;
 use crate::gpu::{GpuBackendLabel, GpuContext};
 use crate::read_tuning::{training_read_backend_label, training_read_target_bytes_from_env};
@@ -247,10 +246,9 @@ pub fn score_from_creature_dir(
     creatures_dir: &Path,
     data_path: &Path,
     gpu_backend: GpuBackendLabel,
-    // Issue #120 — resolved cost selector; dispatch lands in #119-3. Held
-    // here so the CPU directory entry point has the same signature as the
-    // single-creature and GPU paths.
-    _cost: CostKind,
+    // Issue #121 — resolved cost selector; dispatched through
+    // [`accumulate_cost_sum`] inside the per-chunk hot loop.
+    cost: CostKind,
 ) -> Result<BTreeMap<String, ScoreResult>, String> {
     let started = Instant::now();
     let loaded = load_creatures_from_dir(creatures_dir)?;
@@ -337,6 +335,22 @@ pub fn score_from_creature_dir(
     }
     let compile_time_secs = compile_started.elapsed().as_secs_f64();
 
+    // Issue #121: validate that the requested cost is dispatchable before
+    // entering the I/O loop. The probe uses an empty chunk — all supported
+    // costs short-circuit to 0.0 on zero records, while blocked variants
+    // (CATEGORICAL_ERROR pending NEAT-AI-core#88) surface their error here
+    // before any bytes are read.
+    if !flat_networks.is_empty() {
+        accumulate_cost_sum(
+            cost,
+            &mut flat_networks[0],
+            &[],
+            num_inputs,
+            num_outputs,
+            true,
+        )?;
+    }
+
     let mut pending: Vec<u8> = Vec::new();
     let mut head: usize = 0;
     let mut unpack_floats: Vec<f32> = Vec::new();
@@ -374,19 +388,24 @@ pub fn score_from_creature_dir(
 
         // Single flat par_iter over the worker pool — this is the only
         // Rayon parallel layer in the per-chunk hot path (Issue #41).
+        // Issue #121: dispatch on the resolved cost; cost was validated
+        // up-front (see the empty-chunk probe before the I/O loop) so the
+        // inner `.expect` cannot fire for supported variants.
         flat_networks
             .par_iter_mut()
             .zip(worker_sums.par_iter_mut())
             .enumerate()
             .for_each(|(worker_idx, (net, sum))| {
                 if let Some(range) = &work_ranges[worker_idx] {
-                    *sum = mse_sum_batch_packed(
+                    *sum = accumulate_cost_sum(
+                        cost,
                         net,
                         &floats[range.clone()],
                         num_inputs,
                         num_outputs,
                         true,
-                    );
+                    )
+                    .expect("cost validated before per-chunk dispatch");
                 } else {
                     *sum = 0.0;
                 }
@@ -508,6 +527,7 @@ pub fn score_from_creature_dir(
                 gpu_kernel: None,
                 gpu_inflight_chunks: None,
                 gpu_dispatch_count: None,
+                cost_name: cost.as_str().to_string(),
             },
         );
     }
@@ -541,10 +561,19 @@ pub fn score_from_creature_dir_gpu(
     gpu_backend: GpuBackendLabel,
     ctx: Arc<GpuContext>,
     inflight_chunks: usize,
-    // Issue #120 — resolved cost selector; dispatch lands in #119-3. The
-    // GPU `forward_mse_batched` kernel keeps computing MSE for now.
-    _cost: CostKind,
+    // Issue #121 — the GPU `forward_mse_batched` kernel only computes MSE.
+    // Any other cost is a hard error here; callers under `--gpu auto` are
+    // expected to detect this via [`crate::gpu::auto_should_use_gpu`] and
+    // route to the CPU path instead.
+    cost: CostKind,
 ) -> Result<BTreeMap<String, ScoreResult>, String> {
+    if !cost.gpu_supported() {
+        return Err(format!(
+            "GPU kernel not implemented for cost {}: forward_mse_batched only handles MSE \
+             (use --gpu auto for silent CPU fallback, or --gpu off to skip GPU entirely)",
+            cost.as_str()
+        ));
+    }
     let started = Instant::now();
     let loaded = load_creatures_from_dir(creatures_dir)?;
 
@@ -777,6 +806,7 @@ pub fn score_from_creature_dir_gpu(
                 gpu_kernel: Some("forward_mse_batched".to_string()),
                 gpu_inflight_chunks: Some(inflight_chunks),
                 gpu_dispatch_count: Some(dispatch_count),
+                cost_name: cost.as_str().to_string(),
             },
         );
     }

--- a/rust_scorer/src/scoring.rs
+++ b/rust_scorer/src/scoring.rs
@@ -236,6 +236,12 @@ pub struct ScoreResult {
     /// Issue #42: useful for diagnosing how much of `timeTaken` is fixed startup vs scoring.
     #[serde(rename = "compileTimeSecs", skip_serializing_if = "Option::is_none")]
     pub compile_time_secs: Option<f64>,
+    /// Issue #121: the resolved cost-function name that scoring actually
+    /// applied (one of `BUILT_IN_COST_NAMES`). Lets the TS bridge confirm
+    /// `--cost` was honoured by the scorer rather than silently downgraded
+    /// to MSE.
+    #[serde(rename = "costName")]
+    pub cost_name: String,
     /// Issue #82: name of the GPU compute kernel used for this run (e.g.
     /// `"forward_mse_batched"`). Absent when the run executed on CPU.
     #[serde(rename = "gpuKernel", skip_serializing_if = "Option::is_none")]

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -15,9 +15,9 @@
 
 use std::time::Instant;
 
+use crate::cost::{CostKind, accumulate_cost_sum};
 use crate::read_tuning::{MAX_READ_BYTES, training_read_target_bytes_from_env};
 use neat_core::creature::CreatureExport;
-use neat_core::loss::mse_sum_batch_packed;
 use neat_core::network::CompiledNetwork;
 use neat_core::training_bin_stream::for_each_read_chunk;
 use neat_core::training_data::TrainingDataConfig;
@@ -149,15 +149,19 @@ fn compact_pending_if_needed(pending: &mut Vec<u8>, head: &mut usize) {
     *head = 0;
 }
 
-/// Accumulate fused MSE sums over all `.bin` files using env-tuned chunked reads.
+/// Accumulate fused cost-function sums over all `.bin` files using env-tuned
+/// chunked reads. Issue #121 generalises this from MSE-only to dispatch via
+/// [`accumulate_cost_sum`] so every supported [`CostKind`] runs through the
+/// same I/O envelope.
 ///
-/// Returns `(mse_sum, record_count, parallel_activation_batches, max_records_per_batch, clone_time_secs)`.
+/// Returns `(loss_sum, record_count, parallel_activation_batches, max_records_per_batch, clone_time_secs)`.
 /// `clone_time_secs` covers any per-worker `CompiledNetwork` clones for activation parallelism
 /// (always `0.0` when `activation_threads <= 1`). The fourth value is the largest `n_records`
 /// seen in one activation call (diagnostic: if it stays `1` while `parallel_activation_batches`
 /// is `0`, each read chunk holds at most one full record — raise **`NEAT_SCORER_READ_BYTES`**
 /// so multiple records fit in `pending` at once).
-pub fn accumulate_mse_sum_forward_only_fused(
+pub fn accumulate_cost_sum_forward_only_fused(
+    cost: CostKind,
     bin_files: &[std::path::PathBuf],
     config: &TrainingDataConfig,
     _creature: &CreatureExport,
@@ -167,6 +171,19 @@ pub fn accumulate_mse_sum_forward_only_fused(
     if record_bytes == 0 {
         return Err("Invalid record byte length (zero)".to_string());
     }
+
+    // Issue #121: validate the cost is dispatchable up-front so the inner
+    // par_iter can safely use `accumulate_cost_sum(...).unwrap()` — if the
+    // cost is blocked (e.g. CATEGORICAL_ERROR pending NEAT-AI-core#88) we
+    // surface the error before reading a single byte.
+    accumulate_cost_sum(
+        cost,
+        network,
+        &[],
+        config.num_inputs,
+        config.num_outputs,
+        true,
+    )?;
 
     let values_per_record = config.num_inputs + config.num_outputs;
     let target_read_bytes = training_read_target_bytes_from_env(record_bytes);
@@ -236,32 +253,40 @@ pub fn accumulate_mse_sum_forward_only_fused(
                                 .par_iter_mut()
                                 .zip(slices)
                                 .map(|(net, slice)| {
-                                    mse_sum_batch_packed(
+                                    // SAFETY: cost validated above — only
+                                    // dispatchable variants reach this point.
+                                    accumulate_cost_sum(
+                                        cost,
                                         net,
                                         slice,
                                         config.num_inputs,
                                         config.num_outputs,
                                         true,
                                     )
+                                    .expect("cost validated before stream loop")
                                 })
                                 .sum()
                         } else {
-                            mse_sum_batch_packed(
+                            accumulate_cost_sum(
+                                cost,
                                 network,
                                 &unpack_floats,
                                 config.num_inputs,
                                 config.num_outputs,
                                 true,
                             )
+                            .expect("cost validated before stream loop")
                         }
                     }
-                    None => mse_sum_batch_packed(
+                    None => accumulate_cost_sum(
+                        cost,
                         network,
                         &unpack_floats,
                         config.num_inputs,
                         config.num_outputs,
                         true,
-                    ),
+                    )
+                    .expect("cost validated before stream loop"),
                 };
                 total_mse_sum += chunk_sum;
             }
@@ -313,32 +338,38 @@ pub fn accumulate_mse_sum_forward_only_fused(
                             .par_iter_mut()
                             .zip(slices)
                             .map(|(net, slice)| {
-                                mse_sum_batch_packed(
+                                accumulate_cost_sum(
+                                    cost,
                                     net,
                                     slice,
                                     config.num_inputs,
                                     config.num_outputs,
                                     true,
                                 )
+                                .expect("cost validated before stream loop")
                             })
                             .sum()
                     } else {
-                        mse_sum_batch_packed(
+                        accumulate_cost_sum(
+                            cost,
                             network,
                             &unpack_floats,
                             config.num_inputs,
                             config.num_outputs,
                             true,
                         )
+                        .expect("cost validated before stream loop")
                     }
                 }
-                None => mse_sum_batch_packed(
+                None => accumulate_cost_sum(
+                    cost,
                     network,
                     &unpack_floats,
                     config.num_inputs,
                     config.num_outputs,
                     true,
-                ),
+                )
+                .expect("cost validated before stream loop"),
             };
             total_mse_sum += chunk_sum;
             head += complete_len;

--- a/rust_scorer/tests/scorer_smoke.rs
+++ b/rust_scorer/tests/scorer_smoke.rs
@@ -608,12 +608,16 @@ fn scorer_binary_cost_mse_matches_default() {
     );
 }
 
-/// Issue #120: `--cost MAE` must parse cleanly and still compute MSE for now
-/// (dispatch lands in #119-3). Asserts the binary exits 0 and emits the
-/// same numeric result as MSE — proves the plumbing accepts the flag and
-/// has not changed the calculation yet.
+/// Issue #121 update: `--cost MAE` now dispatches the real MAE helper
+/// (previously this asserted MAE silently computed MSE while dispatch was
+/// pending). The fixture is an identity creature whose predictions exactly
+/// match the targets, so both MSE and MAE produce 0.0 error — that gives
+/// us a stable numerical equality without needing different fixtures per
+/// cost, while still proving the binary accepts and runs `--cost MAE` end
+/// to end. The `costName` JSON field must echo `"MAE"` so downstream
+/// callers can confirm dispatch.
 #[test]
-fn scorer_binary_cost_mae_parses_and_runs_as_mse() {
+fn scorer_binary_cost_mae_runs_through_dispatch() {
     let bin = env!("CARGO_BIN_EXE_rust_scorer");
     let creature = fixture("identity_creature.json");
     let data_dir = fixture_data_dir("identity_data.bin");
@@ -628,6 +632,11 @@ fn scorer_binary_cost_mae_parses_and_runs_as_mse() {
     assert!(baseline.status.success());
     let baseline_json: serde_json::Value =
         serde_json::from_slice(&baseline.stdout).expect("baseline stdout is JSON");
+    assert_eq!(
+        baseline_json.get("costName").and_then(|v| v.as_str()),
+        Some("MSE"),
+        "MSE run must report costName=MSE"
+    );
 
     let with_mae = Command::new(bin)
         .arg("--cost")
@@ -645,29 +654,34 @@ fn scorer_binary_cost_mae_parses_and_runs_as_mse() {
     let mae_json: serde_json::Value =
         serde_json::from_slice(&with_mae.stdout).expect("--cost MAE stdout is JSON");
 
-    // Identical numeric result: dispatch lands in #119-3, this PR only
-    // wires the CLI surface.
+    // Identity fixture: every prediction equals its target so both costs
+    // evaluate to exactly 0.0, regardless of which dispatch path ran.
     assert_eq!(baseline_json.get("error"), mae_json.get("error"));
     assert_eq!(baseline_json.get("score"), mae_json.get("score"));
+    assert_eq!(
+        mae_json.get("costName").and_then(|v| v.as_str()),
+        Some("MAE"),
+        "MAE run must report costName=MAE"
+    );
 }
 
-/// Issue #120: every built-in cost name must parse and run cleanly
-/// (still computing MSE until #119-3 lands).
+/// Issue #121 update: every regression-friendly cost (MSE, MAE, MAPE,
+/// MSLE, HINGE) must now run end-to-end through real dispatch and report
+/// its name in `costName`. `CROSS_ENTROPY` is excluded here because the
+/// shared identity fixture contains negative targets, which is not a
+/// valid probability — neat-core happily computes a (negative) CE there
+/// but the scorer's `error >= 0` invariant in `calculate_score` then
+/// fails. A dedicated `[0, 1]`-target fixture exercises CE separately
+/// below. `CATEGORICAL_ERROR` is blocked at runtime pending
+/// `stSoftwareAU/NEAT-AI-core#88` and is exercised by yet another
+/// dedicated test.
 #[test]
-fn scorer_binary_accepts_every_built_in_cost_name() {
+fn scorer_binary_accepts_every_dispatchable_built_in_cost_name() {
     let bin = env!("CARGO_BIN_EXE_rust_scorer");
     let creature = fixture("identity_creature.json");
     let data_dir = fixture_data_dir("identity_data.bin");
 
-    for name in [
-        "MSE",
-        "MAE",
-        "MAPE",
-        "MSLE",
-        "HINGE",
-        "CROSS_ENTROPY",
-        "CATEGORICAL_ERROR",
-    ] {
+    for name in ["MSE", "MAE", "MAPE", "MSLE", "HINGE"] {
         let out = Command::new(bin)
             .arg("--cost")
             .arg(name)
@@ -681,7 +695,188 @@ fn scorer_binary_accepts_every_built_in_cost_name() {
             out.status.code(),
             String::from_utf8_lossy(&out.stderr),
         );
+        let json: serde_json::Value =
+            serde_json::from_slice(&out.stdout).expect("stdout must be JSON");
+        assert_eq!(
+            json.get("costName").and_then(|v| v.as_str()),
+            Some(name),
+            "--cost {name} must echo costName={name}"
+        );
     }
+}
+
+/// Issue #121: `--cost CROSS_ENTROPY` must run end-to-end against a
+/// `[0, 1]`-probability fixture (where the loss is well-defined) and
+/// report `costName=CROSS_ENTROPY`. This is the dedicated CE counterpart
+/// to the regression-friendly dispatchable-costs test above, exercising
+/// the LOGISTIC squash so outputs stay in `(0, 1)`.
+#[test]
+fn scorer_binary_cost_cross_entropy_runs_on_probabilistic_fixture() {
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let tmp = TempDir::new().expect("create tempdir");
+
+    // Logistic-output creature so predictions stay in (0, 1).
+    let creature_json = r#"{
+        "input": 1,
+        "output": 1,
+        "forwardOnly": true,
+        "semanticVersion": "4.0.0",
+        "neurons": [
+            {"type": "output", "uuid": "output-0", "bias": 0.0, "squash": "LOGISTIC"}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "output-0", "weight": 1.0}
+        ]
+    }"#;
+    let creature_path = tmp.path().join("creature.json");
+    std::fs::write(&creature_path, creature_json).expect("write creature.json");
+
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir(&data_dir).expect("create data dir");
+    let mut bin_file = std::fs::File::create(data_dir.join("0.bin")).expect("create 0.bin");
+    // [inputs..., targets...] packed records, targets ∈ [0, 1].
+    let records: &[(f32, f32)] = &[(0.5, 0.6), (1.0, 0.9), (-1.0, 0.1), (2.0, 0.8)];
+    for (input, target) in records {
+        bin_file.write_all(&input.to_le_bytes()).unwrap();
+        bin_file.write_all(&target.to_le_bytes()).unwrap();
+    }
+    drop(bin_file);
+
+    let out = Command::new(bin)
+        .arg("--cost")
+        .arg("CROSS_ENTROPY")
+        .arg(&creature_path)
+        .arg(&data_dir)
+        .output()
+        .expect("failed to spawn rust_scorer (--cost CROSS_ENTROPY)");
+    assert!(
+        out.status.success(),
+        "--cost CROSS_ENTROPY must succeed on a [0,1] fixture, got status {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout must be JSON");
+    assert_eq!(
+        json.get("costName").and_then(|v| v.as_str()),
+        Some("CROSS_ENTROPY"),
+        "CE run must echo costName=CROSS_ENTROPY"
+    );
+    let error = json
+        .get("error")
+        .and_then(|v| v.as_f64())
+        .expect("error must be a number");
+    assert!(
+        error.is_finite() && error >= 0.0,
+        "CE error must be non-negative and finite, got {error}"
+    );
+}
+
+/// Issue #121: `--cost CATEGORICAL_ERROR` must surface a clear runtime
+/// error referencing the upstream dependency (`NEAT-AI-core#88`) rather
+/// than silently falling back to MSE. Once `categorical_error_sum_batch_packed`
+/// lands, this test will fail and can be updated to assert the success
+/// path alongside the others.
+#[test]
+fn scorer_binary_categorical_error_is_blocked_with_helpful_message() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    let out = Command::new(bin)
+        .arg("--cost")
+        .arg("CATEGORICAL_ERROR")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer (--cost CATEGORICAL_ERROR)");
+    assert!(
+        !out.status.success(),
+        "--cost CATEGORICAL_ERROR must exit non-zero while NEAT-AI-core#88 is pending"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("CATEGORICAL_ERROR"),
+        "stderr must mention CATEGORICAL_ERROR, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("#88"),
+        "stderr must reference the blocking upstream issue #88, got: {stderr}"
+    );
+}
+
+/// Issue #121: `--gpu on --cost MAE` must hard-error because the
+/// `forward_mse_batched` kernel has no MAE implementation. The error
+/// message must name the cost so the user can recover by switching mode
+/// or cost.
+#[test]
+fn scorer_binary_gpu_on_with_non_mse_cost_errors() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    let out = Command::new(bin)
+        .arg("--gpu")
+        .arg("on")
+        .arg("--cost")
+        .arg("MAE")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer (--gpu on --cost MAE)");
+    assert!(
+        !out.status.success(),
+        "--gpu on --cost MAE must exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MAE") && stderr.contains("GPU"),
+        "stderr must mention MAE and GPU, got: {stderr}"
+    );
+}
+
+/// Issue #121: `--gpu auto --cost MAE` must complete successfully on
+/// CPU. Whether or not a GPU is available, an unsupported cost forces
+/// the silent fallback path — `gpuBackend` should report `cpu-fallback`
+/// because no GPU kernel ran.
+#[test]
+fn scorer_binary_gpu_auto_with_non_mse_cost_runs_on_cpu() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+    let data_dir = fixture_data_dir("identity_data.bin");
+
+    let out = Command::new(bin)
+        .arg("--gpu")
+        .arg("auto")
+        .arg("--cost")
+        .arg("MAE")
+        .arg(&creature)
+        .arg(data_dir.path())
+        .output()
+        .expect("failed to spawn rust_scorer (--gpu auto --cost MAE)");
+    assert!(
+        out.status.success(),
+        "--gpu auto --cost MAE must succeed via CPU fallback, got status {:?}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout must be JSON");
+    assert_eq!(
+        json.get("costName").and_then(|v| v.as_str()),
+        Some("MAE"),
+        "auto/MAE run must echo costName=MAE"
+    );
+    // The single-creature path always reports `cpu-fallback` in `gpuBackend`
+    // because Issue #81 closed without a single-creature GPU kernel — that
+    // is independent of `--cost`, but lock it in here as part of the
+    // contract anyway.
+    assert_eq!(
+        json.get("gpuBackend").and_then(|v| v.as_str()),
+        Some("cpu-fallback"),
+        "non-MSE cost must run on CPU; gpuBackend should be cpu-fallback"
+    );
 }
 
 /// Issue #120: an unknown `--cost` value must produce a non-zero exit


### PR DESCRIPTION
# Wire CostKind dispatch through stream_score and multi_score (Closes #121)

## Summary

Issue #121 wires the `--cost <NAME>` selector added in #120 through to the
per-chunk loss accumulator so the fused single-creature path
(`stream_score.rs`) and the directory/batch path (`multi_score.rs`) actually
compute the requested NEAT-AI built-in cost instead of always running MSE.

- New `accumulate_cost_sum(kind, net, chunk, input_size, num_outputs, forward_only)`
  in `rust_scorer::cost` dispatches a packed `[inputs..., targets...]`
  chunk to the matching `neat_core::loss::*_sum_batch_packed` helper. MSE,
  MAE, MAPE, MSLE, HINGE, and CROSS_ENTROPY all route here.
- `accumulate_mse_sum_forward_only_fused` is renamed to
  `accumulate_cost_sum_forward_only_fused` and now takes a `CostKind`. The
  multi-creature directory path threads `CostKind` through to the same
  dispatch site.
- CATEGORICAL_ERROR is a hard runtime error referencing
  `stSoftwareAU/NEAT-AI-core#88` — the underlying
  `categorical_error_sum_batch_packed` helper has not yet landed in
  `neat-core` (the issue is open). Once it merges, the dispatch is a
  one-line change.
- GPU dispatch is gated: `auto_should_use_gpu` now also takes the
  `CostKind`, returning `false` for any cost other than MSE.
  `--gpu on --cost X != MSE` hard-errors at the CLI layer; `--gpu auto`
  silently falls back to the CPU pipeline.
- `ScoreResult` gains a `costName: String` field (serialised as
  `"costName"`) populated from the resolved `CostKind`, so the TS bridge
  can confirm which loss was actually applied.
- The recurrent (non-`forwardOnly`) single-creature path now also routes
  through `accumulate_cost_sum`, packing one record at a time and
  passing `forward_only = false` so the helper resets network state per
  record (matching the old hand-rolled loop).

Closes #121.

## Evidence

Pure backend/CLI change — no UI to screenshot. Verified via the full
quality gate:

- `./quality.sh` passes cleanly (shellcheck, fmt, clippy with
  `-D warnings`, cargo-deny, build, all tests, rustdoc, release build).
- 75 unit tests pass (rust_scorer lib + bin), 20 smoke tests, 5
  directory-mode TDD tests, 3 GPU parity tests.

### Dispatch flow

```mermaid
flowchart LR
    Cli["--cost CostKind"] --> Validate{forwardOnly?}
    Validate -- "yes" --> Fused["accumulate_cost_sum_forward_only_fused"]
    Validate -- "no" --> PerRecord["per-record packed buffer"]
    Fused --> Dispatch{accumulate_cost_sum}
    PerRecord --> Dispatch
    Dispatch -- "MSE" --> MSE["mse_sum_batch_packed"]
    Dispatch -- "MAE" --> MAE["mae_sum_batch_packed"]
    Dispatch -- "MAPE" --> MAPE["mape_sum_batch_packed"]
    Dispatch -- "MSLE" --> MSLE["msle_sum_batch_packed"]
    Dispatch -- "HINGE" --> HINGE["hinge_sum_batch_packed"]
    Dispatch -- "CROSS_ENTROPY" --> CE["cross_entropy_sum_batch_packed"]
    Dispatch -- "CATEGORICAL_ERROR" --> Blocked["Err: requires NEAT-AI-core#88"]
    MSE --> GPU{cost == MSE?}
    GPU -- "yes" --> GpuKernel["forward_mse_batched"]
    GPU -- "no" --> CpuOnly["CPU fallback"]
```

## Test Plan

New tests added:

- `rust_scorer/src/cost.rs`:
  - `gpu_supported_only_for_mse` — locks the GPU-cost predicate to MSE.
  - `accumulate_cost_sum_categorical_error_is_blocked` — asserts
    CATEGORICAL_ERROR returns an `Err` mentioning `#88`.
  - `accumulate_cost_sum_mse_matches_direct_helper` — MSE dispatch
    numerically equals `mse_sum_batch_packed` directly (regression
    check on existing fixtures).
  - `accumulate_cost_sum_mae_diverges_from_mse` — proves MAE takes a
    different code path from MSE for `|diff| > 1`.
- `rust_scorer/src/gpu/mod.rs`:
  - `auto_should_use_gpu_directory_falls_back_to_cpu_for_non_mse_costs`
    — every non-MSE variant forces CPU fallback under Auto.
- `rust_scorer/tests/scorer_smoke.rs`:
  - `scorer_binary_accepts_every_dispatchable_built_in_cost_name` —
    end-to-end runs MSE, MAE, MAPE, MSLE, HINGE on the identity
    fixture and asserts each echoes `costName=<NAME>` (CE is exercised
    separately because the fixture has negative targets).
  - `scorer_binary_cost_cross_entropy_runs_on_probabilistic_fixture` —
    builds a `[0, 1]`-target fixture and asserts CE runs cleanly with
    `costName=CROSS_ENTROPY` and a non-negative error.
  - `scorer_binary_categorical_error_is_blocked_with_helpful_message`
    — stderr names CATEGORICAL_ERROR and references issue #88.
  - `scorer_binary_gpu_on_with_non_mse_cost_errors` — `--gpu on --cost
    MAE` exits non-zero with a clear message.
  - `scorer_binary_gpu_auto_with_non_mse_cost_runs_on_cpu` — auto +
    non-MSE silently falls back to CPU and reports
    `gpuBackend=cpu-fallback`.
  - `scorer_binary_cost_mae_runs_through_dispatch` (replaces the older
    `..._parses_and_runs_as_mse`) — the identity fixture has zero
    error under both MSE and MAE, but the JSON now also asserts the
    `costName` field round-trips MAE through dispatch.

Existing tests updated:

- `scorer_binary_accepts_every_built_in_cost_name` renamed to
  `..._accepts_every_dispatchable_built_in_cost_name` and narrowed to
  the regression-friendly costs; CE and CATEGORICAL_ERROR have
  dedicated tests above. Business-logic shift: dispatch is real now,
  so the test must use a fixture appropriate to each cost.
- `scorer_binary_cost_mae_parses_and_runs_as_mse` renamed to
  `scorer_binary_cost_mae_runs_through_dispatch` — the assertion that
  MAE silently equals MSE was tied to the placeholder dispatch.

`./quality.sh < /dev/null` passes cleanly.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)