### PR TITLE
Add CODEOWNERS coverage for .github/workflows/ (Issue #176)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS — review governance for NEAT-AI-scorer (Issue #176)
+#
+# GitHub recognises CODEOWNERS at one of three paths: `CODEOWNERS`,
+# `.github/CODEOWNERS`, or `docs/CODEOWNERS`. We keep it under `.github/`
+# alongside the workflow definitions it primarily protects.
+#
+# When a rule matches a changed file, GitHub auto-requests a review from the
+# listed owner(s). Paired with a branch-protection rule that requires owner
+# review on the default branch (`Develop`), this stops a single account from
+# self-approving a change to a privileged workflow.
+#
+# Owner: the `developers` maintainers team. The team must have write access to
+# this repository for CODEOWNERS auto-assignment to take effect.
+
+# Default owner — every change requests a maintainer review unless a more
+# specific rule below overrides it. CODEOWNERS uses last-match-wins, so the
+# catch-all goes first.
+*                       @stSoftwareAU/developers
+
+# CI / workflow changes require a maintainer review. The workflow directory is
+# privileged: `semgrep.yml` runs with a non-GITHUB_TOKEN secret
+# (`SEMGREP_APP_TOKEN`), so an unreviewed edit here could exfiltrate a secret
+# or weaken a security gate. Covering the whole `.github/` tree also protects
+# this CODEOWNERS file itself and the issue templates.
+/.github/               @stSoftwareAU/developers
+/.github/workflows/     @stSoftwareAU/developers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
             "quality.sh"
             "deny.toml"
             "rust_scorer/src/main.rs"
+            ".github/CODEOWNERS"
           )
           missing_files=()
           for file in "${required_files[@]}"; do

--- a/README.md
+++ b/README.md
@@ -540,6 +540,40 @@ without depending on the full CI graph. It is validated by
 `scripts/check-markdown-lint-workflow.sh` (invoked from `quality.sh`)
 and covered end-to-end by `tests/scripts/markdown_lint_workflow.bats`.
 
+### Review governance (CODEOWNERS) — Issue #176
+
+`.github/CODEOWNERS` designates the `@stSoftwareAU/developers` maintainers
+team as the owner of the repository, with explicit rules over `.github/` and
+`.github/workflows/`. The workflow directory is **privileged**: `semgrep.yml`
+runs with a non-`GITHUB_TOKEN` secret (`SEMGREP_APP_TOKEN`), so an unreviewed
+edit there could exfiltrate that secret or weaken a security gate. When a
+branch-protection rule on `Develop` requires owner review, GitHub auto-requests
+a maintainer's review on any change a CODEOWNERS rule matches — closing the
+self-approval path for workflow edits.
+
+The CODEOWNERS file is validated by `scripts/check-codeowners.sh` (invoked from
+`quality.sh`) and covered end-to-end by `tests/scripts/codeowners.bats`. The
+validator asserts the file exists at a GitHub-recognised path, that every rule
+names a valid owner (`@user`, `@org/team`, or an email), and that at least one
+rule covers `.github/workflows/`. `ci.yml`'s `validation` job also lists
+`.github/CODEOWNERS` among its required files, so the file cannot silently
+disappear.
+
+```mermaid
+flowchart LR
+    pr[PR edits<br/>.github/workflows/] --> co{CODEOWNERS<br/>rule matches?}
+    co -- yes --> rev[Owner review<br/>auto-requested]
+    rev --> bp[Branch protection<br/>blocks merge until approved]
+```
+
+**Branch-protection recommendations (repo-level, not committed).** CODEOWNERS
+only takes effect when the default branch (`Develop`) requires owner review.
+These settings live in repository configuration — a branch-protection rule or
+ruleset — and are not visible from committed files, so a maintainer with admin
+rights must enable them: at least one required PR approval before merge, blocked
+direct push and force-push, required linear history, and required signed
+commits.
+
 ### GitHub Actions pinning policy (SHA pinning + Node 24 compat)
 
 Every `uses:` reference across the workflow files is pinned to a

