### PR TITLE
ci: bump remaining Node 20 actions to Node 24 (#136)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,8 +19,9 @@ name: Dependency Review
 #
 # Action versions follow `scripts/check-workflow-action-versions.sh`:
 # `actions/checkout@v5` (Node 24 policy) and
-# `actions/dependency-review-action@v4` (tracked Node 20 exception — no v5
-# release upstream yet).
+# `actions/dependency-review-action@v5` (Node 24; the prior v4.9 line was a
+# tracked Node 20 exception cleared by Issue #136 once upstream v5.0.0
+# landed on 2026-05-08).
 
 on:
   pull_request:
@@ -42,4 +43,4 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Dependency review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,7 @@ name: Dependency Review
 # `actions/checkout@v5` (Node 24 policy) and
 # `actions/dependency-review-action@v5` (Node 24; the prior v4.9 line was a
 # tracked Node 20 exception cleared by Issue #136 once upstream v5.0.0
-# landed on 2026-05-08).
+# landed on 2026-05-08)
 
 on:
   pull_request:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,11 @@ jobs:
       # Official RustSec GitHub Action — wraps cargo-audit and annotates the PR /
       # check run with any RUSTSEC advisories found in Cargo.lock.
       - name: Cargo Security Audit (rustsec/audit-check)
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
+        # Master HEAD post upstream #48 (commit 858dc40, 2026-03-20) — action.yml
+        # declares `using: node24`. The v2.0.0 tag (2024-09-23) still pins
+        # node20, and no v2.1 / v3 tag has shipped yet, so we SHA-pin to the
+        # master commit. Issue #136 cleared the prior Node 20 exception.
+        uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432  # v2 (master HEAD, Node 24, post upstream #48)
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,6 +66,8 @@ jobs:
 
       - name: Dependency review
         if: ${{ inputs.include-dependency-review && github.event_name == 'pull_request' }}
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+        # Bumped to v5.0.0 in Issue #136 — upstream shipped Node 24 on
+        # 2026-05-08, clearing the prior tracked Node 20 exception.
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
           comment-summary-in-pr: always

--- a/docs/archive/pr-summaries/pr-summary-136.md
+++ b/docs/archive/pr-summaries/pr-summary-136.md
@@ -1,0 +1,84 @@
+## Summary
+
+Continues the work started in PR #135 by clearing the remaining two
+**Node 20 deprecated** GitHub Actions that emit "Actions not starting
+correctly" warnings on every run and would be force-bumped to Node 24
+on 2026-06-02 (8 days from today). With Node 20 removal scheduled for
+2026-09-16, leaving the exceptions in place risks runs that genuinely
+fail to start once GitHub-hosted runners drop the runtime. Closes #136.
+
+Bumps and rationale:
+
+- `actions/dependency-review-action`: `v4.9.0` (SHA `2031cfc0…`, Node 20)
+  → **`v5.0.0`** (SHA `a1d282b3…`, Node 24). Upstream released v5.0.0 on
+  2026-05-08 — well past the worker's 24h external-dep quarantine.
+- `rustsec/audit-check`: `v2.0.0` (SHA `69366f33…`, Node 20, 2024-09-23)
+  → **master HEAD** (SHA `858dc40f…`, Node 24, 2026-03-20). Upstream's
+  PR #48 added Node 24 support on master but hasn't shipped a v2.1 / v3
+  tag yet, so we SHA-pin to the commit and label it
+  `# v2 (master HEAD, Node 24, post upstream #48)`.
+
+Supporting changes so the local quality gate stays green:
+
+- `scripts/check-workflow-action-versions.sh`: both `node20:N` policy
+  entries flipped to `required:N` (5 and 2 respectively). The
+  `node20:N` code path itself is retained for any future exception.
+- `scripts/check-dependency-review-workflow.sh` and
+  `scripts/check-cargo-audit-workflow.sh`: widened the SHA-pin regex
+  from `v?[0-9]+` to `(v[0-9]+|[0-9a-f]{40})\b`. The old regex silently
+  relied on every commit SHA starting with a digit — the new
+  dependency-review-action SHA starts with `a1d282b…`, which the
+  previous regex rejected as "not pinned".
+- `tests/scripts/workflow_action_versions.bats`: updated fixtures
+  (`v4.9.0` → `v5.0.0`; `v2.0.0` → `v2 (master HEAD, …)`), removed the
+  stale `"Node 20 exception, tracked"` assertion in the happy-path test,
+  and added two regression tests (Issue #136) that fail if either
+  dependency-review-action is downgraded below v5 or audit-check below
+  v2.
+
+## Evidence
+
+CLI / workflow change — no UI screenshot. Evidence is the test suite plus
+the validator output.
+
+```mermaid
+flowchart LR
+    Before["v4.9.0 dep-review<br/>v2.0.0 audit-check<br/>(Node 20 — deprecated)"] --> PR136["Issue #136<br/>policy: required:5 + required:2<br/>SHA-pin regex: v[0-9]+|[0-9a-f]{40}"]
+    PR136 --> After["v5.0.0 dep-review<br/>master HEAD audit-check<br/>(Node 24 — supported)"]
+    After --> CI["GitHub Actions runners<br/>(Node 20 forced off 2026-06-02)"]
+```
+
+Verification:
+
+- `./scripts/check-workflow-action-versions.sh` — every `uses:` line
+  reports `>= vN, SHA-pinned` (no `Node 20 exception, tracked` left).
+- `./scripts/check-dependency-review-workflow.sh` — accepts the new
+  `a1d282b3…` SHA pin (previously rejected as "not pinned" because the
+  regex only matched SHAs starting with a digit).
+- `./scripts/check-cargo-audit-workflow.sh` — accepts the master-HEAD
+  SHA pin for `rustsec/audit-check`.
+- `bats tests/scripts/` — 185 tests pass, including the two new
+  regression tests `fails when actions/dependency-review-action comment
+  is older than v5` and `fails when rustsec/audit-check comment is
+  older than v2`.
+- `./quality.sh < /dev/null` — full local gate passes (shellcheck,
+  cargo-deny, fmt, clippy, check, build, test, doc, release).
+
+## Test Plan
+
+- `bats tests/scripts/workflow_action_versions.bats` — 16 tests,
+  including the two new Issue #136 regression tests and an updated
+  happy-path assertion (`>= v5, SHA-pinned`).
+- `bats tests/scripts/dependency_review_workflow.bats` — 10 tests
+  including the real-repo green path (previously failing on the new
+  SHA pin until the regex widened).
+- `bats tests/scripts/cargo_audit_workflow.bats` — 11 tests.
+- `bats tests/scripts/` — full 185-test suite, all passing.
+- `./quality.sh < /dev/null` — full local gate.
+
+## Deno regression avoided
+
+N/A — this is a Rust + GitHub Actions repo with no Deno markers
+(`deno.json` etc.). No Node-only tooling introduced; the only Node
+dependencies touched are GitHub Action SHA pins, which are unavoidable
+for this kind of repo.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.35"
+version = "0.5.36"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-cargo-audit-workflow.sh
+++ b/scripts/check-cargo-audit-workflow.sh
@@ -95,12 +95,16 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 4. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
+# 4. actions/checkout pinned to a numeric major (vN) or a 40-char SHA.
+# Branch refs (e.g. `@main`) disallowed. Issue #136 widened the regex from
+# `v?[0-9]+` so SHAs starting with hex letters a–f are accepted too —
+# rustsec/audit-check has been bumped to commit `858dc40…` and that lesson
+# applies preemptively to actions/checkout here.
 checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
 if [[ -z "$checkout_line" ]]; then
   fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
-  ok "actions/checkout pinned to a numeric major"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@(v[0-9]+|[0-9a-f]{40})\b'; then
+  ok "actions/checkout pinned to a numeric major or 40-char SHA"
 else
   fail "actions/checkout is not pinned — branch refs disallowed"
 fi

--- a/scripts/check-dependency-review-workflow.sh
+++ b/scripts/check-dependency-review-workflow.sh
@@ -90,22 +90,26 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 3. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA.
+# Branch refs (e.g. `@main`) disallowed.
 checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
 if [[ -z "$checkout_line" ]]; then
   fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
-  ok "actions/checkout pinned to a numeric major"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@(v[0-9]+|[0-9a-f]{40})\b'; then
+  ok "actions/checkout pinned to a numeric major or 40-char SHA"
 else
   fail "actions/checkout is not pinned — branch refs disallowed"
 fi
 
-# 4. actions/dependency-review-action present and pinned to a numeric major.
+# 4. actions/dependency-review-action present and pinned to a numeric major
+# or a 40-char SHA. Issue #136 widened this from `v?[0-9]+` to also accept
+# SHAs whose leading char is a hex letter (a–f) — the v5.0.0 commit SHA
+# `a1d282b…` would otherwise be rejected as "not pinned".
 dr_line="$(grep -nE 'uses:[[:space:]]*actions/dependency-review-action@' "$WORKFLOW" || true)"
 if [[ -z "$dr_line" ]]; then
   fail "actions/dependency-review-action missing — workflow performs no review"
-elif echo "$dr_line" | grep -qE 'actions/dependency-review-action@v?[0-9]+'; then
-  ok "actions/dependency-review-action present and pinned to a numeric major"
+elif echo "$dr_line" | grep -qE 'actions/dependency-review-action@(v[0-9]+|[0-9a-f]{40})\b'; then
+  ok "actions/dependency-review-action present and pinned to a numeric major or 40-char SHA"
 else
   fail "actions/dependency-review-action is not pinned — branch refs disallowed"
 fi

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -105,13 +105,17 @@ lookup_policy() {
     actions/setup-node)               echo "required:6" ;;
     peter-evans/create-pull-request)  echo "required:8" ;;
     ludeeus/action-shellcheck)        echo "required:2" ;;
