### PR TITLE
ci(workflows): require actions/setup-node v6+ to prevent Node 20 regression (#137)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-137.md
+++ b/docs/archive/pr-summaries/pr-summary-137.md
@@ -1,7 +1,7 @@
 ## Summary
 
 Harden the workflow-action policy so `actions/setup-node` cannot regress
-to a Node 20 release. Fixes #137.
+to a Node 20 release. Fixes #137
 
 The immediate `setup-node@v4` (Node 20) usage that triggered the
 deprecation warning in Issue #137 was already removed in PR #135 (the

--- a/docs/archive/pr-summaries/pr-summary-137.md
+++ b/docs/archive/pr-summaries/pr-summary-137.md
@@ -1,0 +1,44 @@
+## Summary
+
+Harden the workflow-action policy so `actions/setup-node` cannot regress
+to a Node 20 release. Fixes #137.
+
+The immediate `setup-node@v4` (Node 20) usage that triggered the
+deprecation warning in Issue #137 was already removed in PR #135 (the
+`markdown-lint.yml` step now pins `actions/setup-node@v6` — Node 24).
+However, the validator in
+`scripts/check-workflow-action-versions.sh` still allowed any
+`actions/setup-node` >= v4, so a future bump back to v4 or v5 (both
+Node 20) would have passed the gate. This PR raises the policy floor to
+`required:6` — v6 is the first `actions/setup-node` release on Node 24
+— and adds regression tests for v4 and v5.
+
+## Evidence
+
+Backend-only change to a workflow-policy shell script — no UI to
+screenshot. Tests verify behaviour:
+
+- `bats tests/scripts/workflow_action_versions.bats` — 17/17 pass,
+  including the two new Issue #137 regression cases.
+- `./quality.sh` was run end-to-end; the only failure is the
+  pre-existing `cargo metadata` test, which requires a sibling
+  `NEAT-AI-core` clone that is not present in the local auto-issue-work
+  environment (see AGENTS.md). CI has the sibling clone via the
+  workflow path strategy.
+
+Policy change:
+
+```diff
+-    actions/setup-node)               echo "required:4" ;;
++    # actions/setup-node v4 and v5 still ship a Node 20 runtime; v6.0.0
++    # (2025-10) is the first Node 24 release. Pinning the floor at v6
++    # prevents the deprecation regression that triggered Issue #137.
++    actions/setup-node)               echo "required:6" ;;
+```
+
+## Test Plan
+
+- Added `tests/scripts/workflow_action_versions.bats::fails when actions/setup-node version comment is older than v6 (Node 20 — Issue #137)` — fixture pins setup-node @v4 and asserts the validator exits non-zero with `requires v6 or newer`.
+- Added `tests/scripts/workflow_action_versions.bats::fails when actions/setup-node is pinned to v5 (still Node 20 — Issue #137)` — same shape, pinning @v5, to lock the v5→Node 20 case explicitly.
+- Extended the existing `write_compliant_workflow` fixture with an `actions/setup-node@<sha>  # v6` line so the happy-path test exercises the new policy too.
+- Existing `real repository workflows satisfy the Node 24 compat policy` test continues to pass, confirming `.github/workflows/markdown-lint.yml` already complies.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.34"
+version = "0.5.35"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -99,7 +99,10 @@ lookup_policy() {
   case "$action" in
     actions/checkout)                 echo "required:5" ;;
     actions/cache)                    echo "required:5" ;;
-    actions/setup-node)               echo "required:4" ;;
+    # actions/setup-node v4 and v5 still ship a Node 20 runtime; v6.0.0
+    # (2025-10) is the first Node 24 release. Pinning the floor at v6
+    # prevents the deprecation regression that triggered Issue #137.
+    actions/setup-node)               echo "required:6" ;;
     peter-evans/create-pull-request)  echo "required:8" ;;
     ludeeus/action-shellcheck)        echo "required:2" ;;
     # actions/dependency-review-action: action.yml declares `using: node20`

--- a/tests/scripts/workflow_action_versions.bats
+++ b/tests/scripts/workflow_action_versions.bats
@@ -27,6 +27,7 @@ SHA_SHELLCHECK="4444444444444444444444444444444444444444"
 SHA_PR="5555555555555555555555555555555555555555"
 SHA_DEPREV="6666666666666666666666666666666666666666"
 SHA_AUDIT="7777777777777777777777777777777777777777"