--- a/docs/archive/pr-summaries/pr-summary-176.md
+++ b/docs/archive/pr-summaries/pr-summary-176.md
@@ -27,7 +27,7 @@ validator + bats convention so the coverage cannot silently regress:
   `validation` job's required-files list so the file cannot disappear.
 - **`README.md`** — new "Review governance (CODEOWNERS)" section documenting
   the rule, the validator, and the repo-level branch-protection
-  recommendations.
+  recommendations
 
 Closes #176.
 

--- a/docs/archive/pr-summaries/pr-summary-176.md
+++ b/docs/archive/pr-summaries/pr-summary-176.md
@@ -1,0 +1,86 @@
+# Add CODEOWNERS coverage for `.github/workflows/` (Issue #176)
+
+## Summary
+
+The repository shipped privileged GitHub Actions workflows — `semgrep.yml`
+runs with a non-`GITHUB_TOKEN` secret (`SEMGREP_APP_TOKEN`) — yet had **no
+`CODEOWNERS` file** at any of the three GitHub-recognised paths. Without a
+CODEOWNERS rule over the workflow directory, a single account could
+self-approve a workflow edit that exfiltrates that secret or weakens a
+security gate.
+
+This PR adds `.github/CODEOWNERS` with the `@stSoftwareAU/developers`
+maintainers team as the owner, including explicit rules over `.github/` and
+`.github/workflows/`. It follows the repository's established
+validator + bats convention so the coverage cannot silently regress:
+
+- **`.github/CODEOWNERS`** — default owner plus rules covering the privileged
+  workflow directory (last-match-wins ordering: catch-all first).
+- **`scripts/check-codeowners.sh`** — validates the file exists at a
+  recognised path, every rule names a valid owner (`@user`, `@org/team`, or
+  email), and at least one rule covers `.github/workflows/`. Wired into
+  `quality.sh`.
+- **`tests/scripts/codeowners.bats`** — 10 end-to-end tests exercising the
+  validator against synthetic fixtures (happy path, catch-all, email owner,
+  and each failure mode).
+- **`.github/workflows/ci.yml`** — adds `.github/CODEOWNERS` to the
+  `validation` job's required-files list so the file cannot disappear.
+- **`README.md`** — new "Review governance (CODEOWNERS)" section documenting
+  the rule, the validator, and the repo-level branch-protection
+  recommendations.
+
+Closes #176.
+
+### Branch protection (repo-level — cannot be committed)
+
+The issue also recommends branch-protection controls on `Develop` (required
+PR approval, blocked direct/force-push, required linear history, required
+signed commits). These are repository settings, not committed files — a
+maintainer with admin rights must enable them. They are documented as
+recommendations in the README; CODEOWNERS only takes effect once required
+owner review is enabled on the default branch.
+
+## Evidence
+
+This is a CI/governance change with no web interface to screenshot. Evidence
+is the validator output and the passing bats suite.
+
+Validator against the committed CODEOWNERS:
+
+```text
+OK   .github/CODEOWNERS: contains 3 ownership rule(s)
+OK   .github/CODEOWNERS: a rule covers .github/workflows/ — workflow changes require an owner review
+```
+
+Review-governance flow this PR enables:
+
+```mermaid
+flowchart LR
+    pr[PR edits<br/>.github/workflows/] --> co{CODEOWNERS<br/>rule matches?}
+    co -- yes --> rev[Owner review<br/>auto-requested]
+    rev --> bp[Branch protection<br/>blocks merge until approved]
+```
+
+### Local quality gate note
+
+`./quality.sh` validators, shellcheck, the full bats suite (including the new
+`codeowners.bats`), codespell, and markdownlint all pass. The cargo build
+chain (`cargo_metadata.bats` and the cargo steps) cannot run in this local
+environment because the `neat-core` path dependency requires a sibling
+`NEAT-AI-core` checkout that is not present locally; CI provisions it. This is
+a pre-existing environmental limitation unrelated to this change, which is
+shell/config/docs only and touches no Rust code.
+
+## Test Plan
+
+- Added `tests/scripts/codeowners.bats` (10 tests) covering
+  `scripts/check-codeowners.sh`:
+  - passes on the canonical fixture, a catch-all-only file, and an
+    email-owner workflow rule;
+  - fails when no rule covers `.github/workflows/`, a rule has no owner, an
+    owner token is malformed, or the file is comment-only;
+  - errors on a missing file and an unknown flag;
+  - asserts the real repository CODEOWNERS satisfies every rule.
+- `shellcheck` and `bash -n` pass on `scripts/check-codeowners.sh` and the
+  updated `quality.sh`.
+- `python3 -c "yaml.safe_load(...)"` confirms `ci.yml` remains valid YAML.