-    # actions/dependency-review-action: action.yml declares `using: node20`
-    # at v4.9.x (2026-04). No v5 release exists yet. Revisit when upstream
-    # ships a Node 24 runtime.
-    actions/dependency-review-action) echo "node20:4" ;;
-    # rustsec/audit-check: v2.0.0 (2025) still uses Node 20. No v3 exists.
-    # Revisit when upstream publishes a Node 24 release.
-    rustsec/audit-check)              echo "node20:2" ;;
+    # actions/dependency-review-action: v5.0.0 (2026-05-08) ships on Node 24.
+    # The previous v4.9.x line was a tracked Node 20 exception — Issue #136
+    # cleared it once upstream published the Node 24 release.
+    actions/dependency-review-action) echo "required:5" ;;
+    # rustsec/audit-check: the v2.0.0 tag (2024-09-23) still declares
+    # `using: node20`, but master HEAD post upstream #48 (commit
+    # 858dc40, 2026-03-20) is `using: node24`. No v2.1 / v3 tag exists yet,
+    # so we SHA-pin to the master commit and label it `# v2 (master HEAD,
+    # Node 24, post upstream #48)`. Issue #136 cleared the Node 20 exception
+    # when we adopted that SHA.
+    rustsec/audit-check)              echo "required:2" ;;
     # dtolnay/rust-toolchain is a composite/shell action. No Node runtime,
     # so the Node 24 deprecation does not apply.
     dtolnay/rust-toolchain)           echo "no-node" ;;

