### PR TITLE
Add least-privilege permissions block to ci.yml (Issue #155)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ on:
       - Develop
   workflow_dispatch:
 
+# Least-privilege default token scope (Issue #155). Without this block every
+# job would inherit the broad repository/organisation default GITHUB_TOKEN.
+# The `quality`, `validation`, `shell-checks` and `spell-check` jobs only read
+# the checked-out code, so a read-only default is sufficient. The `security`
+# job opts into the wider scopes its reusable workflow needs at the job level
+# (see below) — narrowing here, granting there, keeps the blast radius small.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_JOBS: "2"
@@ -144,6 +153,16 @@ jobs:
     # Fan-in after `validation` keeps security audits aligned with the rest
     # of the graph — no advisory scan runs against a broken repo layout.
     needs: [validation]
+    # The reusable security.yml writes check-run annotations and PR/issue
+    # comments, so the calling job must grant those scopes explicitly: a
+    # called workflow's token can only be narrowed, never elevated, along the
+    # caller chain. With the read-only workflow default above, omitting this
+    # block would clamp security.yml's own `checks: write` / `issues: write`
+    # away. Mirrors the permissions declared in security.yml.
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'
     with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "serde",
  "serde_json",
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.39"
+version = "0.5.40"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -323,6 +323,41 @@ graph LR
 The graph is validated by `scripts/check-ci-job-graph.sh` (wired into
 `quality.sh`) and covered end-to-end by `tests/scripts/workflow_job_graph.bats`.
 
+### Least-privilege token scope (Issue #155)
+
+`.github/workflows/ci.yml` declares an explicit workflow-level
+`permissions:` block so every job runs with a least-privilege
+`GITHUB_TOKEN` instead of the broad repository/organisation default:
+
+```yaml
+permissions:
+  contents: read
+```
+
+The `quality`, `validation`, `shell-checks` and `spell-check` jobs only read
+the checked-out code, so the read-only default covers them. The `security`
+job calls the reusable `security.yml`, which writes check-run annotations and
+PR/issue comments, so it opts into the wider scopes **at the job level**:
+
+```yaml
+  security:
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+    uses: ./.github/workflows/security.yml
+```
+
+The job-level grant is required because a called workflow's token can only be
+narrowed, never elevated, along the caller chain — without it the read-only
+workflow default would clamp away `security.yml`'s own `checks: write` /
+`issues: write` and its annotations would silently fail. The rule "narrow at
+the workflow level, grant only where needed at the job level" keeps the blast
+radius small if any step (or a dependency it installs) is compromised.
+
+The scope is validated by `scripts/check-ci-permissions.sh` (wired into
+`quality.sh`) and covered end-to-end by `tests/scripts/ci_permissions.bats`.
+
 ### Pre-quality dependency bump (`bump-deps.sh`)
 
 `bump-deps.sh` lives at the repo root and is invoked by the Vibe Coder

--- a/docs/archive/pr-summaries/pr-summary-155.md
+++ b/docs/archive/pr-summaries/pr-summary-155.md
@@ -1,0 +1,77 @@
+# Add explicit least-privilege `permissions:` to `ci.yml` (Issue #155)
+
+## Summary
+
+`.github/workflows/ci.yml` was the only workflow in the repository without an
+explicit `permissions:` block, so every job inherited the broad
+repository/organisation default `GITHUB_TOKEN` — far more than its read-only
+build/lint/test work needs. This change scopes the token to least privilege.
+Closes #155.
+
+- **Workflow-level default → read-only.** Added a top-level
+  `permissions: { contents: read }` block. The `quality`, `validation`,
+  `shell-checks` and `spell-check` jobs only read the checked-out code, so the
+  read-only default covers them.
+- **`security` job grants its reusable workflow the scopes it needs.** The
+  `security` job calls the reusable `security.yml`, which writes check-run
+  annotations and PR/issue comments (`checks: write`, `issues: write`). A
+  called workflow's token **can only be narrowed, never elevated**, along the
+  caller chain (GitHub: *"permissions can only be maintained or reduced — not
+  elevated — throughout the chain"*). So a job-level `permissions:` block was
+  added to the `security` job mirroring `security.yml`'s own scopes; without
+  it the read-only workflow default would clamp those writes away and the
+  security annotations would silently fail. This is the issue's own guidance —
+  *"grant it at the job level rather than widening the workflow default"*.
+
+```mermaid
+flowchart TD
+    W["ci.yml workflow default<br/>permissions: contents: read"]
+    W --> Q["quality<br/>(inherits read-only)"]
+    W --> V["validation<br/>(inherits read-only)"]
+    W --> SH["shell-checks<br/>(inherits read-only)"]
+    W --> SP["spell-check<br/>(inherits read-only)"]
+    W --> S["security job<br/>permissions:<br/>contents: read<br/>checks: write<br/>issues: write"]
+    S -->|uses| R["security.yml (reusable)<br/>needs checks/issues write"]
+```
+
+## Evidence
+
+Backend/CI change only — no web interface to screenshot. Verified via a new
+validator and BATS suite that follow this repo's established
+`scripts/check-*.sh` + `tests/scripts/*.bats` convention.
+
+- `scripts/check-ci-permissions.sh` fails (red) against the pre-fix `ci.yml`
+  and passes (green) against the fixed file:
+
+  ```text
+  OK   workflow-level permissions block present
+  OK   top-level default grants contents: read
+  OK   top-level default declares no write scopes (read-only)
+  OK   security job declares a job-level permissions block
+  OK   security job grants checks: write
+  OK   security job grants issues: write
+  OK   security job grants contents: read
+  ```
+
+- Wired into `quality.sh` next to the other workflow validators.
+- All 194 BATS tests pass (`bats tests/scripts`), plus `shellcheck -s bash`,
+  `bash -n`, codespell, and markdownlint are clean.
+
+The full `cargo` build/test/release stages of `quality.sh` were not run: this
+change touches only workflow YAML, shell scripts, and docs (no Rust), and
+`quality.sh`'s `cargo upgrade`/`cargo update` steps would dirty the tree with
+dependency bumps unrelated to this issue. Every workflow/shell/docs gate that
+applies to the change was run and passes.
+
+## Test Plan
+
+- Added `scripts/check-ci-permissions.sh` — validates a read-only top-level
+  default and the security job's job-level scopes.
+- Added `tests/scripts/ci_permissions.bats` (10 cases): happy path, missing
+  workflow-level block, missing `contents: read`, write scope at top level,
+  missing security job permissions, missing `checks: write`, missing
+  `issues: write`, missing file, unknown flag, and a guard asserting the real
+  shipped `ci.yml` satisfies every rule.
+- Wired the validator into `quality.sh`.
+- Updated the README **CI** section with a "Least-privilege token scope"
+  subsection.

--- a/quality.sh
+++ b/quality.sh
@@ -65,6 +65,9 @@ echo "🧭 Validating CI job dependency graph (Issue #23)..."
 echo "🔢 Validating workflow action versions for Node 24 compat (Issue #24)..."
 ./scripts/check-workflow-action-versions.sh
 
+echo "🔑 Validating CI least-privilege token scope (Issue #155)..."
+./scripts/check-ci-permissions.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.40"
+version = "0.5.41"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-ci-permissions.sh
+++ b/scripts/check-ci-permissions.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Validate the least-privilege GITHUB_TOKEN scope in .github/workflows/ci.yml
+# (Issue #155).
+#
+# Background: a workflow with no `permissions:` block inherits the
+# repository/organisation default token scope, which can be read/write across
+# many scopes. The `ci.yml` jobs only read the checked-out code and run
+# build/lint/test steps, so a broad token violates least privilege and widens
+# the blast radius if any step (or a dependency it installs) is compromised.
+#
+# Rules enforced:
+#   1. A workflow-level (top-level, column 0) `permissions:` block exists.
+#   2. That default is read-only: it grants `contents: read` and declares no
+#      `*: write` scope at the workflow level.
+#   3. The `security` job — which calls the reusable `security.yml` — declares
+#      its own job-level `permissions:` granting the scopes the reusable
+#      workflow needs (`checks: write`, `issues: write`, and `contents: read`).
+#      This is required because a called workflow's token can only be narrowed,
+#      never elevated, along the caller chain — without the job-level grant the
+#      reusable workflow's own `checks: write` / `issues: write` would be
+#      clamped away by the read-only workflow default and the security
+#      annotations would silently fail.
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. With no argument it validates
+# `.github/workflows/ci.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-ci-permissions.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the CI workflow YAML file (default:
+                    .github/workflows/ci.yml relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow declares a read-only top-level permissions default
+and grants the security job the scopes its reusable workflow needs. Exits
+non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# Emit a TSV report describing the workflow-level permissions block and the
+# `security` job's job-level permissions block. A minimal Python scanner walks
+# the YAML by indentation rather than pulling in a YAML parser — the same
+# approach as check-ci-job-graph.sh.
+#
+# Report lines:
+#   TOPLEVEL_PERMS\t<0|1>          workflow-level permissions block present
+#   TOP\t<key>\t<value>           a scope declared in the top-level block
+#   SECURITY_JOB\t<0|1>            a `security` job is defined
+#   SECURITY_PERMS\t<0|1>         the security job declares permissions
+#   SEC\t<key>\t<value>          a scope declared in the security job block
+report="$(
+  python3 - "$WORKFLOW" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+def indent_of(line):
+    return len(line) - len(line.lstrip(" "))
+
+def is_blank_or_comment(line):
+    s = line.strip()
+    return (not s) or s.startswith("#")
+
+def collect_block(start, parent_indent):
+    """Collect `key: value` children whose indent is exactly parent_indent+2,
+    stopping at the first line indented back to <= parent_indent."""
+    child_indent = parent_indent + 2
+    out = []
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        if is_blank_or_comment(line):
+            i += 1
+            continue
+        ind = indent_of(line)
+        if ind <= parent_indent:
+            break
+        if ind == child_indent and ":" in line:
+            key, _, val = line.strip().partition(":")
+            out.append((key.strip(), val.strip()))
+        i += 1
+    return out
+
+# --- Workflow-level permissions (indent 0) ---
+top_perms_present = False
+top_perms = []
+for i, line in enumerate(lines):
+    if indent_of(line) == 0 and line.strip().rstrip() == "permissions:":
+        top_perms_present = True
+        top_perms = collect_block(i + 1, 0)
+        break
+
+print(f"TOPLEVEL_PERMS\t{1 if top_perms_present else 0}")
+for k, v in top_perms:
+    print(f"TOP\t{k}\t{v}")
+
+# --- Locate the jobs map and the `security` job block ---
+jobs_start = None
+for i, line in enumerate(lines):
+    if indent_of(line) == 0 and line.strip() == "jobs:":
+        jobs_start = i + 1
+        break
+
+security_job_present = False
+security_perms_present = False
+security_perms = []
+
+if jobs_start is not None:
+    # Job entries are keys at the first indent level under `jobs:`.
+    job_indent = None
+    sec_start = None
+    sec_end = len(lines)
+    i = jobs_start
+    while i < len(lines):
+        line = lines[i]
+        if is_blank_or_comment(line):
+            i += 1
+            continue
+        ind = indent_of(line)
+        if ind == 0:
+            break
+        if job_indent is None:
+            job_indent = ind
+        if ind == job_indent and line.rstrip().endswith(":"):
+            name = line.strip().rstrip(":")
+            if name == "security":
+                security_job_present = True
+                sec_start = i + 1
+                # find end: next line at indent <= job_indent
+                for j in range(i + 1, len(lines)):
+                    if is_blank_or_comment(lines[j]):
+                        continue
+                    if indent_of(lines[j]) <= job_indent:
+                        sec_end = j
+                        break
+                break
+        i += 1
+
+    if security_job_present and sec_start is not None:
+        child_indent = job_indent + 2
+        k = sec_start
+        while k < sec_end:
+            line = lines[k]
+            if is_blank_or_comment(line):
+                k += 1
+                continue
+            if indent_of(line) == child_indent and line.strip().rstrip() == "permissions:":
+                security_perms_present = True
+                security_perms = collect_block(k + 1, child_indent)
+                break
+            k += 1
+
+print(f"SECURITY_JOB\t{1 if security_job_present else 0}")
+print(f"SECURITY_PERMS\t{1 if security_perms_present else 0}")
+for k, v in security_perms:
+    print(f"SEC\t{k}\t{v}")
+PY
+)"
+
+# --- Helpers to query the TSV report ---
+field() {
+  # field <TAG> -> prints the single value column for a 2-column tag line
+  awk -F '\t' -v tag="$1" '$1==tag { print $2 }' <<< "$report"
+}
+scope_value() {
+  # scope_value <TAG> <key> -> prints the value for a scope under TAG (TOP|SEC)
+  awk -F '\t' -v tag="$1" -v key="$2" '$1==tag && $2==key { print $3 }' <<< "$report"
+}
+write_scopes() {
+  # write_scopes <TAG> -> prints "key" for each scope whose value is "write"
+  awk -F '\t' -v tag="$1" '$1==tag && $3=="write" { print $2 }' <<< "$report"
+}
+
+# 1. Workflow-level permissions block present.
+if [[ "$(field TOPLEVEL_PERMS)" == "1" ]]; then
+  ok "workflow-level permissions block present"
+else
+  fail "no workflow-level 'permissions:' block — token inherits the broad repository default"
+fi
+
+# 2. Top-level default is read-only.
+if [[ "$(scope_value TOP contents)" == "read" ]]; then
+  ok "top-level default grants contents: read"
+else
+  fail "top-level permissions must grant 'contents: read'"
+fi
+
+top_writes="$(write_scopes TOP)"
+if [[ -z "$top_writes" ]]; then
+  ok "top-level default declares no write scopes (read-only)"
+else
+  fail "top-level permissions must not grant write scopes (found: $(echo "$top_writes" | tr '\n' ' '))"
+fi
+
+# 3. The security job grants the reusable workflow its required scopes.
+if [[ "$(field SECURITY_JOB)" == "1" ]]; then
+  ok "security job defined"
+
+  if [[ "$(field SECURITY_PERMS)" == "1" ]]; then
+    ok "security job declares a job-level permissions block"
+  else
+    fail "security job must declare job-level 'permissions:' — the reusable security.yml needs checks/issues write, and a read-only default would clamp them away"
+  fi
+
+  for scope in checks issues; do
+    if [[ "$(scope_value SEC "$scope")" == "write" ]]; then
+      ok "security job grants $scope: write"
+    else
+      fail "security job must grant '$scope: write' for the reusable security.yml"
+    fi
+  done
+
+  if [[ "$(scope_value SEC contents)" == "read" ]]; then
+    ok "security job grants contents: read"
+  else
+    fail "security job must grant 'contents: read' for the reusable security.yml"
+  fi
+else
+  fail "no 'security' job found — cannot verify its token scope"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/ci_permissions.bats
+++ b/tests/scripts/ci_permissions.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-ci-permissions.sh — Issue #155.
+#
+# Exercises the least-privilege token-scope validator end-to-end with
+# synthetic CI workflow YAML in temporary directories, plus one assertion
+# against the real repo workflow so the enforced rules and the shipped
+# workflow cannot drift apart.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-ci-permissions.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF_DIR="$(mktemp -d)"
+  TMP_WF="$TMP_WF_DIR/ci.yml"
+  export TMP_WF_DIR TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF_DIR"
+}
+
+# Canonical fixture: a least-privilege CI workflow. Failure tests mutate this
+# one rule at a time.
+write_good_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: CI
+on: [pull_request]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validation:
+    name: Project Validation
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+
+  quality:
+    name: Quality Checks
+    needs: [validation]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+
+  security:
+    needs: [validation]
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+    uses: ./.github/workflows/security.yml
+    if: github.event_name == 'pull_request'
+    with:
+      include-dependency-review: true
+EOF
+}
+
+@test "passes on a least-privilege workflow" {
+  write_good_workflow "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"workflow-level permissions block present"* ]]
+  [[ "$output" == *"top-level default grants contents: read"* ]]
+  [[ "$output" == *"top-level default declares no write scopes"* ]]
+  [[ "$output" == *"security job grants checks: write"* ]]
+  [[ "$output" == *"security job grants issues: write"* ]]
+}
+
+@test "fails when there is no workflow-level permissions block" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  security:
+    needs: [validation]
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+    uses: ./.github/workflows/security.yml
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no workflow-level 'permissions:' block"* ]]
+}
+
+@test "fails when the top-level default omits contents: read" {
+  write_good_workflow "$TMP_WF"
+  # Replace the top-level read default with an unrelated scope only.
+  sed -i.bak 's/^  contents: read$/  actions: read/' "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"top-level permissions must grant 'contents: read'"* ]]
+}
+
+@test "fails when the top-level default grants a write scope" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+
+permissions:
+  contents: write
+
+jobs:
+  security:
+    needs: [validation]
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+    uses: ./.github/workflows/security.yml
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must not grant write scopes"* ]]
+}
+
+@test "fails when the security job has no permissions block" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    needs: [validation]
+    uses: ./.github/workflows/security.yml
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"security job must declare job-level 'permissions:'"* ]]
+}
+
+@test "fails when the security job omits checks: write" {
+  write_good_workflow "$TMP_WF"
+  # Drop the checks: write line from the security job's permissions block.
+  grep -v 'checks: write' "$TMP_WF" >"$TMP_WF.stripped"
+  mv "$TMP_WF.stripped" "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"security job must grant 'checks: write'"* ]]
+}
+
+@test "fails when the security job omits issues: write" {
+  write_good_workflow "$TMP_WF"
+  grep -v 'issues: write' "$TMP_WF" >"$TMP_WF.stripped"
+  mv "$TMP_WF.stripped" "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"security job must grant 'issues: write'"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository ci.yml satisfies every least-privilege rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Add explicit least-privilege `permissions:` to `ci.yml` (Issue #155)

## Summary

`.github/workflows/ci.yml` was the only workflow in the repository without an
explicit `permissions:` block, so every job inherited the broad
repository/organisation default `GITHUB_TOKEN` — far more than its read-only
build/lint/test work needs. This change scopes the token to least privilege.
Closes #155.

- **Workflow-level default → read-only.** Added a top-level
  `permissions: { contents: read }` block. The `quality`, `validation`,
  `shell-checks` and `spell-check` jobs only read the checked-out code, so the
  read-only default covers them.
- **`security` job grants its reusable workflow the scopes it needs.** The
  `security` job calls the reusable `security.yml`, which writes check-run
  annotations and PR/issue comments (`checks: write`, `issues: write`). A
  called workflow's token **can only be narrowed, never elevated**, along the
  caller chain (GitHub: *"permissions can only be maintained or reduced — not
  elevated — throughout the chain"*). So a job-level `permissions:` block was
  added to the `security` job mirroring `security.yml`'s own scopes; without
  it the read-only workflow default would clamp those writes away and the
  security annotations would silently fail. This is the issue's own guidance —
  *"grant it at the job level rather than widening the workflow default"*.

```mermaid
flowchart TD
    W["ci.yml workflow default<br/>permissions: contents: read"]
    W --> Q["quality<br/>(inherits read-only)"]
    W --> V["validation<br/>(inherits read-only)"]
    W --> SH["shell-checks<br/>(inherits read-only)"]
    W --> SP["spell-check<br/>(inherits read-only)"]
    W --> S["security job<br/>permissions:<br/>contents: read<br/>checks: write<br/>issues: write"]
    S -->|uses| R["security.yml (reusable)<br/>needs checks/issues write"]
```

## Evidence

Backend/CI change only — no web interface to screenshot. Verified via a new
validator and BATS suite that follow this repo's established
`scripts/check-*.sh` + `tests/scripts/*.bats` convention.

- `scripts/check-ci-permissions.sh` fails (red) against the pre-fix `ci.yml`
  and passes (green) against the fixed file:

  ```text
  OK   workflow-level permissions block present
  OK   top-level default grants contents: read
  OK   top-level default declares no write scopes (read-only)
  OK   security job declares a job-level permissions block
  OK   security job grants checks: write
  OK   security job grants issues: write
  OK   security job grants contents: read
  ```

- Wired into `quality.sh` next to the other workflow validators.
- All 194 BATS tests pass (`bats tests/scripts`), plus `shellcheck -s bash`,
  `bash -n`, codespell, and markdownlint are clean.

The full `cargo` build/test/release stages of `quality.sh` were not run: this
change touches only workflow YAML, shell scripts, and docs (no Rust), and
`quality.sh`'s `cargo upgrade`/`cargo update` steps would dirty the tree with
dependency bumps unrelated to this issue. Every workflow/shell/docs gate that
applies to the change was run and passes.

## Test Plan

- Added `scripts/check-ci-permissions.sh` — validates a read-only top-level
  default and the security job's job-level scopes.
- Added `tests/scripts/ci_permissions.bats` (10 cases): happy path, missing
  workflow-level block, missing `contents: read`, write scope at top level,
  missing security job permissions, missing `checks: write`, missing
  `issues: write`, missing file, unknown flag, and a guard asserting the real
  shipped `ci.yml` satisfies every rule.
- Wired the validator into `quality.sh`.
- Updated the README **CI** section with a "Least-privilege token scope"
  subsection.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq2se953-70aa18`<!-- vibe-worker-issue-155 -->