### PR TITLE
Fix CreatureError->String conversion in score_from_json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.27"
+version = "0.1.33"
 dependencies = [
  "serde",
  "serde_json",
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.34"
+version = "0.5.36"
 dependencies = [
  "bytemuck",
  "clap",

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.36"
+version = "0.5.37"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -303,14 +303,14 @@ fn score_from_json(
     cost: CostKind,
 ) -> Result<ScoreResult, String> {
     let started = Instant::now();
-    let creature = parse_creature_json(creature_json)?;
+    let creature = parse_creature_json(creature_json).map_err(|e| e.to_string())?;
 
     if creature.input == 0 || creature.output == 0 {
         return Err("Creature JSON must set positive input and output counts".to_string());
     }
 
     let compile_started = Instant::now();
-    let mut network = compile_creature(&creature)?;
+    let mut network = compile_creature(&creature).map_err(|e| e.to_string())?;
     let mut compile_time_secs = compile_started.elapsed().as_secs_f64();
     let num_outputs = creature.output;
 


### PR DESCRIPTION
## Problem

`neat-core` (Develop) changed `parse_creature_json` and `compile_creature` to return `Result<_, CreatureError>` instead of `Result<_, String>`. Most call sites in `rust_scorer` were updated with `.map_err(|e| e.to_string())`, but `score_from_json` in `rust_scorer/src/main.rs` still used the bare `?` operator on both calls.

Since `score_from_json` returns `Result<ScoreResult, String>` and there is no `From<CreatureError> for String`, the release build fails:

```
error[E0277]: `?` couldn't convert the error to `std::string::String`
  --> rust_scorer/src/main.rs:306:54
  --> rust_scorer/src/main.rs:313:50
```

## Fix

Apply the same `.map_err(|e| e.to_string())` conversion already used by the other call sites (e.g. `cost_scan_bench.rs`, `multi_score.rs`) to lines 306 and 313.

Also refreshes `Cargo.lock` (stale `neat-core` 0.1.27 → 0.1.33).

## Verification

```
RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer
    Finished `release` profile [optimized] target(s)
```

Builds cleanly against current `neat-core` Develop.

## Context

This breakage blocks **Run quality checks** in `stSoftwareAU/NEAT-AI-Examples` PR #560 (and every other PR there), which builds `rust_scorer` from this repo's `Develop` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)