### PR TITLE
Add per-job timeout-minutes across all workflows (Issue #154)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -28,6 +28,7 @@ jobs:
   auto-format:
     name: Auto-format Code
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Skip forks — GITHUB_TOKEN cannot push to a fork's branch. Formatting
     # on fork PRs is the author's responsibility.
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -39,6 +39,7 @@ concurrency:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5

--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -40,6 +40,7 @@ jobs:
   quality:
     name: Cargo Format and Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       RUSTFLAGS: "-D warnings"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
     # Foundational layout check must pass before we spend minutes compiling.
     needs: [validation]
     runs-on: ubuntu-latest
+    # Full cargo build + test + doc + release; the heaviest job in the graph.
+    timeout-minutes: 30
     env:
       RUSTFLAGS: "-D warnings"
 
@@ -171,6 +173,7 @@ jobs:
   validation:
     name: Project Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -222,6 +225,7 @@ jobs:
   shell-checks:
     name: Shell Script Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Upstream ShellCheck project: https://github.com/koalaman/shellcheck
     # Action wrapper used below: ludeeus/action-shellcheck (runs koalaman/shellcheck).
 
@@ -281,6 +285,7 @@ jobs:
   spell-check:
     name: Spell Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -321,6 +326,8 @@ jobs:
     needs: [validation, quality, security, shell-checks, spell-check]
     if: always()
     runs-on: ubuntu-latest
+    # Lightweight fan-in gate — only inspects upstream job results.
+    timeout-minutes: 5
     steps:
       - name: Verify all gating jobs succeeded
         env:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,6 +38,7 @@ concurrency:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -25,6 +25,7 @@ jobs:
   gitleaks:
     name: Gitleaks Secrets Detection
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Pinned release. Bump both values together and record the upstream
     # release notes / rationale in the PR that lifts them.
     env:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -35,6 +35,7 @@ jobs:
   markdownlint:
     name: Markdown Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,6 +37,7 @@ jobs:
   semgrep:
     name: Semgrep SAST Scanning
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container:
       # Pinned Semgrep release. Equivalent to `uses: semgrep/semgrep-action@v1`.
       # Digest pin: semgrep/semgrep v1.86.0 multi-arch manifest, frozen

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -30,6 +30,7 @@ jobs:
   guard:
     name: Version Bump Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Never attempt to push onto a fork's branch — the GITHUB_TOKEN cannot
     # write there, and bump-on-fork is the PR author's responsibility.
     if: github.event.pull_request.head.repo.full_name == github.repository
@@ -77,6 +78,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.should_bump == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5

--- a/README.md
+++ b/README.md
@@ -358,6 +358,21 @@ radius small if any step (or a dependency it installs) is compromised.
 The scope is validated by `scripts/check-ci-permissions.sh` (wired into
 `quality.sh`) and covered end-to-end by `tests/scripts/ci_permissions.bats`.
 
+### Per-job timeouts (Issue #154)
+
+Every job across `.github/workflows/` declares an explicit `timeout-minutes`
+so a hung compile, a wedged `cargo install`, a stuck network fetch, or a
+runaway test fails fast instead of occupying a shared runner for GitHub's
+360-minute (6-hour) default. Budgets are sized to the work each job performs:
+`ci.yml`'s `quality` job (full cargo build + test + doc + release) gets 30
+minutes, the security/audit jobs 15, and the lint/format/spell/version jobs
+5–10. A reusable-workflow-call job (`security` in `ci.yml`) cannot declare
+`timeout-minutes` — GitHub rejects that keyword on caller jobs — so its budget
+lives in the called workflow's own job (`security.yml`).
+
+The rule is validated by `scripts/check-workflow-timeouts.sh` (wired into
+`quality.sh`) and covered end-to-end by `tests/scripts/workflow_timeouts.bats`.
+
 ### Pre-quality dependency bump (`bump-deps.sh`)
 
 `bump-deps.sh` lives at the repo root and is invoked by the Vibe Coder

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NEAT-AI-scorer
 
-Native **MSE scorer** CLI for NEAT-AI creatures. Shared logic lives in **`neat-core`**, resolved from a **path dependency** on **[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)** (see `rust_scorer/Cargo.toml`). GitHub Actions checks out `NEAT-AI-core` next to this repo so CI can resolve that path.
+Native **MSE scorer** CLI for NEAT-AI creatures. Shared logic lives in **`neat-core`**, resolved from a **path dependency** on **[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)** (see `rust_scorer/Cargo.toml`). GitHub Actions checks out `NEAT-AI-core` next to this repo so CI can resolve that path
 
 ## Source
 

--- a/docs/archive/pr-summaries/pr-summary-154.md
+++ b/docs/archive/pr-summaries/pr-summary-154.md
@@ -1,0 +1,87 @@
+# Add per-job `timeout-minutes` across all workflows (Issue #154)
+
+## Summary
+
+No job under `.github/workflows/` declared `timeout-minutes`, so every job
+inherited GitHub's 360-minute (6-hour) default. A hung compile, a wedged
+`cargo install`, a stuck network fetch, or a runaway test could occupy a shared
+runner for the full six hours before reclamation — delaying queued runs,
+burning runner minutes, and masking a stuck step behind a long silent wait.
+
+This PR adds an explicit, work-sized `timeout-minutes` to every job and ships a
+guard (`scripts/check-workflow-timeouts.sh`, wired into `quality.sh`) plus BATS
+coverage so the rule cannot regress. Closes #154.
+
+### Budgets applied
+
+| Workflow | Job | timeout-minutes |
+| --- | --- | --- |
+| `ci.yml` | `quality` (cargo build + test + doc + release) | 30 |
+| `ci.yml` | `validation` | 10 |
+| `ci.yml` | `shell-checks` | 10 |
+| `ci.yml` | `spell-check` | 10 |
+| `ci.yml` | `ci-required` (fan-in gate) | 5 |
+| `security.yml` | `security` | 15 |
+| `cargo-audit.yml` | `audit` | 15 |
+| `cargo-quality.yml` | `quality` | 15 |
+| `dependency-review.yml` | `dependency-review` | 10 |
+| `auto-format.yml` | `auto-format` | 10 |
+| `version-increment.yml` | `guard` | 5 |
+| `version-increment.yml` | `bump` | 10 |
+| `gitleaks.yml` | `gitleaks` | 10 |
+| `markdown-lint.yml` | `markdownlint` | 10 |
+| `semgrep.yml` | `semgrep` | 10 |
+
+The `security` job in `ci.yml` is a reusable-workflow call (`uses:`). GitHub
+rejects `timeout-minutes` on caller jobs, so its budget lives in the called
+workflow's own job — `security.yml`'s `security` (15 min). The validator
+understands this and does not require (in fact forbids) a timeout on caller
+jobs.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified via the new guard
+script and BATS suite.
+
+`scripts/check-workflow-timeouts.sh` before the fix (all jobs flagged):
+
+```
+FAIL ci.yml: job 'quality' has no timeout-minutes — it inherits GitHub's 360-minute default
+FAIL ci.yml: job 'validation' has no timeout-minutes — it inherits GitHub's 360-minute default
+... (every normal job across every workflow)
+```
+
+After the fix:
+
+```
+OK   ci.yml: job 'quality' declares timeout-minutes: 30
+OK   ci.yml: job 'security' is a reusable-workflow call (timeout belongs in the called workflow)
+OK   security.yml: job 'security' declares timeout-minutes: 15
+... (every job OK, exit 0)
+```
+
+### Validation flow
+
+```mermaid
+flowchart LR
+    A[quality.sh] --> B[check-workflow-timeouts.sh]
+    B --> C{Each job in<br/>.github/workflows/}
+    C -->|reusable uses: job| D[must NOT set timeout]
+    C -->|normal job| E[must set 1..360 min]
+    D --> F[exit 0 / fail with message]
+    E --> F
+```
+
+## Test Plan
+
+- Added `scripts/check-workflow-timeouts.sh` — an indentation-based YAML scanner
+  that asserts every normal job declares a `timeout-minutes` between 1 and 360,
+  and that reusable-call jobs declare none.
+- Added `tests/scripts/workflow_timeouts.bats` (9 cases): passes on a good
+  workflow; fails on a missing timeout, a non-integer value, a value above 360,
+  a zero value, and a timeout on a reusable-call job; handles a missing file and
+  an unknown flag; and asserts the real repository workflows all pass.
+- Wired the guard into `quality.sh` alongside the other workflow validators.
+- `bats tests/scripts` — all 203 cases pass.
+- `shellcheck -s bash` clean across every `*.sh`.
+- All existing workflow check scripts still pass against the edited YAML.

--- a/docs/archive/pr-summaries/pr-summary-154.md
+++ b/docs/archive/pr-summaries/pr-summary-154.md
@@ -45,7 +45,7 @@ script and BATS suite.
 
 `scripts/check-workflow-timeouts.sh` before the fix (all jobs flagged):
 
-```
+```text
 FAIL ci.yml: job 'quality' has no timeout-minutes — it inherits GitHub's 360-minute default
 FAIL ci.yml: job 'validation' has no timeout-minutes — it inherits GitHub's 360-minute default
 ... (every normal job across every workflow)
@@ -53,7 +53,7 @@ FAIL ci.yml: job 'validation' has no timeout-minutes — it inherits GitHub's 36
 
 After the fix:
 
-```
+```text
 OK   ci.yml: job 'quality' declares timeout-minutes: 30
 OK   ci.yml: job 'security' is a reusable-workflow call (timeout belongs in the called workflow)
 OK   security.yml: job 'security' declares timeout-minutes: 15

--- a/quality.sh
+++ b/quality.sh
@@ -68,6 +68,9 @@ echo "🔢 Validating workflow action versions for Node 24 compat (Issue #24)...
 echo "🔑 Validating CI least-privilege token scope (Issue #155)..."
 ./scripts/check-ci-permissions.sh
 
+echo "⏱️  Validating per-job timeout-minutes across workflows (Issue #154)..."
+./scripts/check-workflow-timeouts.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.41"
+version = "0.5.42"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-workflow-timeouts.sh
+++ b/scripts/check-workflow-timeouts.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Validate that every job across .github/workflows/ declares an explicit
+# `timeout-minutes` (Issue #154).
+#
+# Background: a job without `timeout-minutes` inherits GitHub's 360-minute
+# (6-hour) default. A hung compile, a wedged `cargo install`, a stuck network
+# fetch, or a runaway test can then occupy a shared runner for the full six
+# hours before it is reclaimed — delaying queued runs, burning runner minutes,
+# and masking a genuinely stuck step behind a long, silent wait. An explicit
+# per-job timeout converts a hang into a fast, legible failure.
+#
+# Rules enforced, per job in each workflow:
+#   1. A normal job (one that runs steps on a runner) MUST declare a
+#      job-level `timeout-minutes:`.
+#   2. The declared value MUST be a positive integer no greater than 360
+#      (GitHub's own ceiling — a larger value is silently capped and signals a
+#      mistake).
+#   3. A reusable-workflow-call job (a job whose body is a `uses:` reference)
+#      MUST NOT declare `timeout-minutes` — GitHub rejects that keyword on
+#      caller jobs; the timeout belongs in the called workflow's own jobs.
+#
+# The script accepts zero or more `--workflow PATH` arguments so BATS tests can
+# exercise it against fixtures. With no argument it validates every
+# `*.yml`/`*.yaml` file under `.github/workflows/` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-workflow-timeouts.sh [--workflow PATH]...
+
+Options:
+  --workflow PATH   Path to a workflow YAML file to validate. May be repeated.
+                    With no --workflow argument, every *.yml/*.yaml file under
+                    .github/workflows/ (relative to the repo root) is checked.
+  -h, --help        Show this message.
+
+Exits 0 when every normal job declares a sane `timeout-minutes` and no
+reusable-call job declares one. Exits non-zero with a descriptive message
+otherwise.
+EOF
+}
+
+WORKFLOWS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      [[ $# -ge 2 ]] || { echo "--workflow requires a PATH argument" >&2; exit 2; }
+      WORKFLOWS+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WF_DIR="$SCRIPT_DIR/../.github/workflows"
+  while IFS= read -r f; do
+    WORKFLOWS+=("$f")
+  done < <(find "$WF_DIR" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+fi
+
+if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then
+  echo "No workflow files to validate" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $1: ${*:2}" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $1: ${*:2}"
+}
+
+# Maximum permitted timeout — GitHub caps a job at 360 minutes regardless.
+MAX_TIMEOUT=360
+
+validate_workflow() {
+  local wf="$1"
+
+  if [[ ! -f "$wf" ]]; then
+    echo "Workflow file not found: $wf" >&2
+    EXIT_CODE=1
+    return
+  fi
+
+  # Emit a TSV report, one line per job:
+  #   JOB\t<name>\t<is_reusable 0|1>\t<has_timeout 0|1>\t<timeout_value|->
+  # A minimal indentation-based scanner walks the YAML rather than pulling in a
+  # YAML parser — the same approach as check-ci-permissions.sh.
+  local report
+  report="$(
+    python3 - "$wf" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+def indent_of(line):
+    return len(line) - len(line.lstrip(" "))
+
+def is_blank_or_comment(line):
+    s = line.strip()
+    return (not s) or s.startswith("#")
+
+# Locate the top-level `jobs:` map.
+jobs_start = None
+for i, line in enumerate(lines):
+    if indent_of(line) == 0 and line.strip() == "jobs:":
+        jobs_start = i + 1
+        break
+
+if jobs_start is None:
+    sys.exit(0)
+
+# Determine the job-key indent (first non-blank line under `jobs:`).
+job_indent = None
+for i in range(jobs_start, len(lines)):
+    if is_blank_or_comment(lines[i]):
+        continue
+    ind = indent_of(lines[i])
+    if ind == 0:
+        break
+    job_indent = ind
+    break
+
+if job_indent is None:
+    sys.exit(0)
+
+child_indent = job_indent + 2
+
+# Collect job boundaries.
+jobs = []  # (name, start_line, end_line)
+i = jobs_start
+current = None
+while i < len(lines):
+    line = lines[i]
+    if is_blank_or_comment(line):
+        i += 1
+        continue
+    ind = indent_of(line)
+    if ind == 0:
+        break
+    if ind == job_indent and line.rstrip().endswith(":"):
+        if current is not None:
+            jobs.append((current[0], current[1], i))
+        name = line.strip().rstrip(":")
+        current = (name, i + 1)
+    i += 1
+if current is not None:
+    jobs.append((current[0], current[1], i))
+
+for name, start, end in jobs:
+    is_reusable = 0
+    has_timeout = 0
+    timeout_value = "-"
+    for k in range(start, end):
+        line = lines[k]
+        if is_blank_or_comment(line):
+            continue
+        if indent_of(line) != child_indent:
+            continue
+        key, _, val = line.strip().partition(":")
+        key = key.strip()
+        val = val.strip()
+        if key == "uses":
+            is_reusable = 1
+        elif key == "timeout-minutes":
+            has_timeout = 1
+            timeout_value = val if val else "-"
+    print(f"JOB\t{name}\t{is_reusable}\t{has_timeout}\t{timeout_value}")
+PY
+  )"
+
+  if [[ -z "$report" ]]; then
+    fail "$wf" "no jobs found — cannot verify timeouts"
+    return
+  fi
+
+  while IFS=$'\t' read -r tag name is_reusable has_timeout value; do
+    [[ "$tag" == "JOB" ]] || continue
+    if [[ "$is_reusable" == "1" ]]; then
+      # Reusable-call jobs must not declare timeout-minutes.
+      if [[ "$has_timeout" == "1" ]]; then
+        fail "$wf" "job '$name' calls a reusable workflow and must not declare timeout-minutes (set it in the called workflow's jobs)"
+      else
+        ok "$wf" "job '$name' is a reusable-workflow call (timeout belongs in the called workflow)"
+      fi
+      continue
+    fi
+
+    if [[ "$has_timeout" != "1" ]]; then
+      fail "$wf" "job '$name' has no timeout-minutes — it inherits GitHub's 360-minute default"
+      continue
+    fi
+
+    if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+      fail "$wf" "job '$name' timeout-minutes must be a positive integer (found: '$value')"
+      continue
+    fi
+    if [[ "$value" -lt 1 || "$value" -gt "$MAX_TIMEOUT" ]]; then
+      fail "$wf" "job '$name' timeout-minutes must be between 1 and $MAX_TIMEOUT (found: $value)"
+      continue
+    fi
+
+    ok "$wf" "job '$name' declares timeout-minutes: $value"
+  done <<< "$report"
+}
+
+for wf in "${WORKFLOWS[@]}"; do
+  validate_workflow "$wf"
+done
+
+exit "$EXIT_CODE"

--- a/tests/scripts/workflow_timeouts.bats
+++ b/tests/scripts/workflow_timeouts.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-workflow-timeouts.sh — Issue #154.
+#
+# Exercises the per-job `timeout-minutes` validator end-to-end with synthetic
+# workflow YAML in temporary directories, plus one assertion against the real
+# repo workflows so the enforced rule and the shipped workflows cannot drift
+# apart.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-workflow-timeouts.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF_DIR="$(mktemp -d)"
+  TMP_WF="$TMP_WF_DIR/wf.yml"
+  export TMP_WF_DIR TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF_DIR"
+}
+
+# Canonical fixture: a workflow where every normal job declares a sane
+# timeout and the reusable-call job correctly declares none.
+write_good_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: CI
+on: [pull_request]
+
+jobs:
+  quality:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - run: echo ok
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - run: echo ok
+
+  security:
+    needs: [quality]
+    uses: ./.github/workflows/security.yml
+    if: github.event_name == 'pull_request'
+EOF
+}
+
+@test "passes when every normal job declares a sane timeout" {
+  write_good_workflow "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"job 'quality' declares timeout-minutes: 30"* ]]
+  [[ "$output" == *"job 'lint' declares timeout-minutes: 10"* ]]
+  [[ "$output" == *"job 'security' is a reusable-workflow call"* ]]
+}
+
+@test "fails when a normal job has no timeout-minutes" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [push]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"job 'build' has no timeout-minutes"* ]]
+}
+
+@test "fails when the timeout value is not a positive integer" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: soon
+    steps:
+      - run: echo ok
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be a positive integer"* ]]
+}
+
+@test "fails when the timeout exceeds GitHub's 360-minute ceiling" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 600
+    steps:
+      - run: echo ok
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be between 1 and 360"* ]]
+}
+
+@test "fails when a zero timeout is declared" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 0
+    steps:
+      - run: echo ok
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be between 1 and 360"* ]]
+}
+
+@test "fails when a reusable-call job declares timeout-minutes" {
+  cat >"$TMP_WF" <<'EOF'
+name: CI
+on: [pull_request]
+
+jobs:
+  security:
+    timeout-minutes: 15
+    uses: ./.github/workflows/security.yml
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"calls a reusable workflow and must not declare timeout-minutes"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "every real repository workflow job declares a sane timeout" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Add per-job `timeout-minutes` across all workflows (Issue #154)

## Summary

No job under `.github/workflows/` declared `timeout-minutes`, so every job
inherited GitHub's 360-minute (6-hour) default. A hung compile, a wedged
`cargo install`, a stuck network fetch, or a runaway test could occupy a shared
runner for the full six hours before reclamation — delaying queued runs,
burning runner minutes, and masking a stuck step behind a long silent wait.

This PR adds an explicit, work-sized `timeout-minutes` to every job and ships a
guard (`scripts/check-workflow-timeouts.sh`, wired into `quality.sh`) plus BATS
coverage so the rule cannot regress. Closes #154.

### Budgets applied

| Workflow | Job | timeout-minutes |
| --- | --- | --- |
| `ci.yml` | `quality` (cargo build + test + doc + release) | 30 |
| `ci.yml` | `validation` | 10 |
| `ci.yml` | `shell-checks` | 10 |
| `ci.yml` | `spell-check` | 10 |
| `ci.yml` | `ci-required` (fan-in gate) | 5 |
| `security.yml` | `security` | 15 |
| `cargo-audit.yml` | `audit` | 15 |
| `cargo-quality.yml` | `quality` | 15 |
| `dependency-review.yml` | `dependency-review` | 10 |
| `auto-format.yml` | `auto-format` | 10 |
| `version-increment.yml` | `guard` | 5 |
| `version-increment.yml` | `bump` | 10 |
| `gitleaks.yml` | `gitleaks` | 10 |
| `markdown-lint.yml` | `markdownlint` | 10 |
| `semgrep.yml` | `semgrep` | 10 |

The `security` job in `ci.yml` is a reusable-workflow call (`uses:`). GitHub
rejects `timeout-minutes` on caller jobs, so its budget lives in the called
workflow's own job — `security.yml`'s `security` (15 min). The validator
understands this and does not require (in fact forbids) a timeout on caller
jobs.

## Evidence

Backend/CI change — no web interface to screenshot. Verified via the new guard
script and BATS suite.

`scripts/check-workflow-timeouts.sh` before the fix (all jobs flagged):

```
FAIL ci.yml: job 'quality' has no timeout-minutes — it inherits GitHub's 360-minute default
FAIL ci.yml: job 'validation' has no timeout-minutes — it inherits GitHub's 360-minute default
... (every normal job across every workflow)
```

After the fix:

```
OK   ci.yml: job 'quality' declares timeout-minutes: 30
OK   ci.yml: job 'security' is a reusable-workflow call (timeout belongs in the called workflow)
OK   security.yml: job 'security' declares timeout-minutes: 15
... (every job OK, exit 0)
```

### Validation flow

```mermaid
flowchart LR
    A[quality.sh] --> B[check-workflow-timeouts.sh]
    B --> C{Each job in<br/>.github/workflows/}
    C -->|reusable uses: job| D[must NOT set timeout]
    C -->|normal job| E[must set 1..360 min]
    D --> F[exit 0 / fail with message]
    E --> F
```

## Test Plan

- Added `scripts/check-workflow-timeouts.sh` — an indentation-based YAML scanner
  that asserts every normal job declares a `timeout-minutes` between 1 and 360,
  and that reusable-call jobs declare none.
- Added `tests/scripts/workflow_timeouts.bats` (9 cases): passes on a good
  workflow; fails on a missing timeout, a non-integer value, a value above 360,
  a zero value, and a timeout on a reusable-call job; handles a missing file and
  an unknown flag; and asserts the real repository workflows all pass.
- Wired the guard into `quality.sh` alongside the other workflow validators.
- `bats tests/scripts` — all 203 cases pass.
- `shellcheck -s bash` clean across every `*.sh`.
- All existing workflow check scripts still pass against the edited YAML.