--- a/tests/scripts/workflow_action_versions.bats
+++ b/tests/scripts/workflow_action_versions.bats
@@ -47,8 +47,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@${SHA_TOOLCHAIN}  # stable, frozen 2026-05-18
       - uses: ludeeus/action-shellcheck@${SHA_SHELLCHECK}  # v2.0.0
       - uses: peter-evans/create-pull-request@${SHA_PR}  # v8
-      - uses: actions/dependency-review-action@${SHA_DEPREV}  # v4.9.0
-      - uses: rustsec/audit-check@${SHA_AUDIT}  # v2.0.0
+      - uses: actions/dependency-review-action@${SHA_DEPREV}  # v5.0.0
+      - uses: rustsec/audit-check@${SHA_AUDIT}  # v2 (master HEAD, Node 24, post upstream #48)
 EOF
 }
 
@@ -58,7 +58,12 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"actions/checkout@${SHA_CHECKOUT}"* ]]
   [[ "$output" == *"SHA-pinned"* ]]
-  [[ "$output" == *"Node 20 exception, tracked"* ]]
+  # Issue #136: dependency-review-action and audit-check both now ship on
+  # Node 24 (>= v5 and master post #48 respectively) — no Node 20 exceptions
+  # remain in the policy. Assert the >= v<N> form replaces the old tracked
+  # exception banner.
+  [[ "$output" == *">= v5, SHA-pinned"* ]]
+  [[ "$output" != *"Node 20 exception, tracked"* ]]
 }
 
 @test "fails when an action is pinned to a version tag instead of a SHA" {
@@ -151,14 +156,24 @@ EOF
   [[ "$output" == *"requires v8 or newer"* ]]
 }
 