+SHA_SETUP_NODE="8888888888888888888888888888888888888888"
 
 # A minimal compliant workflow — every action SHA-pinned with the version
 # label in the trailing comment. Individual failure tests rewrite a single
@@ -42,6 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@${SHA_CHECKOUT}  # v5
       - uses: actions/cache@${SHA_CACHE}  # v5
+      - uses: actions/setup-node@${SHA_SETUP_NODE}  # v6
       - uses: dtolnay/rust-toolchain@${SHA_TOOLCHAIN}  # stable, frozen 2026-05-18
       - uses: ludeeus/action-shellcheck@${SHA_SHELLCHECK}  # v2.0.0
       - uses: peter-evans/create-pull-request@${SHA_PR}  # v8
@@ -120,6 +122,25 @@ EOF
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -ne 0 ]
   [[ "$output" == *"requires v5 or newer"* ]]
+}
+
+@test "fails when actions/setup-node version comment is older than v6 (Node 20 — Issue #137)" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  # setup-node v4 and v5 still ship a Node 20 runtime; v6 is the first
+  # Node 24 release. Regressing to v4 or v5 re-introduces the Node.js 20
+  # deprecation warning that triggered Issue #137.
+  sed -i.bak "s|actions/setup-node@${SHA_SETUP_NODE}  # v6|actions/setup-node@${SHA_SETUP_NODE}  # v4|" "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires v6 or newer"* ]]
+}
+
+@test "fails when actions/setup-node is pinned to v5 (still Node 20 — Issue #137)" {
+  write_compliant_workflow "$TMP_WF/example.yml"
+  sed -i.bak "s|actions/setup-node@${SHA_SETUP_NODE}  # v6|actions/setup-node@${SHA_SETUP_NODE}  # v5|" "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires v6 or newer"* ]]
 }
 
 @test "fails when peter-evans/create-pull-request comment is older than v8" {


### PR DESCRIPTION
## Summary

Harden the workflow-action policy so `actions/setup-node` cannot regress
to a Node 20 release. Fixes #137.

The immediate `setup-node@v4` (Node 20) usage that triggered the
deprecation warning in Issue #137 was already removed in PR #135 (the
`markdown-lint.yml` step now pins `actions/setup-node@v6` — Node 24).
However, the validator in
`scripts/check-workflow-action-versions.sh` still allowed any
`actions/setup-node` >= v4, so a future bump back to v4 or v5 (both
Node 20) would have passed the gate. This PR raises the policy floor to
`required:6` — v6 is the first `actions/setup-node` release on Node 24
— and adds regression tests for v4 and v5.

## Evidence

Backend-only change to a workflow-policy shell script — no UI to
screenshot. Tests verify behaviour:

- `bats tests/scripts/workflow_action_versions.bats` — 17/17 pass,
  including the two new Issue #137 regression cases.
- `./quality.sh` was run end-to-end; the only failure is the
  pre-existing `cargo metadata` test, which requires a sibling
  `NEAT-AI-core` clone that is not present in the local auto-issue-work
  environment (see AGENTS.md). CI has the sibling clone via the
  workflow path strategy.

Policy change:

```diff
-    actions/setup-node)               echo "required:4" ;;
+    # actions/setup-node v4 and v5 still ship a Node 20 runtime; v6.0.0
+    # (2025-10) is the first Node 24 release. Pinning the floor at v6
+    # prevents the deprecation regression that triggered Issue #137.
+    actions/setup-node)               echo "required:6" ;;
```

## Test Plan

- Added `tests/scripts/workflow_action_versions.bats::fails when actions/setup-node version comment is older than v6 (Node 20 — Issue #137)` — fixture pins setup-node @v4 and asserts the validator exits non-zero with `requires v6 or newer`.
- Added `tests/scripts/workflow_action_versions.bats::fails when actions/setup-node is pinned to v5 (still Node 20 — Issue #137)` — same shape, pinning @v5, to lock the v5→Node 20 case explicitly.
- Extended the existing `write_compliant_workflow` fixture with an `actions/setup-node@<sha>  # v6` line so the happy-path test exercises the new policy too.
- Existing `real repository workflows satisfy the Node 24 compat policy` test continues to pass, confirming `.github/workflows/markdown-lint.yml` already complies.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-137 -->