### PR TITLE
feat(scorer): add cost_scan_bench and record per-cost CPU baseline (#124)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-124.md
+++ b/docs/archive/pr-summaries/pr-summary-124.md
@@ -1,0 +1,79 @@
+## Summary
+
+Adds the `cost_scan_bench` bin and records the per-cost CPU baseline that
+Issue #124 ("Follow-up: bench non-MSE GPU kernels; raise per-cost issues
+for winners") asks for. **No follow-up GPU kernel issues are raised** —
+no candidate GPU kernel exists for any non-MSE cost today (the only
+shipped shader is `forward_mse_batched.wgsl`), so the per-cost branch is
+"no candidate kernel — skip" for every row. `Closes #124`.
+
+## Evidence
+
+Per-cost CPU throughput on the standard synthetic fixture (8 inputs,
+2 outputs, 8 hidden TANH; ~16 MiB / 419 430 records, 5 runs, median;
+Apple Silicon release build without PGO — PGO would tighten CPU further):
+
+| Cost | Median (ms) | Throughput (records/s) | GPU candidate | Decision |
+|---|---:|---:|---|---|
+| `MSE` | 128.47 | 3 264 722 | shipped (#82) | already on GPU under `Auto` |
+| `MAE` | 105.69 | 3 968 549 | none | **no candidate kernel — skip** |
+| `MAPE` | 145.82 | 2 876 412 | none | **no candidate kernel — skip** |
+| `MSLE` | 87.05 | 4 818 302 | none | **no candidate kernel — skip** |
+| `HINGE` | 40.50 | 10 355 273 | none | **no candidate kernel — skip** (CPU > 10 M rec/s — GPU dispatch overhead unlikely to pay back) |
+| `CROSS_ENTROPY` | 92.27 | 4 545 531 | none | **no candidate kernel — skip** |
+| `CATEGORICAL_ERROR` | — | — | n/a | **blocked** on `stSoftwareAU/NEAT-AI-core#88` |
+
+Raw output (`cost_scan_bench` on the 16 MiB synthetic fixture):
+
+```json
+{"creature":"…/creature.json","dataDir":"…/data","fileCount":1,"totalBytes":16777200,
+ "numInputs":8,"numOutputs":2,"runs":5,
+ "rows":[
+   {"cost":"MSE","medianMs":128.47,"records":419430,"recordsPerSec":3264722.10},
+   {"cost":"MAE","medianMs":105.69,"records":419430,"recordsPerSec":3968549.09},
+   {"cost":"MAPE","medianMs":145.82,"records":419430,"recordsPerSec":2876412.76},
+   {"cost":"MSLE","medianMs":87.05,"records":419430,"recordsPerSec":4818302.23},
+   {"cost":"HINGE","medianMs":40.50,"records":419430,"recordsPerSec":10355273.55},
+   {"cost":"CROSS_ENTROPY","medianMs":92.27,"records":419430,"recordsPerSec":4545531.29}
+ ],
+ "skipped":[{"cost":"CATEGORICAL_ERROR","reason":"… blocked on stSoftwareAU/NEAT-AI-core#88 …"}]}
+```
+
+Per-cost decision flow:
+
+```mermaid
+flowchart LR
+    A[Per-cost row] --> B{Candidate GPU kernel?}
+    B -->|No #124| Skip[no candidate kernel — skip]
+    B -->|Yes| C{≥ 2× CPU+PGO?}
+    C -->|Yes| Issue[Raise GPU kernel follow-up]
+    C -->|No| Negative[Comment numbers, close negative]
+```
+
+Host B (Linux + NVIDIA Vulkan) is tracked separately under
+[Issue #87](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/87) —
+the bench bin is host-agnostic, so a Vulkan-host run only needs to
+repeat the command in
+[`docs/performance-baseline.md` → "Refreshing the baseline"](../../performance-baseline.md)
+and append a Host B row.
+
+Acceptance criteria from the issue:
+
+- [x] One bench row per non-MSE cost recorded (table above + comment on
+      issue #124).
+- [x] Follow-up GPU kernel issues raised for clear winners — **none, no
+      candidate kernel exists for any non-MSE cost.**
+- [x] If no cost wins, this issue is closed with the numbers documented
+      (this PR closes #124; numbers live in the doc + issue comment).
+- [x] Linux + NVIDIA cross-platform run linked to #87 — referenced.
+
+## Test Plan
+
+- Added `rust_scorer/tests/cost_scan_bench_smoke.rs`:
+  - `cost_scan_bench_emits_one_row_per_supported_cost` drives the bin
+    end-to-end against a synthetic tempdir fixture and asserts one row
+    per dispatchable cost, finite `medianMs`, positive `recordsPerSec`,
+    and `CATEGORICAL_ERROR` in `skipped` with `#88` in the reason.
+  - `cost_scan_bench_rejects_missing_data_dir` confirms the CLI exits
+    non-zero when `data_dir` does not exist.
+- `./quality.sh` passes (fmt, clippy, check, build, test, doc, release).

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -380,6 +380,67 @@ The codified rule is one match expression in
 suite (or the Vulkan host run) only requires updating that function plus
 the table above; no other call site embeds the per-path decision.
 
+## Per-cost CPU baseline — 24 May 2026 (Issue #124)
+
+Issue #124 is the "bench-and-decide" step that the parent issue
+([#119](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/119))
+defers GPU kernel work behind: for every non-MSE cost, measure CPU
+throughput and only raise a follow-up GPU kernel issue if a candidate
+GPU port shows a clear (≥ 2×) repeatable win. The CPU numbers below come
+from the new
+[`cost_scan_bench`](../rust_scorer/src/bin/cost_scan_bench.rs) bin
+driving
+[`accumulate_cost_sum_forward_only_fused`](../rust_scorer/src/stream_score.rs)
+through every supported `CostKind` on the standard synthetic fixture
+(8 inputs, 2 outputs, 8 hidden TANH; ≈ 16 MiB / 419 430 records per
+run, 5 runs, median).
+
+Host A — Apple Silicon (release build, no PGO; PGO typically shaves
+8–10 % so the CPU baseline below is conservative).
+
+| Cost | Median (ms) | Throughput (records/s) | GPU candidate | Per-cost decision |
+|---|---:|---:|---|---|
+| `MSE` | 128.47 | 3 264 722 | `forward_mse_batched` (shipped #82) | Already on GPU under `Auto` (`auto_should_use_gpu`) |
+| `MAE` | 105.69 | 3 968 549 | none (would need new WGSL) | **no candidate kernel — skip** |
+| `MAPE` | 145.82 | 2 876 412 | none (would need new WGSL) | **no candidate kernel — skip** |
+| `MSLE` | 87.05 | 4 818 302 | none (would need new WGSL) | **no candidate kernel — skip** |
+| `HINGE` | 40.50 | 10 355 273 | none (would need new WGSL) | **no candidate kernel — skip** (CPU is already > 10 M records/s — GPU dispatch overhead unlikely to pay back) |
+| `CROSS_ENTROPY` | 92.27 | 4 545 531 | none (would need new WGSL) | **no candidate kernel — skip** |
+| `CATEGORICAL_ERROR` | — | — | n/a | **blocked** on `stSoftwareAU/NEAT-AI-core#88` (`categorical_error_sum_batch_packed` not in `neat-core` yet) |
+
+**Decision: no follow-up GPU kernel issues raised.** The only existing
+GPU shader is `forward_mse_batched.wgsl`, which inlines `d * d` for the
+loss step — a "quick GPU port" of any other cost would require:
+
+* a new WGSL kernel encoding the cost-specific math
+  (e.g. `abs(d)` for MAE, `max(0, 1 - target*pred)` for HINGE,
+  `-target * log(pred)` for CROSS_ENTROPY), and
+* a Rust runner mirroring `gpu::forward_mse_batched::BatchedRunner`, and
+* parity tests + corpus-size sweeps against the CPU baseline above.
+
+No such candidate kernel exists for any non-MSE cost today, so the
+per-cost branch of the issue's flowchart is **"no candidate kernel —
+skip"** for every row. The decision is recorded here (per Issue #124's
+"No win" branch) rather than as fresh per-cost GPU follow-ups; a future
+PR that lands a candidate kernel for any cost should re-run
+`cost_scan_bench` on the same fixture and raise a per-cost GPU follow-up
+issue only when the 2× bar is met.
+
+Host B (Linux + NVIDIA Vulkan) is tracked separately under
+[Issue #87](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/87) —
+the per-cost CPU numbers above are macOS-only. The bench bin is
+host-agnostic, so the Linux host run only needs to repeat the command in
+"Refreshing the baseline" below and append a Host B row to the table.
+
+```mermaid
+flowchart LR
+    A[Per-cost row] --> B{Candidate GPU kernel?}
+    B -->|No #124| Skip[no candidate kernel — skip]
+    B -->|Yes| C{≥ 2× CPU+PGO?}
+    C -->|Yes| Issue[Raise GPU kernel follow-up]
+    C -->|No| Negative[Comment numbers, close negative]
+```
+
 ## Refreshing the baseline
 
 1. Run `./scripts/run-benches.sh` (default fixture) and record the median +
@@ -391,3 +452,12 @@ the table above; no other call site embeds the per-path decision.
 3. When proposing a perf PR, paste the Criterion comparison output (or the
    before/after median + CI) into the PR summary. PRs without before/after
    evidence are rejected per `AGENTS.md`.
+4. For a per-cost CPU refresh (Issue #124), build the bench bin and run it
+   against any synthetic creature + `.bin` corpus:
+
+   ```bash
+   cargo build --release -p rust_scorer --bin cost_scan_bench
+   ./target/release/cost_scan_bench <creature.json> <data_dir> --runs 5
+   ```
+
+   Append a new dated Host row to the "Per-cost CPU baseline" table.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -26,6 +26,14 @@ path = "src/main.rs"
 name = "float_scan_bench"
 path = "src/bin/float_scan_bench.rs"
 
+# Per-cost CPU throughput bench (Issue #124). Sister to `float_scan_bench` —
+# drives `accumulate_cost_sum_forward_only_fused` for every supported
+# `CostKind` so each non-MSE cost gets the bench-and-decide step the parent
+# issue (#119) defers GPU kernel work behind.
+[[bin]]
+name = "cost_scan_bench"
+path = "src/bin/cost_scan_bench.rs"
+
 # Criterion bench harness — see `benches/scoring.rs` and
 # `docs/performance-baseline.md`. Not wired into `quality.sh` (Criterion runs
 # are slow and non-deterministic enough to be unsuitable as a merge gate);

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.30"
+version = "0.5.31"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/bin/cost_scan_bench.rs
+++ b/rust_scorer/src/bin/cost_scan_bench.rs
@@ -1,0 +1,239 @@
+//! Per-cost CPU throughput bench — Issue #124.
+//!
+//! Companion to `float_scan_bench` that drives the full forward-only fused
+//! scoring path
+//! ([`rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused`]) for
+//! every supported [`rust_scorer::cost::CostKind`] against a single creature
+//! and a `.bin` corpus. Used by Issue #124 to record the per-cost CPU
+//! baseline so each non-MSE cost gets the bench-and-decide step the parent
+//! issue (#119) defers GPU kernel work behind.
+//!
+//! `CATEGORICAL_ERROR` is blocked on `stSoftwareAU/NEAT-AI-core#88`
+//! (no `categorical_error_sum_batch_packed` helper exists upstream yet), so
+//! it is reported under `skipped` with the issue number rather than crashing
+//! the run.
+//!
+//! Output is a single JSON object on stdout, suitable for piping into
+//! `jq`/notebooks and for pasting straight into the issue thread. Build:
+//!
+//! ```text
+//! cargo build --release -p rust_scorer --bin cost_scan_bench
+//! ./target/release/cost_scan_bench <creature.json> <data_dir> --runs 5
+//! ```
+//!
+//! Both `--runs` and the corpus size affect how stable the median is — the
+//! existing `float_scan_bench` defaults to 7 runs, this bin defaults to 5 so
+//! a 6-cost sweep stays within ~1 minute on a small corpus.
+
+#[path = "../read_tuning.rs"]
+#[allow(dead_code)] // selectively used by the bench; the rest mirrors float_scan_bench.
+mod read_tuning;
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Parser;
+use neat_core::creature::{compile_creature, parse_creature_json};
+use neat_core::training_data::{TrainingDataConfig, find_bin_files};
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused;
+
+#[derive(Parser, Debug)]
+#[command(name = "cost_scan_bench")]
+struct Cli {
+    /// Path to the creature JSON file (forward-only).
+    creature: PathBuf,
+
+    /// Directory containing `.bin` training files (numeric sort,
+    /// same as the production scorer).
+    data_dir: PathBuf,
+
+    /// Number of timed iterations per cost (median reported).
+    #[arg(long, default_value_t = 5)]
+    runs: usize,
+}
+
+/// Result of one timed run for a single cost.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CostRow {
+    cost: &'static str,
+    median_ms: f64,
+    times_ms: Vec<f64>,
+    records: usize,
+    records_per_sec: f64,
+    checksum: f64,
+}
+
+#[derive(serde::Serialize)]
+struct SkippedRow {
+    cost: &'static str,
+    reason: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Report {
+    creature: PathBuf,
+    data_dir: PathBuf,
+    file_count: usize,
+    total_bytes: u64,
+    num_inputs: usize,
+    num_outputs: usize,
+    runs: usize,
+    rows: Vec<CostRow>,
+    skipped: Vec<SkippedRow>,
+}
+
+fn median_ms(times: &mut [f64]) -> f64 {
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mid = times.len() / 2;
+    if times.len() % 2 == 1 {
+        times[mid]
+    } else {
+        (times[mid - 1] + times[mid]) / 2.0
+    }
+}
+
+fn run_one_cost(
+    cost: CostKind,
+    bin_files: &[PathBuf],
+    config: &TrainingDataConfig,
+    creature_json: &str,
+    runs: usize,
+) -> Result<CostRow, String> {
+    let creature = parse_creature_json(creature_json).map_err(|e| e.to_string())?;
+    // Warm-up run: validates the cost is dispatchable and primes caches.
+    let mut net = compile_creature(&creature).map_err(|e| e.to_string())?;
+    let (warm_sum, warm_records, _, _, _) =
+        accumulate_cost_sum_forward_only_fused(cost, bin_files, config, &creature, &mut net)?;
+
+    let mut times = Vec::with_capacity(runs);
+    let mut checksum = warm_sum;
+    let mut records = warm_records;
+    for _ in 0..runs {
+        // Re-compile per iteration so the network state is identical between
+        // runs — matches the Criterion `iter_batched` pattern in
+        // `benches/scoring.rs::bench_score_from_json_fused`.
+        let mut net = compile_creature(&creature).map_err(|e| e.to_string())?;
+        let t0 = Instant::now();
+        let (sum, n_records, _, _, _) =
+            accumulate_cost_sum_forward_only_fused(cost, bin_files, config, &creature, &mut net)?;
+        let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+        times.push(elapsed_ms);
+        checksum = sum;
+        records = n_records;
+    }
+
+    let med = median_ms(&mut times.clone());
+    let rps = if med > 0.0 {
+        (records as f64) / (med / 1000.0)
+    } else {
+        0.0
+    };
+    Ok(CostRow {
+        cost: cost.as_str(),
+        median_ms: (med * 100.0).round() / 100.0,
+        times_ms: times
+            .into_iter()
+            .map(|t| (t * 100.0).round() / 100.0)
+            .collect(),
+        records,
+        records_per_sec: (rps * 100.0).round() / 100.0,
+        checksum,
+    })
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let creature_json = match fs::read_to_string(&cli.creature) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Failed to read {}: {e}", cli.creature.display());
+            std::process::exit(2);
+        }
+    };
+    let creature = match parse_creature_json(&creature_json) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to parse creature {}: {e}", cli.creature.display());
+            std::process::exit(2);
+        }
+    };
+
+    if !cli.data_dir.is_dir() {
+        eprintln!("data_dir does not exist: {}", cli.data_dir.display());
+        std::process::exit(2);
+    }
+    let bin_files = match find_bin_files(&cli.data_dir) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "Failed to list bin files in {}: {e}",
+                cli.data_dir.display()
+            );
+            std::process::exit(2);
+        }
+    };
+    if bin_files.is_empty() {
+        eprintln!("No .bin files in {}", cli.data_dir.display());
+        std::process::exit(2);
+    }
+
+    let num_inputs = creature.input;
+    let num_outputs = creature.output;
+    let config = TrainingDataConfig {
+        num_inputs,
+        num_outputs,
+    };
+
+    let total_bytes: u64 = bin_files
+        .iter()
+        .map(|p| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
+        .sum();
+
+    // Costs we measure. CATEGORICAL_ERROR is reported in `skipped` with the
+    // dispatch error string so the JSON stays a single artefact.
+    let candidates = [
+        CostKind::Mse,
+        CostKind::Mae,
+        CostKind::Mape,
+        CostKind::Msle,
+        CostKind::Hinge,
+        CostKind::CrossEntropy,
+        CostKind::CategoricalError,
+    ];
+
+    let mut rows: Vec<CostRow> = Vec::new();
+    let mut skipped: Vec<SkippedRow> = Vec::new();
+    for cost in candidates {
+        match run_one_cost(cost, &bin_files, &config, &creature_json, cli.runs) {
+            Ok(row) => rows.push(row),
+            Err(e) => skipped.push(SkippedRow {
+                cost: cost.as_str(),
+                reason: e,
+            }),
+        }
+    }
+
+    let report = Report {
+        creature: cli.creature,
+        data_dir: cli.data_dir,
+        file_count: bin_files.len(),
+        total_bytes,
+        num_inputs,
+        num_outputs,
+        runs: cli.runs,
+        rows,
+        skipped,
+    };
+
+    // Single-line JSON keeps the output trivially parseable.
+    println!(
+        "{}",
+        serde_json::to_string(&report).expect("serialise report")
+    );
+}

--- a/rust_scorer/tests/cost_scan_bench_smoke.rs
+++ b/rust_scorer/tests/cost_scan_bench_smoke.rs
@@ -1,0 +1,150 @@
+//! Smoke test for the `cost_scan_bench` binary (Issue #124).
+//!
+//! Drives the binary end-to-end against a synthetic creature + corpus and
+//! asserts the JSON output carries one row per supported `CostKind` (every
+//! built-in cost except `CATEGORICAL_ERROR`, which is blocked on
+//! `stSoftwareAU/NEAT-AI-core#88`). The bench bin itself produces the
+//! per-cost numbers that Issue #124 records on the issue thread; this test
+//! guards the CLI contract so the script that consumes the JSON keeps
+//! working.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Minimal forward-only identity creature: 1 input → 1 output, IDENTITY
+/// squash, weight 1.0. Small enough that the fused path runs in
+/// milliseconds even on the largest corpus this smoke test creates.
+const IDENTITY_CREATURE_JSON: &str = r#"{
+    "input": 1,
+    "output": 1,
+    "forwardOnly": true,
+    "semanticVersion": "4.0.0",
+    "neurons": [
+        {"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}
+    ],
+    "synapses": [
+        {"fromUUID":"input-0","toUUID":"output-0","weight":1.0}
+    ]
+}"#;
+
+/// Write a tiny `.bin` corpus: 64 records of [input, target] f32 pairs.
+fn write_tiny_corpus(data_dir: &std::path::Path) {
+    fs::create_dir_all(data_dir).unwrap();
+    let mut bytes: Vec<u8> = Vec::new();
+    for i in 0_u32..64 {
+        let x = (i as f32) * 0.01;
+        let t = x + 0.1;
+        bytes.extend_from_slice(&x.to_le_bytes());
+        bytes.extend_from_slice(&t.to_le_bytes());
+    }
+    fs::write(data_dir.join("0.bin"), &bytes).unwrap();
+}
+
+fn bench_bin() -> PathBuf {
+    // Cargo sets `CARGO_BIN_EXE_<name>` for any bin target the integration
+    // test depends on (the bin is declared in `Cargo.toml`).
+    PathBuf::from(env!("CARGO_BIN_EXE_cost_scan_bench"))
+}
+
+#[test]
+fn cost_scan_bench_emits_one_row_per_supported_cost() {
+    let tmp = TempDir::new().unwrap();
+    let creature = tmp.path().join("creature.json");
+    fs::write(&creature, IDENTITY_CREATURE_JSON).unwrap();
+    let data_dir = tmp.path().join("data");
+    write_tiny_corpus(&data_dir);
+
+    let output = Command::new(bench_bin())
+        .arg(&creature)
+        .arg(&data_dir)
+        .arg("--runs")
+        .arg("2")
+        .output()
+        .expect("run cost_scan_bench");
+
+    assert!(
+        output.status.success(),
+        "bench exited non-zero: status={:?}\nstdout={}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON from bench: {e}\nstdout:\n{stdout}"));
+
+    let rows = json["rows"].as_array().expect("rows must be a JSON array");
+
+    // Every supported (non-blocked) cost should produce a row.
+    // CATEGORICAL_ERROR is blocked on NEAT-AI-core#88 and is reported in a
+    // separate `skipped` array — see the bench impl.
+    let want = ["MSE", "MAE", "MAPE", "MSLE", "HINGE", "CROSS_ENTROPY"];
+    assert_eq!(
+        rows.len(),
+        want.len(),
+        "expected {} rows, got {}: {}",
+        want.len(),
+        rows.len(),
+        stdout
+    );
+    for name in want {
+        let row = rows
+            .iter()
+            .find(|r| r["cost"].as_str() == Some(name))
+            .unwrap_or_else(|| panic!("missing row for cost {name}\nstdout:\n{stdout}"));
+        // Each row must carry a finite median time and a throughput estimate.
+        let median = row["medianMs"]
+            .as_f64()
+            .unwrap_or_else(|| panic!("medianMs missing for {name}: {row}"));
+        assert!(
+            median.is_finite() && median >= 0.0,
+            "medianMs not finite for {name}: {median}"
+        );
+        let rps = row["recordsPerSec"]
+            .as_f64()
+            .unwrap_or_else(|| panic!("recordsPerSec missing for {name}: {row}"));
+        assert!(
+            rps.is_finite() && rps > 0.0,
+            "recordsPerSec must be positive for {name}: {rps}"
+        );
+    }
+
+    // CATEGORICAL_ERROR must appear in `skipped` with a reason mentioning #88.
+    let skipped = json["skipped"]
+        .as_array()
+        .expect("skipped must be an array");
+    let cat = skipped
+        .iter()
+        .find(|r| r["cost"].as_str() == Some("CATEGORICAL_ERROR"))
+        .unwrap_or_else(|| panic!("CATEGORICAL_ERROR must be skipped: {stdout}"));
+    let reason = cat["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("#88"),
+        "skip reason must mention #88, got: {reason}"
+    );
+}
+
+#[test]
+fn cost_scan_bench_rejects_missing_data_dir() {
+    let tmp = TempDir::new().unwrap();
+    let creature = tmp.path().join("creature.json");
+    fs::write(&creature, IDENTITY_CREATURE_JSON).unwrap();
+    let missing = tmp.path().join("no-such-dir");
+
+    let output = Command::new(bench_bin())
+        .arg(&creature)
+        .arg(&missing)
+        .arg("--runs")
+        .arg("1")
+        .output()
+        .expect("run cost_scan_bench");
+
+    assert!(
+        !output.status.success(),
+        "bench must exit non-zero when data_dir is missing"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the `cost_scan_bench` bin and records the per-cost CPU baseline that
Issue #124 ("Follow-up: bench non-MSE GPU kernels; raise per-cost issues
for winners") asks for. **No follow-up GPU kernel issues are raised** —
no candidate GPU kernel exists for any non-MSE cost today (the only
shipped shader is `forward_mse_batched.wgsl`), so the per-cost branch is
"no candidate kernel — skip" for every row. `Closes #124`.

## Evidence

Per-cost CPU throughput on the standard synthetic fixture (8 inputs,
2 outputs, 8 hidden TANH; ~16 MiB / 419 430 records, 5 runs, median;
Apple Silicon release build without PGO — PGO would tighten CPU further):

| Cost | Median (ms) | Throughput (records/s) | GPU candidate | Decision |
|---|---:|---:|---|---|
| `MSE` | 128.47 | 3 264 722 | shipped (#82) | already on GPU under `Auto` |
| `MAE` | 105.69 | 3 968 549 | none | **no candidate kernel — skip** |
| `MAPE` | 145.82 | 2 876 412 | none | **no candidate kernel — skip** |
| `MSLE` | 87.05 | 4 818 302 | none | **no candidate kernel — skip** |
| `HINGE` | 40.50 | 10 355 273 | none | **no candidate kernel — skip** (CPU > 10 M rec/s — GPU dispatch overhead unlikely to pay back) |
| `CROSS_ENTROPY` | 92.27 | 4 545 531 | none | **no candidate kernel — skip** |
| `CATEGORICAL_ERROR` | — | — | n/a | **blocked** on `stSoftwareAU/NEAT-AI-core#88` |

Raw output (`cost_scan_bench` on the 16 MiB synthetic fixture):

```json
{"creature":"…/creature.json","dataDir":"…/data","fileCount":1,"totalBytes":16777200,
 "numInputs":8,"numOutputs":2,"runs":5,
 "rows":[
   {"cost":"MSE","medianMs":128.47,"records":419430,"recordsPerSec":3264722.10},
   {"cost":"MAE","medianMs":105.69,"records":419430,"recordsPerSec":3968549.09},
   {"cost":"MAPE","medianMs":145.82,"records":419430,"recordsPerSec":2876412.76},
   {"cost":"MSLE","medianMs":87.05,"records":419430,"recordsPerSec":4818302.23},
   {"cost":"HINGE","medianMs":40.50,"records":419430,"recordsPerSec":10355273.55},
   {"cost":"CROSS_ENTROPY","medianMs":92.27,"records":419430,"recordsPerSec":4545531.29}
 ],
 "skipped":[{"cost":"CATEGORICAL_ERROR","reason":"… blocked on stSoftwareAU/NEAT-AI-core#88 …"}]}
```

Per-cost decision flow:

```mermaid
flowchart LR
    A[Per-cost row] --> B{Candidate GPU kernel?}
    B -->|No #124| Skip[no candidate kernel — skip]
    B -->|Yes| C{≥ 2× CPU+PGO?}
    C -->|Yes| Issue[Raise GPU kernel follow-up]
    C -->|No| Negative[Comment numbers, close negative]
```

Host B (Linux + NVIDIA Vulkan) is tracked separately under
[Issue #87](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/87) —
the bench bin is host-agnostic, so a Vulkan-host run only needs to
repeat the command in
[`docs/performance-baseline.md` → "Refreshing the baseline"](../../performance-baseline.md)
and append a Host B row.

Acceptance criteria from the issue:

- [x] One bench row per non-MSE cost recorded (table above + comment on
      issue #124).
- [x] Follow-up GPU kernel issues raised for clear winners — **none, no
      candidate kernel exists for any non-MSE cost.**
- [x] If no cost wins, this issue is closed with the numbers documented
      (this PR closes #124; numbers live in the doc + issue comment).
- [x] Linux + NVIDIA cross-platform run linked to #87 — referenced.

## Test Plan

- Added `rust_scorer/tests/cost_scan_bench_smoke.rs`:
  - `cost_scan_bench_emits_one_row_per_supported_cost` drives the bin
    end-to-end against a synthetic tempdir fixture and asserts one row
    per dispatchable cost, finite `medianMs`, positive `recordsPerSec`,
    and `CATEGORICAL_ERROR` in `skipped` with `#88` in the reason.
  - `cost_scan_bench_rejects_missing_data_dir` confirms the CLI exits
    non-zero when `data_dir` does not exist.
- `./quality.sh` passes (fmt, clippy, check, build, test, doc, release).



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-124 -->