--- a/quality.sh
+++ b/quality.sh
@@ -59,6 +59,9 @@ echo "📝 Validating Markdown Lint workflow (Issue #63)..."
 echo "📦 Validating Dependency Review workflow (Issue #62)..."
 ./scripts/check-dependency-review-workflow.sh
 
+echo "👥 Validating CODEOWNERS coverage for .github/workflows/ (Issue #176)..."
+./scripts/check-codeowners.sh
+
 echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 ./scripts/check-auto-format-workflow.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.44"
+version = "0.5.45"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-codeowners.sh
+++ b/scripts/check-codeowners.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Validate the repository CODEOWNERS file (Issue #176).
+#
+# The repository ships privileged GitHub Actions workflows — `semgrep.yml`
+# runs with a non-GITHUB_TOKEN secret (`SEMGREP_APP_TOKEN`). Without a
+# CODEOWNERS rule covering `.github/workflows/`, a single account could
+# self-approve a workflow edit that exfiltrates that secret or weakens a
+# security gate. A CODEOWNERS rule over the workflow directory forces a
+# designated maintainer's review on every such change.
+#
+# The CODEOWNERS file must:
+#   1. Exist at one of the three GitHub-recognised paths (`CODEOWNERS`,
+#      `.github/CODEOWNERS`, or `docs/CODEOWNERS`).
+#   2. Contain at least one ownership rule (pattern + owner).
+#   3. Contain a rule whose pattern covers `.github/workflows/` so workflow
+#      changes always request an owner review.
+#   4. Assign every rule at least one owner, and every owner token must be a
+#      valid GitHub handle (`@user`), team (`@org/team`), or email address.
+#
+# The script takes a single optional `--codeowners PATH` argument so BATS
+# tests can exercise it against fixtures. With no argument it locates the
+# CODEOWNERS file at the first recognised path relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-codeowners.sh [--codeowners PATH]
+
+Options:
+  --codeowners PATH   Path to the CODEOWNERS file to validate (default: the
+                      first of CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS
+                      that exists relative to the repo root).
+  -h, --help          Show this message.
+
+Exits 0 when the CODEOWNERS file satisfies every rule in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+CODEOWNERS=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --codeowners)
+      CODEOWNERS="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$CODEOWNERS" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$SCRIPT_DIR/.."
+  for candidate in "CODEOWNERS" ".github/CODEOWNERS" "docs/CODEOWNERS"; do
+    if [[ -f "$REPO_ROOT/$candidate" ]]; then
+      CODEOWNERS="$REPO_ROOT/$candidate"
+      break
+    fi
+  done
+  if [[ -z "$CODEOWNERS" ]]; then
+    echo "CODEOWNERS not found at any recognised path: CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS" >&2
+    exit 2
+  fi
+fi
+
+if [[ ! -f "$CODEOWNERS" ]]; then
+  echo "CODEOWNERS file not found: $CODEOWNERS" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $CODEOWNERS: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $CODEOWNERS: $*"
+}
+
+# Does a CODEOWNERS pattern cover .github/workflows/ ?
+# CODEOWNERS uses gitignore-style globs; we accept the patterns that
+# unambiguously include the workflow directory. The leading slash is optional.
+covers_workflows() {
+  local pat="${1#/}"
+  case "$pat" in
+    '*') return 0 ;;
+    '.github' | '.github/' | '.github/*' | '.github/**') return 0 ;;
+    '.github/workflows' | '.github/workflows/' | '.github/workflows/*' | '.github/workflows/**') return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Is a token a valid CODEOWNERS owner — @user, @org/team, or an email?
+valid_owner() {
+  local owner="$1"
+  if [[ "$owner" =~ ^@[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)?$ ]]; then
+    return 0
+  fi
+  if [[ "$owner" =~ ^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+rule_count=0
+workflow_covered=0
+
+while IFS= read -r raw || [[ -n "$raw" ]]; do
+  # Strip a trailing comment, then trim surrounding whitespace.
+  line="${raw%%#*}"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [[ -z "$line" ]] && continue
+
+  # First field is the pattern; the remainder are owners.
+  read -r pattern owners <<<"$line"
+  rule_count=$((rule_count + 1))
+
+  if [[ -z "$owners" ]]; then
+    fail "rule for pattern '$pattern' has no owner — every rule needs at least one owner"
+    continue
+  fi
+
+  for owner in $owners; do
+    if ! valid_owner "$owner"; then
+      fail "invalid owner token '$owner' for pattern '$pattern' — expected @user, @org/team, or an email"
+    fi
+  done
+
+  if covers_workflows "$pattern"; then
+    workflow_covered=1
+  fi
+done <"$CODEOWNERS"
+
+# 2. At least one ownership rule.
+if [[ "$rule_count" -gt 0 ]]; then
+  ok "contains $rule_count ownership rule(s)"
+else
+  fail "no ownership rules found — file is empty or only comments"
+fi
+
+# 3. A rule covering .github/workflows/.
+if [[ "$workflow_covered" -eq 1 ]]; then
+  ok "a rule covers .github/workflows/ — workflow changes require an owner review"
+else
+  fail "no rule covers .github/workflows/ — privileged workflow edits could merge unreviewed"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/codeowners.bats
+++ b/tests/scripts/codeowners.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-codeowners.sh — Issue #176.
+#
+# Exercises the CODEOWNERS validator with synthetic CODEOWNERS fixtures in
+# temporary directories so behaviour (exit codes, reported failures) is
+# verified end-to-end without mutating the real CODEOWNERS file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-codeowners.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_CO="$(mktemp -d)"
+  export TMP_CO
+}
+
+teardown() {
+  rm -rf "$TMP_CO"
+}
+
+# Canonical valid CODEOWNERS. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_codeowners() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+# Review governance
+*                       @stSoftwareAU/developers
+/.github/               @stSoftwareAU/developers
+/.github/workflows/     @stSoftwareAU/developers
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_codeowners "$TMP_CO/CODEOWNERS"
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/CODEOWNERS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ownership rule(s)"* ]]
+  [[ "$output" == *"covers .github/workflows/"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "passes when only a catch-all rule is present" {
+  printf '* @stSoftwareAU/developers\n' >"$TMP_CO/CODEOWNERS"
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/CODEOWNERS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"covers .github/workflows/"* ]]
+}
+
+@test "passes when a workflow-directory rule lists an email owner" {
+  printf '/.github/workflows/ maintainer@example.com\n' >"$TMP_CO/CODEOWNERS"
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/CODEOWNERS"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when no rule covers the workflows directory" {
+  cat >"$TMP_CO/CODEOWNERS" <<'EOF'
+/docs/  @stSoftwareAU/developers
+/src/   @stSoftwareAU/developers
+EOF
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/CODEOWNERS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no rule covers .github/workflows/"* ]]
+}
+
+@test "fails when a rule has a pattern but no owner" {
+  printf '/.github/workflows/\n' >"$TMP_CO/CODEOWNERS"
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/CODEOWNERS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"has no owner"* ]]
+}
+
+@test "fails when an owner token is malformed" {
+  printf '/.github/workflows/ not-a-valid-owner\n' >"$TMP_CO/CODEOWNERS"
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/CODEOWNERS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid owner token"* ]]
+}
+
+@test "fails when the file has only comments" {
+  cat >"$TMP_CO/CODEOWNERS" <<'EOF'
+# just a comment
+# another comment
+EOF
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/CODEOWNERS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no ownership rules found"* ]]
+}
+
+@test "reports an error when the CODEOWNERS file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/does-not-exist"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository CODEOWNERS satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Add CODEOWNERS coverage for `.github/workflows/` (Issue #176)

## Summary

The repository shipped privileged GitHub Actions workflows — `semgrep.yml`
runs with a non-`GITHUB_TOKEN` secret (`SEMGREP_APP_TOKEN`) — yet had **no
`CODEOWNERS` file** at any of the three GitHub-recognised paths. Without a
CODEOWNERS rule over the workflow directory, a single account could
self-approve a workflow edit that exfiltrates that secret or weakens a
security gate.

This PR adds `.github/CODEOWNERS` with the `@stSoftwareAU/developers`
maintainers team as the owner, including explicit rules over `.github/` and
`.github/workflows/`. It follows the repository's established
validator + bats convention so the coverage cannot silently regress:

- **`.github/CODEOWNERS`** — default owner plus rules covering the privileged
  workflow directory (last-match-wins ordering: catch-all first).
- **`scripts/check-codeowners.sh`** — validates the file exists at a
  recognised path, every rule names a valid owner (`@user`, `@org/team`, or
  email), and at least one rule covers `.github/workflows/`. Wired into
  `quality.sh`.
- **`tests/scripts/codeowners.bats`** — 10 end-to-end tests exercising the
  validator against synthetic fixtures (happy path, catch-all, email owner,
  and each failure mode).
- **`.github/workflows/ci.yml`** — adds `.github/CODEOWNERS` to the
  `validation` job's required-files list so the file cannot disappear.
- **`README.md`** — new "Review governance (CODEOWNERS)" section documenting
  the rule, the validator, and the repo-level branch-protection
  recommendations.

Closes #176.

### Branch protection (repo-level — cannot be committed)

The issue also recommends branch-protection controls on `Develop` (required
PR approval, blocked direct/force-push, required linear history, required
signed commits). These are repository settings, not committed files — a
maintainer with admin rights must enable them. They are documented as
recommendations in the README; CODEOWNERS only takes effect once required
owner review is enabled on the default branch.

## Evidence

This is a CI/governance change with no web interface to screenshot. Evidence
is the validator output and the passing bats suite.

Validator against the committed CODEOWNERS:

```text
OK   .github/CODEOWNERS: contains 3 ownership rule(s)
OK   .github/CODEOWNERS: a rule covers .github/workflows/ — workflow changes require an owner review
```

Review-governance flow this PR enables:

```mermaid
flowchart LR
    pr[PR edits<br/>.github/workflows/] --> co{CODEOWNERS<br/>rule matches?}
    co -- yes --> rev[Owner review<br/>auto-requested]
    rev --> bp[Branch protection<br/>blocks merge until approved]
```

### Local quality gate note

`./quality.sh` validators, shellcheck, the full bats suite (including the new
`codeowners.bats`), codespell, and markdownlint all pass. The cargo build
chain (`cargo_metadata.bats` and the cargo steps) cannot run in this local
environment because the `neat-core` path dependency requires a sibling
`NEAT-AI-core` checkout that is not present locally; CI provisions it. This is
a pre-existing environmental limitation unrelated to this change, which is
shell/config/docs only and touches no Rust code.

## Test Plan

- Added `tests/scripts/codeowners.bats` (10 tests) covering
  `scripts/check-codeowners.sh`:
  - passes on the canonical fixture, a catch-all-only file, and an
    email-owner workflow rule;
  - fails when no rule covers `.github/workflows/`, a rule has no owner, an
    owner token is malformed, or the file is comment-only;
  - errors on a missing file and an unknown flag;
  - asserts the real repository CODEOWNERS satisfies every rule.
- `shellcheck` and `bash -n` pass on `scripts/check-codeowners.sh` and the
  updated `quality.sh`.
- `python3 -c "yaml.safe_load(...)"` confirms `ci.yml` remains valid YAML.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq4mc7zq-8193cf`<!-- vibe-worker-issue-176 -->