### PR TITLE
Add CycloneDX SBOM workflow for the rust_scorer binary (Issue #172)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,83 @@
+name: SBOM
+
+# Software Bill of Materials workflow (Issue #172).
+#
+# `rust_scorer` ships a binary (`[[bin]] name = "rust_scorer"`), so it has a
+# real binary surface whose dependency inventory should be captured in a
+# standard, scanner-consumable format. `Cargo.lock` already pins the full
+# graph; this workflow exports it as a CycloneDX SBOM and uploads the document
+# as a build artefact. When a supply-chain advisory drops ("crate X version Y
+# is compromised"), the SBOM is the lookup table that answers "are we affected,
+# and where?" in seconds — without re-deriving the dependency tree by hand or
+# needing a Rust toolchain.
+#
+# Scope note (see issue cross-links): active dependency vulnerabilities are
+# owned by `cargo-audit.yml` / `security.yml`; this workflow only emits the
+# inventory artefact (the posture gap), it does not gate on advisories.
+#
+# Action versions follow `scripts/check-workflow-action-versions.sh`: every
+# `uses:` is SHA-pinned with a trailing `# <version>` comment.
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [Develop]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  workflow_dispatch:
+
+# Least-privilege token scope (Issue #155): generating and uploading an SBOM
+# only reads the checked-out code.
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      # Path strategy for the NEAT-AI-core sibling (Issue #18): clone it INTO
+      # the workspace, then symlink so Cargo resolves the
+      # `../../NEAT-AI-core/neat-core` path dependency. cargo-cyclonedx reads
+      # the resolved workspace metadata, so the path dependency must resolve.
+      - name: Checkout NEAT-AI-core (path dependency for neat-core)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          ref: Develop
+          path: NEAT-AI-core
+
+      - name: Link NEAT-AI-core sibling path expected by Cargo
+        run: |
+          if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
+            ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
+
+      - name: Install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --locked
+
+      - name: Generate CycloneDX SBOM
+        # Reads Cargo.lock / resolved workspace metadata and emits a standard
+        # CycloneDX document per crate (e.g. rust_scorer.cdx.json). No runtime
+        # dependency on the binary is introduced.
+        run: cargo cyclonedx --format json --all
+
+      - name: Upload SBOM artefact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sbom
+          path: "**/*.cdx.json"
+          if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "serde",
  "serde_json",
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.40"
+version = "0.5.42"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -454,6 +454,29 @@ validated by `scripts/check-cargo-audit-workflow.sh` (invoked from
 `quality.sh`) and covered end-to-end by
 `tests/scripts/cargo_audit_workflow.bats`.
 
+A standalone SBOM workflow (`.github/workflows/sbom.yml`, Issue #172) exports
+the dependency inventory as a CycloneDX Software Bill of Materials and uploads
+it as a build artefact. `rust_scorer` ships a binary, so its dependency graph
+has a real binary surface; `Cargo.lock` already pins that graph, and this
+workflow turns it into a standard, scanner-consumable document. When a
+supply-chain advisory drops ("crate X version Y is compromised"), the SBOM is
+the lookup table that answers "are we affected, and where?" in seconds —
+without a Rust toolchain. The job installs `cargo-cyclonedx`, runs
+`cargo cyclonedx --format json --all`, and uploads the resulting `*.cdx.json`
+files via `actions/upload-artifact`. It runs on pull requests, pushes to
+`Develop`, and `workflow_dispatch`. This workflow only emits the inventory
+artefact (the supply-chain _posture_ gap); active advisories remain owned by
+`cargo-audit.yml` / `security.yml`. The workflow is validated by
+`scripts/check-sbom-workflow.sh` (invoked from `quality.sh`) and covered
+end-to-end by `tests/scripts/sbom_workflow.bats`.
+
+```mermaid
+flowchart LR
+    lock[Cargo.lock<br/>pinned graph] --> gen[cargo cyclonedx<br/>--format json]
+    gen --> cdx[*.cdx.json<br/>CycloneDX SBOM]
+    cdx --> art[upload-artifact<br/>name: sbom]
+```
+
 A standalone Cargo Quality workflow (`.github/workflows/cargo-quality.yml`,
 Issue #66) runs `cargo fmt --check` and `cargo clippy -- -D warnings` on
 pull requests against **any** branch (`branches: ["*"]`). `ci.yml` only

--- a/docs/archive/pr-summaries/pr-summary-172.md
+++ b/docs/archive/pr-summaries/pr-summary-172.md
@@ -1,0 +1,81 @@
+# PR Summary — Issue #172
+
+## Summary
+
+`rust_scorer` ships a binary (`[[bin]] name = "rust_scorer"`) but no Software
+Bill of Materials (SBOM) artefact was generated anywhere in the repo or CI. An
+SBOM is the lookup table you reach for after a supply-chain advisory drops:
+given "crate X version Y is compromised", it answers "are we affected, and
+where?" in seconds — and makes the inventory consumable by standard scanners
+and downstream consumers without a Rust toolchain.
+
+This PR adds a dedicated **SBOM workflow** that exports the dependency graph
+(already pinned in `Cargo.lock`) as a CycloneDX document and uploads it as a
+build artefact. This closes the supply-chain *posture* gap only — active
+advisories remain owned by `cargo-audit.yml` / `security.yml`.
+
+Changes:
+
+- **`.github/workflows/sbom.yml`** (new) — installs `cargo-cyclonedx`, runs
+  `cargo cyclonedx --format json --all`, and uploads the resulting
+  `*.cdx.json` files via `actions/upload-artifact`. Runs on pull requests,
+  pushes to `Develop`, and `workflow_dispatch`. SHA-pinned actions,
+  least-privilege `contents: read`, a 15-minute timeout, and the standard
+  NEAT-AI-core sibling-link step so `cargo-cyclonedx` resolves the path
+  dependency.
+- **`scripts/check-sbom-workflow.sh`** (new) — validates the workflow against
+  six rules (build trigger, least-privilege permissions, pinned
+  `actions/checkout`, Rust toolchain, CycloneDX generation, artefact upload).
+  Wired into `quality.sh`.
+- **`tests/scripts/sbom_workflow.bats`** (new) — end-to-end tests for the
+  validator, exercising the happy path and one failure per rule against
+  synthetic fixtures, plus a check that the real repo workflow passes.
+- **`scripts/check-workflow-action-versions.sh`** — added
+  `actions/upload-artifact` to the Node-24 policy table (`required:6`; v6.0.0
+  is the first Node 24 release, pinned here to v7.0.1).
+- **`README.md`** — documented the workflow with a Mermaid diagram.
+
+Closes #172
+
+## Evidence
+
+This is a CI/tooling change with no web interface to screenshot. Verified via
+the repository's own validators and test suites.
+
+Data flow of the new workflow:
+
+```mermaid
+flowchart LR
+    lock[Cargo.lock<br/>pinned graph] --> gen[cargo cyclonedx<br/>--format json]
+    gen --> cdx[*.cdx.json<br/>CycloneDX SBOM]
+    cdx --> art[upload-artifact<br/>name: sbom]
+```
+
+Validation output (all green):
+
+- `bats tests/scripts/sbom_workflow.bats` — 10/10 pass, including
+  *"real repository SBOM workflow satisfies every rule"*.
+- `scripts/check-sbom-workflow.sh` — passes against the committed workflow.
+- `scripts/check-workflow-paths.sh`, `check-workflow-action-versions.sh`,
+  `check-workflow-timeouts.sh` — the new `sbom.yml` satisfies the sibling-path,
+  SHA-pinning/Node-24, and per-job timeout invariants.
+- `./quality.sh` — full gate passes cleanly (shellcheck, all workflow
+  validators, bats suites, cargo-deny, fmt, clippy, check, build, test, doc,
+  release).
+
+## Test Plan
+
+- Added `tests/scripts/sbom_workflow.bats`:
+  - passes on the canonical fixture
+  - fails when no build trigger is present
+  - fails when the permissions block is missing
+  - fails when `actions/checkout` is unpinned
+  - fails when `dtolnay/rust-toolchain` is missing
+  - fails when `cargo cyclonedx` is not invoked
+  - fails when the SBOM is not uploaded as an artefact
+  - reports an error when the workflow file does not exist
+  - unknown flag prints usage and exits non-zero
+  - real repository SBOM workflow satisfies every rule
+- Existing `workflow_action_versions.bats`, `workflow_timeouts.bats`,
+  `workflow_neat_ai_core_path.bats` continue to pass with the new workflow
+  present.

--- a/quality.sh
+++ b/quality.sh
@@ -44,6 +44,9 @@ echo "🛡️  Validating Semgrep SAST workflow (Issue #47)..."
 echo "🦀 Validating Cargo Security Audit workflow (Issue #64)..."
 ./scripts/check-cargo-audit-workflow.sh
 
+echo "📋 Validating SBOM workflow (Issue #172)..."
+./scripts/check-sbom-workflow.sh
+
 echo "🧹 Validating Cargo Quality (fmt + clippy) workflow (Issue #66)..."
 ./scripts/check-cargo-quality-workflow.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.42"
+version = "0.5.43"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-sbom-workflow.sh
+++ b/scripts/check-sbom-workflow.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Validate the SBOM (Software Bill of Materials) workflow (Issue #172).
+#
+# `rust_scorer` ships a binary, so its dependency inventory should be
+# exportable in a standard, scanner-consumable format. `Cargo.lock` already
+# pins the full graph; this workflow exports it as a CycloneDX SBOM and
+# uploads the document as a build artefact so downstream consumers can answer
+# "are we affected by advisory X, and where?" without a Rust toolchain.
+#
+# The SBOM workflow must:
+#   1. Trigger on a build event — pull_request, push, release, or
+#      workflow_dispatch — so the inventory is refreshed when the graph
+#      changes.
+#   2. Declare an explicit `permissions:` block (least privilege:
+#      contents: read).
+#   3. Pin `actions/checkout` to a numeric major version (vN) or a 40-char SHA.
+#   4. Install a Rust toolchain via `dtolnay/rust-toolchain` so cargo-cyclonedx
+#      can resolve the workspace metadata.
+#   5. Generate a CycloneDX SBOM via `cargo cyclonedx`.
+#   6. Upload the generated SBOM as a build artefact (actions/upload-artifact).
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/sbom.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-sbom-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the SBOM workflow YAML file (default:
+                    .github/workflows/sbom.yml relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/sbom.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. Triggered on a build event — pull_request, push, release, or
+#    workflow_dispatch.
+if grep -qE '^[[:space:]]+(pull_request|push|release|workflow_dispatch):' "$WORKFLOW" \
+  || grep -qE '^on:[[:space:]]*\[?.*(pull_request|push|release|workflow_dispatch)' "$WORKFLOW"; then
+  ok "triggers on a build event"
+else
+  fail "no build trigger — pull_request, push, release or workflow_dispatch required"
+fi
+
+# 2. Explicit permissions block (least privilege).
+if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
+  ok "permissions block grants only contents: read"
+else
+  fail "no 'permissions: contents: read' block — least-privilege required"
+fi
+
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA.
+checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
+if [[ -z "$checkout_line" ]]; then
+  fail "actions/checkout step missing — workflow cannot fetch the repo"
+elif echo "$checkout_line" | grep -qvE 'actions/checkout@(v[0-9]+|[0-9a-f]{40})\b'; then
+  fail "actions/checkout is not pinned — branch refs disallowed"
+else
+  ok "actions/checkout pinned to a numeric major or 40-char SHA"
+fi
+
+# 4. Rust toolchain provisioned via dtolnay/rust-toolchain.
+if grep -qE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$WORKFLOW"; then
+  ok "dtolnay/rust-toolchain present"
+else
+  fail "dtolnay/rust-toolchain missing — Rust toolchain not provisioned"
+fi
+
+# 5. CycloneDX SBOM generated via cargo cyclonedx.
+if grep -qE 'cargo[[:space:]-]+cyclonedx' "$WORKFLOW"; then
+  ok "CycloneDX SBOM generated via cargo cyclonedx"
+else
+  fail "CycloneDX SBOM is not generated — a 'cargo cyclonedx' step is required"
+fi
+
+# 6. Generated SBOM uploaded as a build artefact.
+if grep -qE 'uses:[[:space:]]*actions/upload-artifact@' "$WORKFLOW"; then
+  ok "SBOM uploaded as an artefact via actions/upload-artifact"
+else
+  fail "SBOM is not uploaded — an actions/upload-artifact step is required"
+fi
+
+exit "$EXIT_CODE"

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -99,6 +99,11 @@ lookup_policy() {
   case "$action" in
     actions/checkout)                 echo "required:5" ;;
     actions/cache)                    echo "required:5" ;;
+    # actions/upload-artifact: v4 and v5 still ship a Node 20 runtime; v6.0.0
+    # (2025) is the first Node 24 release, and v7.0.1 is the current line.
+    # Pinning the floor at v6 keeps the SBOM workflow (Issue #172) clear of
+    # the Node 20 deprecation.
+    actions/upload-artifact)          echo "required:6" ;;
     # actions/setup-node v4 and v5 still ship a Node 20 runtime; v6.0.0
     # (2025-10) is the first Node 24 release. Pinning the floor at v6
     # prevents the deprecation regression that triggered Issue #137.

--- a/tests/scripts/sbom_workflow.bats
+++ b/tests/scripts/sbom_workflow.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-sbom-workflow.sh — Issue #172.
+#
+# Exercises the SBOM workflow validator with synthetic workflow YAML in
+# temporary directories so behaviour (exit codes, reported failures) is
+# verified end-to-end without mutating the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-sbom-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_sbom_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: SBOM
+
+# Generate a CycloneDX SBOM for the rust_scorer binary (Issue #172).
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [Develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          ref: Develop
+          path: NEAT-AI-core
+      - name: Link NEAT-AI-core sibling path expected by Cargo
+        run: ln -s a b
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-cyclonedx --locked
+      - run: cargo cyclonedx --format json --all
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: '**/*.cdx.json'
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"triggers on a build event"* ]]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+  [[ "$output" == *"dtolnay/rust-toolchain present"* ]]
+  [[ "$output" == *"CycloneDX SBOM generated"* ]]
+  [[ "$output" == *"SBOM uploaded as an artefact"* ]]
+}
+
+@test "fails when no build trigger is present" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  python3 - "$TMP_WF/sbom.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+text = text.replace("  push:\n    branches: [Develop]\n", "")
+text = text.replace("  workflow_dispatch:\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no build trigger"* ]]
+}
+
+@test "fails when the permissions block is missing" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  python3 - "$TMP_WF/sbom.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("permissions:\n  contents: read\n\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read'"* ]]
+}
+
+@test "fails when actions/checkout is unpinned" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@main|' "$TMP_WF/sbom.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when dtolnay/rust-toolchain is missing" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  sed -i.bak '/dtolnay\/rust-toolchain/d' "$TMP_WF/sbom.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"dtolnay/rust-toolchain"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when cargo cyclonedx is not invoked" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  sed -i.bak '/cyclonedx/d' "$TMP_WF/sbom.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"CycloneDX SBOM"* ]]
+  [[ "$output" == *"not generated"* ]]
+}
+
+@test "fails when the SBOM is not uploaded as an artefact" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  python3 - "$TMP_WF/sbom.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "      - uses: actions/upload-artifact@v7\n"
+    "        with:\n"
+    "          name: sbom\n"
+    "          path: '**/*.cdx.json'\n",
+    "",
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not uploaded"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository SBOM workflow satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# PR Summary — Issue #172