-@test "fails when a Node 20 exception is bumped to an unknown major" {
+@test "fails when actions/dependency-review-action comment is older than v5" {
+  # Issue #136 regression: bumping back to v4 (Node 20) must fail because the
+  # policy now requires v5 or newer (Node 24).
   write_compliant_workflow "$TMP_WF/example.yml"
-  # rustsec/audit-check has no v3 yet — enforcing "stay on v2" surfaces the
-  # accidental bump so someone can verify the new major before we adopt it.
-  sed -i.bak "s|rustsec/audit-check@${SHA_AUDIT}  # v2.0.0|rustsec/audit-check@${SHA_AUDIT}  # v3.0.0|" "$TMP_WF/example.yml"
+  sed -i.bak "s|actions/dependency-review-action@${SHA_DEPREV}  # v5.0.0|actions/dependency-review-action@${SHA_DEPREV}  # v4.9.0|" "$TMP_WF/example.yml"
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"tracked Node 20 exception"* ]]
+  [[ "$output" == *"requires v5 or newer"* ]]
+}
+
+@test "fails when rustsec/audit-check comment is older than v2" {
+  # Issue #136 regression: the master HEAD pin must still carry a v2 (or
+  # newer) label so an accidental downgrade to v1 surfaces immediately.
+  write_compliant_workflow "$TMP_WF/example.yml"
+  sed -i.bak "s|rustsec/audit-check@${SHA_AUDIT}  # v2 (master HEAD, Node 24, post upstream #48)|rustsec/audit-check@${SHA_AUDIT}  # v1.4.1|" "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"requires v2 or newer"* ]]
 }
 
 @test "warns but does not fail on an unknown SHA-pinned action" {


### PR DESCRIPTION
## Summary

Continues the work started in PR #135 by clearing the remaining two
**Node 20 deprecated** GitHub Actions that emit "Actions not starting
correctly" warnings on every run and would be force-bumped to Node 24
on 2026-06-02 (8 days from today). With Node 20 removal scheduled for
2026-09-16, leaving the exceptions in place risks runs that genuinely
fail to start once GitHub-hosted runners drop the runtime. Closes #136.

Bumps and rationale:

- `actions/dependency-review-action`: `v4.9.0` (SHA `2031cfc0…`, Node 20)
  → **`v5.0.0`** (SHA `a1d282b3…`, Node 24). Upstream released v5.0.0 on
  2026-05-08 — well past the worker's 24h external-dep quarantine.
- `rustsec/audit-check`: `v2.0.0` (SHA `69366f33…`, Node 20, 2024-09-23)
  → **master HEAD** (SHA `858dc40f…`, Node 24, 2026-03-20). Upstream's
  PR #48 added Node 24 support on master but hasn't shipped a v2.1 / v3
  tag yet, so we SHA-pin to the commit and label it
  `# v2 (master HEAD, Node 24, post upstream #48)`.

Supporting changes so the local quality gate stays green:

- `scripts/check-workflow-action-versions.sh`: both `node20:N` policy
  entries flipped to `required:N` (5 and 2 respectively). The
  `node20:N` code path itself is retained for any future exception.
- `scripts/check-dependency-review-workflow.sh` and
  `scripts/check-cargo-audit-workflow.sh`: widened the SHA-pin regex
  from `v?[0-9]+` to `(v[0-9]+|[0-9a-f]{40})\b`. The old regex silently
  relied on every commit SHA starting with a digit — the new
  dependency-review-action SHA starts with `a1d282b…`, which the
  previous regex rejected as "not pinned".
- `tests/scripts/workflow_action_versions.bats`: updated fixtures
  (`v4.9.0` → `v5.0.0`; `v2.0.0` → `v2 (master HEAD, …)`), removed the
  stale `"Node 20 exception, tracked"` assertion in the happy-path test,
  and added two regression tests (Issue #136) that fail if either
  dependency-review-action is downgraded below v5 or audit-check below
  v2.

## Evidence

CLI / workflow change — no UI screenshot. Evidence is the test suite plus
the validator output.

```mermaid
flowchart LR
    Before["v4.9.0 dep-review<br/>v2.0.0 audit-check<br/>(Node 20 — deprecated)"] --> PR136["Issue #136<br/>policy: required:5 + required:2<br/>SHA-pin regex: v[0-9]+|[0-9a-f]{40}"]
    PR136 --> After["v5.0.0 dep-review<br/>master HEAD audit-check<br/>(Node 24 — supported)"]
    After --> CI["GitHub Actions runners<br/>(Node 20 forced off 2026-06-02)"]
```

Verification:

- `./scripts/check-workflow-action-versions.sh` — every `uses:` line
  reports `>= vN, SHA-pinned` (no `Node 20 exception, tracked` left).
- `./scripts/check-dependency-review-workflow.sh` — accepts the new
  `a1d282b3…` SHA pin (previously rejected as "not pinned" because the
  regex only matched SHAs starting with a digit).
- `./scripts/check-cargo-audit-workflow.sh` — accepts the master-HEAD
  SHA pin for `rustsec/audit-check`.
- `bats tests/scripts/` — 185 tests pass, including the two new
  regression tests `fails when actions/dependency-review-action comment
  is older than v5` and `fails when rustsec/audit-check comment is
  older than v2`.
- `./quality.sh < /dev/null` — full local gate passes (shellcheck,
  cargo-deny, fmt, clippy, check, build, test, doc, release).

## Test Plan

- `bats tests/scripts/workflow_action_versions.bats` — 16 tests,
  including the two new Issue #136 regression tests and an updated
  happy-path assertion (`>= v5, SHA-pinned`).
- `bats tests/scripts/dependency_review_workflow.bats` — 10 tests
  including the real-repo green path (previously failing on the new
  SHA pin until the regex widened).
- `bats tests/scripts/cargo_audit_workflow.bats` — 11 tests.
- `bats tests/scripts/` — full 185-test suite, all passing.
- `./quality.sh < /dev/null` — full local gate.

## Deno regression avoided

N/A — this is a Rust + GitHub Actions repo with no Deno markers
(`deno.json` etc.). No Node-only tooling introduced; the only Node
dependencies touched are GitHub Action SHA pins, which are unavoidable
for this kind of repo.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-136 -->