### PR TITLE
Add concurrency groups to pile-up-prone workflows (Issue #156)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -24,6 +24,12 @@ permissions:
   contents: write
   pull-requests: read
 
+# This workflow commits and pushes back to the PR head branch, so a single
+# in-flight run per branch avoids overlapping runs racing on the same ref.
+concurrency:
+  group: auto-format-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   auto-format:
     name: Auto-format Code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ on:
 permissions:
   contents: read
 
+# CI is the heaviest workflow (full cargo build/test/doc), so overlapping runs
+# are the most expensive. Cancel superseded runs per-ref on rapid pushes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_JOBS: "2"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -21,6 +21,11 @@ on:
 permissions:
   contents: read
 
+# Avoid stacking overlapping scans on rapid pushes; keep only the latest run.
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: Gitleaks Secrets Detection

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -33,6 +33,11 @@ on:
 permissions:
   contents: read
 
+# Avoid stacking overlapping scans on rapid pushes; keep only the latest run.
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     name: Semgrep SAST Scanning

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -22,6 +22,12 @@ permissions:
   contents: write
   pull-requests: read
 
+# This workflow commits and pushes back to the PR head branch, so a single
+# in-flight run per branch avoids overlapping runs racing on the same ref.
+concurrency:
+  group: version-increment-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Gate: establish a canonical "should we attempt a bump?" signal that the
   # actual writer job depends on. Making this a separate job keeps the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-156.md
+++ b/docs/archive/pr-summaries/pr-summary-156.md
@@ -1,0 +1,74 @@
+# Add concurrency groups to pile-up-prone workflows (Issue #156)
+
+## Summary
+
+Several `pull_request`-triggered workflows (and `ci.yml`, which also runs on
+`push`) declared no `concurrency:` group, so rapid successive pushes to a branch
+or PR stacked overlapping runs instead of cancelling superseded ones. This
+wasted runner minutes and — for the two workflows that push commits back to the
+PR head branch — risked two overlapping runs racing on the same ref.
+
+This change adds the hardened concurrency pattern already used by the standalone
+quality workflows (`cargo-audit.yml`, `cargo-quality.yml`,
+`dependency-review.yml`, `markdown-lint.yml`) to the five affected workflows,
+keyed per-ref with `cancel-in-progress: true`:
+
+```yaml
+concurrency:
+  group: <workflow>-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Affected workflows:
+
+| Workflow | Trigger | Why it matters |
+| --- | --- | --- |
+| `ci.yml` | `push` (Develop) + `pull_request` | Heaviest workflow (full build/test/doc) — overlapping runs are the most expensive. |
+| `auto-format.yml` | `pull_request` | Commits and pushes back to the PR branch — overlap can race. |
+| `version-increment.yml` | `pull_request` | Also pushes back to the PR branch — same race risk. |
+| `gitleaks.yml` | `pull_request` | Wasted runner minutes on overlapping scans. |
+| `semgrep.yml` | `pull_request` | Wasted runner minutes on overlapping scans. |
+
+A new validator, `scripts/check-workflow-concurrency.sh`, enforces the pattern
+so the gate cannot regress, and it is wired into `quality.sh`.
+
+Closes #156.
+
+## Evidence
+
+This is a CI/workflow configuration change with no web interface, so there is no
+screenshot. Verification is via the new validator and its BATS suite.
+
+```mermaid
+flowchart LR
+    P1[Push 1 to PR ref] --> R1[Run 1 starts]
+    P2[Push 2 to same ref] --> C{concurrency<br/>group per ref}
+    C -->|cancel-in-progress: true| X[Run 1 cancelled]
+    C --> R2[Run 2 runs alone]
+```
+
+Validator output against the real workflows (all pass):
+
+```text
+OK   ci.yml: declares a top-level concurrency block
+OK   ci.yml: concurrency group is keyed by github.ref
+OK   ci.yml: cancel-in-progress is true
+... (auto-format, version-increment, gitleaks, semgrep) ...
+```
+
+## Test Plan
+
+- Added `scripts/check-workflow-concurrency.sh` — validates that each
+  pile-up-prone workflow declares a top-level `concurrency:` block, a `group:`
+  keyed by `${{ github.ref }}`, and `cancel-in-progress: true`. Accepts both the
+  `<workflow>-${{ github.ref }}` and `${{ github.workflow }}-${{ github.ref }}`
+  group forms.
+- Added `tests/scripts/workflow_concurrency.bats` (8 cases) exercising the
+  validator end-to-end against synthetic fixtures: canonical pass, missing
+  concurrency block, group not keyed by ref, `cancel-in-progress` not true,
+  `github.workflow`-keyed form accepted, missing file, unknown flag, and a
+  real-repository check that every pile-up-prone workflow passes.
+- Wired `check-workflow-concurrency.sh` into `quality.sh`.
+- Confirmed the validator reports failures **before** the fix and passes
+  **after**, following TDD.
+- Ran `./quality.sh < /dev/null` — passes cleanly.

--- a/quality.sh
+++ b/quality.sh
@@ -74,6 +74,9 @@ echo "🔑 Validating CI least-privilege token scope (Issue #155)..."
 echo "⏱️  Validating per-job timeout-minutes across workflows (Issue #154)..."
 ./scripts/check-workflow-timeouts.sh
 
+echo "🔁 Validating concurrency groups on pile-up-prone workflows (Issue #156)..."
+./scripts/check-workflow-concurrency.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.43"
+version = "0.5.44"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-workflow-concurrency.sh
+++ b/scripts/check-workflow-concurrency.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Validate that pile-up-prone workflows declare a concurrency group (Issue #156).
+#
+# Workflows triggered on `pull_request` (and `push` for ci.yml) must declare a
+# top-level `concurrency:` block so rapid successive pushes to a branch cancel
+# superseded runs instead of stacking overlapping runs. This matters most for:
+#   * ci.yml             — the heaviest workflow (full build/test/doc).
+#   * auto-format.yml    — pushes a commit back to the PR branch (race risk).
+#   * version-increment.yml — also pushes back to the PR branch (race risk).
+#   * gitleaks.yml / semgrep.yml — wasted runner minutes on overlapping scans.
+#
+# The hardened pattern (mirrored from cargo-audit.yml, cargo-quality.yml,
+# dependency-review.yml, markdown-lint.yml) is:
+#
+#   concurrency:
+#     group: <workflow>-${{ github.ref }}
+#     cancel-in-progress: true
+#
+# A workflow satisfies this validator when it declares:
+#   1. A top-level `concurrency:` key.
+#   2. A `group:` keyed by `${{ github.ref }}` (one in-flight run per ref).
+#   3. `cancel-in-progress: true` (superseded runs are cancelled).
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# every pile-up-prone workflow under `.github/workflows/` relative to the repo
+# root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-workflow-concurrency.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to a single workflow YAML file to validate (default:
+                    validate every pile-up-prone workflow under
+                    .github/workflows/ relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when every checked workflow declares a concurrency group keyed by
+${{ github.ref }} with cancel-in-progress: true. Exits non-zero with a
+descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $1: ${*:2}" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $1: ${*:2}"
+}
+
+check_workflow() {
+  local wf="$1"
+
+  if [[ ! -f "$wf" ]]; then
+    echo "Workflow file not found: $wf" >&2
+    EXIT_CODE=2
+    return
+  fi
+
+  # 1. Top-level concurrency: block.
+  if ! grep -qE '^concurrency:[[:space:]]*$' "$wf"; then
+    fail "$wf" "no top-level 'concurrency:' block — overlapping runs will pile up"
+    return
+  fi
+  ok "$wf" "declares a top-level concurrency block"
+
+  # 2. group: keyed by the ref so there is one in-flight run per branch/PR.
+  if grep -qE '^[[:space:]]+group:[[:space:]]*.*\$\{\{[[:space:]]*github\.ref[[:space:]]*\}\}' "$wf"; then
+    ok "$wf" "concurrency group is keyed by github.ref"
+  else
+    fail "$wf" "concurrency group is not keyed by \${{ github.ref }}"
+  fi
+
+  # 3. cancel-in-progress: true so superseded runs are cancelled.
+  if grep -qE '^[[:space:]]+cancel-in-progress:[[:space:]]*true[[:space:]]*$' "$wf"; then
+    ok "$wf" "cancel-in-progress is true"
+  else
+    fail "$wf" "cancel-in-progress is not set to true — superseded runs would keep running"
+  fi
+}
+
+if [[ -n "$WORKFLOW" ]]; then
+  check_workflow "$WORKFLOW"
+else
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WF_DIR="$SCRIPT_DIR/../.github/workflows"
+  # Pile-up-prone workflows that must declare a concurrency group (Issue #156).
+  PILE_UP_PRONE=(
+    ci.yml
+    auto-format.yml
+    version-increment.yml
+    gitleaks.yml
+    semgrep.yml
+  )
+  for name in "${PILE_UP_PRONE[@]}"; do
+    check_workflow "$WF_DIR/$name"
+  done
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/workflow_concurrency.bats
+++ b/tests/scripts/workflow_concurrency.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-workflow-concurrency.sh — Issue #156.
+#
+# Exercises the concurrency-group validator with synthetic workflow YAML in
+# temporary directories so behaviour (exit codes, reported failures) is
+# verified end-to-end without mutating the real workflow files.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-workflow-concurrency.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_hardened_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Example
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: example-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+}
+
+@test "passes on the canonical hardened fixture" {
+  write_hardened_workflow "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"declares a top-level concurrency block"* ]]
+  [[ "$output" == *"keyed by github.ref"* ]]
+  [[ "$output" == *"cancel-in-progress is true"* ]]
+}
+
+@test "fails when the concurrency block is missing" {
+  write_hardened_workflow "$TMP_WF/example.yml"
+  python3 - "$TMP_WF/example.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "concurrency:\n  group: example-${{ github.ref }}\n  cancel-in-progress: true\n\n",
+    "",
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no top-level 'concurrency:' block"* ]]
+}
+
+@test "fails when the group is not keyed by github.ref" {
+  write_hardened_workflow "$TMP_WF/example.yml"
+  sed -i.bak 's|group: example-${{ github.ref }}|group: example-static|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not keyed by"* ]]
+}
+
+@test "fails when cancel-in-progress is not true" {
+  write_hardened_workflow "$TMP_WF/example.yml"
+  sed -i.bak 's|cancel-in-progress: true|cancel-in-progress: false|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cancel-in-progress is not set to true"* ]]
+}
+
+@test "accepts the github.workflow-keyed group form" {
+  write_hardened_workflow "$TMP_WF/example.yml"
+  sed -i.bak 's|group: example-${{ github.ref }}|group: ${{ github.workflow }}-${{ github.ref }}|' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"keyed by github.ref"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "every pile-up-prone repository workflow declares a concurrency group" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Add concurrency groups to pile-up-prone workflows (Issue #156)

## Summary

Several `pull_request`-triggered workflows (and `ci.yml`, which also runs on
`push`) declared no `concurrency:` group, so rapid successive pushes to a branch
or PR stacked overlapping runs instead of cancelling superseded ones. This
wasted runner minutes and — for the two workflows that push commits back to the
PR head branch — risked two overlapping runs racing on the same ref.

This change adds the hardened concurrency pattern already used by the standalone
quality workflows (`cargo-audit.yml`, `cargo-quality.yml`,
`dependency-review.yml`, `markdown-lint.yml`) to the five affected workflows,
keyed per-ref with `cancel-in-progress: true`:

```yaml
concurrency:
  group: <workflow>-${{ github.ref }}
  cancel-in-progress: true
```

Affected workflows:

| Workflow | Trigger | Why it matters |
| --- | --- | --- |
| `ci.yml` | `push` (Develop) + `pull_request` | Heaviest workflow (full build/test/doc) — overlapping runs are the most expensive. |
| `auto-format.yml` | `pull_request` | Commits and pushes back to the PR branch — overlap can race. |
| `version-increment.yml` | `pull_request` | Also pushes back to the PR branch — same race risk. |
| `gitleaks.yml` | `pull_request` | Wasted runner minutes on overlapping scans. |
| `semgrep.yml` | `pull_request` | Wasted runner minutes on overlapping scans. |

A new validator, `scripts/check-workflow-concurrency.sh`, enforces the pattern
so the gate cannot regress, and it is wired into `quality.sh`.

Closes #156.

## Evidence

This is a CI/workflow configuration change with no web interface, so there is no
screenshot. Verification is via the new validator and its BATS suite.

```mermaid
flowchart LR
    P1[Push 1 to PR ref] --> R1[Run 1 starts]
    P2[Push 2 to same ref] --> C{concurrency<br/>group per ref}
    C -->|cancel-in-progress: true| X[Run 1 cancelled]
    C --> R2[Run 2 runs alone]
```

Validator output against the real workflows (all pass):

```text
OK   ci.yml: declares a top-level concurrency block
OK   ci.yml: concurrency group is keyed by github.ref
OK   ci.yml: cancel-in-progress is true
... (auto-format, version-increment, gitleaks, semgrep) ...
```

## Test Plan

- Added `scripts/check-workflow-concurrency.sh` — validates that each
  pile-up-prone workflow declares a top-level `concurrency:` block, a `group:`
  keyed by `${{ github.ref }}`, and `cancel-in-progress: true`. Accepts both the
  `<workflow>-${{ github.ref }}` and `${{ github.workflow }}-${{ github.ref }}`
  group forms.
- Added `tests/scripts/workflow_concurrency.bats` (8 cases) exercising the
  validator end-to-end against synthetic fixtures: canonical pass, missing
  concurrency block, group not keyed by ref, `cancel-in-progress` not true,
  `github.workflow`-keyed form accepted, missing file, unknown flag, and a
  real-repository check that every pile-up-prone workflow passes.
- Wired `check-workflow-concurrency.sh` into `quality.sh`.
- Confirmed the validator reports failures **before** the fix and passes
  **after**, following TDD.
- Ran `./quality.sh < /dev/null` — passes cleanly.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq3wf5hv-1f3a35`<!-- vibe-worker-issue-156 -->