## Summary

`rust_scorer` ships a binary (`[[bin]] name = "rust_scorer"`) but no Software
Bill of Materials (SBOM) artefact was generated anywhere in the repo or CI. An
SBOM is the lookup table you reach for after a supply-chain advisory drops:
given "crate X version Y is compromised", it answers "are we affected, and
where?" in seconds — and makes the inventory consumable by standard scanners
and downstream consumers without a Rust toolchain.

This PR adds a dedicated **SBOM workflow** that exports the dependency graph
(already pinned in `Cargo.lock`) as a CycloneDX document and uploads it as a
build artefact. This closes the supply-chain *posture* gap only — active
advisories remain owned by `cargo-audit.yml` / `security.yml`.

Changes:

- **`.github/workflows/sbom.yml`** (new) — installs `cargo-cyclonedx`, runs
  `cargo cyclonedx --format json --all`, and uploads the resulting
  `*.cdx.json` files via `actions/upload-artifact`. Runs on pull requests,
  pushes to `Develop`, and `workflow_dispatch`. SHA-pinned actions,
  least-privilege `contents: read`, a 15-minute timeout, and the standard
  NEAT-AI-core sibling-link step so `cargo-cyclonedx` resolves the path
  dependency.
- **`scripts/check-sbom-workflow.sh`** (new) — validates the workflow against
  six rules (build trigger, least-privilege permissions, pinned
  `actions/checkout`, Rust toolchain, CycloneDX generation, artefact upload).
  Wired into `quality.sh`.
- **`tests/scripts/sbom_workflow.bats`** (new) — end-to-end tests for the
  validator, exercising the happy path and one failure per rule against
  synthetic fixtures, plus a check that the real repo workflow passes.
- **`scripts/check-workflow-action-versions.sh`** — added
  `actions/upload-artifact` to the Node-24 policy table (`required:6`; v6.0.0
  is the first Node 24 release, pinned here to v7.0.1).
- **`README.md`** — documented the workflow with a Mermaid diagram.

Closes #172

## Evidence

This is a CI/tooling change with no web interface to screenshot. Verified via
the repository's own validators and test suites.

Data flow of the new workflow:

```mermaid
flowchart LR
    lock[Cargo.lock<br/>pinned graph] --> gen[cargo cyclonedx<br/>--format json]
    gen --> cdx[*.cdx.json<br/>CycloneDX SBOM]
    cdx --> art[upload-artifact<br/>name: sbom]
```

Validation output (all green):

- `bats tests/scripts/sbom_workflow.bats` — 10/10 pass, including
  *"real repository SBOM workflow satisfies every rule"*.
- `scripts/check-sbom-workflow.sh` — passes against the committed workflow.
- `scripts/check-workflow-paths.sh`, `check-workflow-action-versions.sh`,
  `check-workflow-timeouts.sh` — the new `sbom.yml` satisfies the sibling-path,
  SHA-pinning/Node-24, and per-job timeout invariants.
- `./quality.sh` — full gate passes cleanly (shellcheck, all workflow
  validators, bats suites, cargo-deny, fmt, clippy, check, build, test, doc,
  release).

## Test Plan

- Added `tests/scripts/sbom_workflow.bats`:
  - passes on the canonical fixture
  - fails when no build trigger is present
  - fails when the permissions block is missing
  - fails when `actions/checkout` is unpinned
  - fails when `dtolnay/rust-toolchain` is missing
  - fails when `cargo cyclonedx` is not invoked
  - fails when the SBOM is not uploaded as an artefact
  - reports an error when the workflow file does not exist
  - unknown flag prints usage and exits non-zero
  - real repository SBOM workflow satisfies every rule
- Existing `workflow_action_versions.bats`, `workflow_timeouts.bats`,
  `workflow_neat_ai_core_path.bats` continue to pass with the new workflow
  present.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq3rk0oi-e64dfb`<!-- vibe-worker-issue-172 -->