### PR TITLE
Add CONTRIBUTING.md and CHANGELOG.md to complete the docs floor (Issue #178)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,8 @@ jobs:
             "Cargo.toml"
             "README.md"
             "LICENSE"
+            "CONTRIBUTING.md"
+            "CHANGELOG.md"
             "quality.sh"
             "deny.toml"
             "rust_scorer/src/main.rs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to **NEAT-AI-scorer** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The `rust_scorer` package version in
+[`rust_scorer/Cargo.toml`](./rust_scorer/Cargo.toml) is bumped automatically
+on each pull request by the
+[Version Increment](./.github/workflows/version-increment.yml) workflow, so
+this changelog is the human-readable record of *what* changed between
+versions. Add new entries under `## [Unreleased]`; on release, rename that
+section to the released version with its date.
+
+## [Unreleased]
+
+### Added
+
+- `CONTRIBUTING.md` — contributor guide summarising the local gate
+  (`./quality.sh`), prerequisites, coding standards, and the pull request
+  workflow.
+- `CHANGELOG.md` — this file, following Keep a Changelog, to record changes
+  alongside the automated `rust_scorer` version bumps.
+
+### Changed
+
+- CI now enforces the documentation floor: `CONTRIBUTING.md` and
+  `CHANGELOG.md` are listed in the `validation` job's required-files check
+  (`.github/workflows/ci.yml`), guarded by `tests/scripts/docs_floor.bats`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to NEAT-AI-scorer
+
+Thanks for your interest in improving **NEAT-AI-scorer** — the native MSE
+scorer CLI for NEAT-AI creatures. This guide summarises how to build, test,
+and submit changes. It mirrors the local gate documented in
+[`AGENTS.md`](./AGENTS.md) and the CI workflow in
+[`.github/workflows/ci.yml`](./.github/workflows/ci.yml).
+
+## Repository layout
+
+This is a multi-binary Rust workspace. The sole workspace member is
+**`rust_scorer`** (the `rust_scorer`, `float_scan_bench`, and
+`cost_scan_bench` binaries). The shared scoring logic lives in
+**`neat-core`**, resolved as a **path dependency** on a sibling clone of
+[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core).
+
+Clone both repositories under the same parent directory so the path
+dependency resolves:
+
+```text
+parent/
+  NEAT-AI-core/      # clone of stSoftwareAU/NEAT-AI-core
+  NEAT-AI-scorer/    # this repository
+```
+
+## Prerequisites
+
+The local gate and CI expect the following tools on your `PATH`:
+
+- **Rust** (stable toolchain) — `cargo`, `rustc`, `clippy`, `rustfmt`.
+- **shellcheck** — lints the bash helper scripts.
+- **cargo-deny** — licence and dependency audit (`cargo install cargo-deny --locked`).
+- **codespell** — spell check (`pip install --user codespell`), driven by [`scripts/spell-check.sh`](./scripts/spell-check.sh).
+- **bats** *(optional)* — runs the shell helper tests under `tests/scripts`.
+- **cargo-edit** *(optional)* — enables the dependency upgrade step in `./quality.sh`.
+
+## Local gate
+
+Run the full local quality gate before every commit or pull request:
+
+```bash
+./quality.sh < /dev/null
+```
+
+`./quality.sh` mirrors CI and runs, in order:
+
+1. **shellcheck** — bash syntax and lint across all `*.sh` scripts.
+2. **Workflow validators** — the `scripts/check-*.sh` guards over `.github/workflows`.
+3. **codespell** — via `scripts/spell-check.sh`.
+4. **bats** — shell helper tests under `tests/scripts` (when `bats` is installed).
+5. **cargo-deny** — licence and advisory checks.
+6. **`cargo fmt --all`** — formatting (CI runs `fmt --check`).
+7. **`cargo clippy`** — lint with `-D warnings` plus `filter_next` and `collapsible_if`.
+8. **`cargo check`**, **`cargo build`**, **`cargo test`** — type checks, debug build, and the test suite.
+9. **`cargo doc`** — rustdoc with `RUSTDOCFLAGS=-D warnings`.
+10. **Release build** — `cargo build --workspace --release`.
+
+Keep re-running `./quality.sh < /dev/null` until it passes cleanly.
+
+## Coding standards
+
+- **Australian English** throughout code, comments, and documentation
+  (e.g. *colour*, *behaviour*, *organisation*, *favour*, *centre*).
+- Keep the **positional** CLI contract (`<creature.json> <data_dir>`) stable.
+- Add tests that exercise real behaviour — call functions with test data and
+  assert on results, exit codes, or side effects.
+- When a domain term trips codespell, add it with a short justification to
+  [`.codespellrc`](./.codespellrc) rather than silencing a whole file.
+
+## Pull request workflow
+
+1. Branch from `Develop`.
+2. Make your change with accompanying tests.
+3. Run `./quality.sh < /dev/null` until it passes.
+4. Update [`CHANGELOG.md`](./CHANGELOG.md) under the `## [Unreleased]`
+   section, and update the README or other docs if behaviour changes.
+5. Open a pull request targeting `Develop`.
+
+On each PR the **Version Increment** workflow
+([`.github/workflows/version-increment.yml`](./.github/workflows/version-increment.yml))
+automatically bumps the patch component of `rust_scorer`'s version in
+`rust_scorer/Cargo.toml` once, if it has not already been bumped on the
+branch. Because the version is bumped automatically, the `CHANGELOG.md` is
+the human-readable record of *what* changed — please keep it current.
+
+## Licence
+
+By contributing, you agree that your contributions are licensed under the
+[Apache-2.0](./LICENSE) licence that covers this project.

--- a/docs/archive/pr-summaries/pr-summary-178.md
+++ b/docs/archive/pr-summaries/pr-summary-178.md
@@ -19,7 +19,7 @@ the floor cannot silently regress. Closes #178.
   *what* changed between versions.
 - **CI enforcement** — `CONTRIBUTING.md` and `CHANGELOG.md` are added to the
   `validation` job's required-files check in `.github/workflows/ci.yml`,
-  guarded by a new `tests/scripts/docs_floor.bats` suite.
+  guarded by a new `tests/scripts/docs_floor.bats` suite
 
 ## Evidence
 

--- a/docs/archive/pr-summaries/pr-summary-178.md
+++ b/docs/archive/pr-summaries/pr-summary-178.md
@@ -1,0 +1,63 @@
+# PR Summary — Issue #178
+
+## Summary
+
+The repository had a substantial `README.md` and an Apache-2.0 `LICENSE`,
+but was missing both `CONTRIBUTING.md` and `CHANGELOG.md`. This PR completes
+the repository "docs floor" by adding both files and enforcing them in CI so
+the floor cannot silently regress. Closes #178.
+
+- **`CONTRIBUTING.md`** — contributor guide summarising the repository
+  layout, prerequisites, the `./quality.sh` local gate (shellcheck,
+  cargo-deny, `fmt --check`, clippy, check, build, test, rustdoc, release),
+  the coding standards (Australian English, stable positional CLI contract),
+  and the per-PR workflow including the automated `version-increment.yml`
+  bump.
+- **`CHANGELOG.md`** — follows [Keep a Changelog](https://keepachangelog.com/)
+  with an `## [Unreleased]` section, noting that the `rust_scorer` version is
+  bumped automatically so the changelog is the human-readable record of
+  *what* changed between versions.
+- **CI enforcement** — `CONTRIBUTING.md` and `CHANGELOG.md` are added to the
+  `validation` job's required-files check in `.github/workflows/ci.yml`,
+  guarded by a new `tests/scripts/docs_floor.bats` suite.
+
+## Evidence
+
+This is a documentation/CI change with no web interface, so no screenshot
+applies. Verification is via the bats suite (run by `./quality.sh`):
+
+```text
+ok 1 CONTRIBUTING.md exists at the repository root
+ok 2 CHANGELOG.md exists at the repository root
+ok 3 CONTRIBUTING.md documents the local quality gate
+ok 4 CHANGELOG.md follows Keep a Changelog with an Unreleased section
+ok 5 ci.yml required-files check lists CONTRIBUTING.md
+ok 6 ci.yml required-files check lists CHANGELOG.md
+```
+
+The full `./quality.sh` gate passes cleanly (codespell, markdownlint, all
+239 bats tests, cargo-deny, fmt, clippy, check, build, test, rustdoc,
+release).
+
+```mermaid
+flowchart LR
+    A[Contributor] --> B[CONTRIBUTING.md<br/>build &amp; test guide]
+    B --> C[./quality.sh local gate]
+    C --> D[Open PR to Develop]
+    D --> E[version-increment.yml<br/>auto patch bump]
+    D --> F[CHANGELOG.md<br/>Unreleased entry]
+    D --> G[CI validation<br/>required-files check]
+```
+
+## Test Plan
+
+- Added `tests/scripts/docs_floor.bats` (TDD — tests 5 & 6 failed before the
+  `ci.yml` change, all pass after):
+  - asserts `CONTRIBUTING.md` and `CHANGELOG.md` exist at the repo root;
+  - asserts `CONTRIBUTING.md` documents the `./quality.sh` gate;
+  - asserts `CHANGELOG.md` uses the Keep a Changelog format with an
+    `[Unreleased]` section;
+  - asserts `ci.yml` lists both files in the required-files check.
+- Ran `./scripts/spell-check.sh` (codespell) and `markdownlint-cli2` on the
+  new files — both clean.
+- Ran the full `./quality.sh` gate — passes.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.47"
+version = "0.5.48"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/tests/scripts/docs_floor.bats
+++ b/tests/scripts/docs_floor.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# Tests for Issue #178 — complete the repository "docs floor" by adding
+# CONTRIBUTING.md and CHANGELOG.md and enforcing them as required files in CI.
+
+setup() {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export REPO_ROOT
+  export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+  CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+  export CI_WORKFLOW
+}
+
+@test "CONTRIBUTING.md exists at the repository root" {
+  [ -f "$REPO_ROOT/CONTRIBUTING.md" ]
+}
+
+@test "CHANGELOG.md exists at the repository root" {
+  [ -f "$REPO_ROOT/CHANGELOG.md" ]
+}
+
+@test "CONTRIBUTING.md documents the local quality gate" {
+  run grep -F './quality.sh' "$REPO_ROOT/CONTRIBUTING.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "CHANGELOG.md follows Keep a Changelog with an Unreleased section" {
+  run grep -F '[Unreleased]' "$REPO_ROOT/CHANGELOG.md"
+  [ "$status" -eq 0 ]
+  run grep -Fi 'keep a changelog' "$REPO_ROOT/CHANGELOG.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "ci.yml required-files check lists CONTRIBUTING.md" {
+  run grep -F '"CONTRIBUTING.md"' "$CI_WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "ci.yml required-files check lists CHANGELOG.md" {
+  run grep -F '"CHANGELOG.md"' "$CI_WORKFLOW"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #178

## Summary

The repository had a substantial `README.md` and an Apache-2.0 `LICENSE`,
but was missing both `CONTRIBUTING.md` and `CHANGELOG.md`. This PR completes
the repository "docs floor" by adding both files and enforcing them in CI so
the floor cannot silently regress. Closes #178.

- **`CONTRIBUTING.md`** — contributor guide summarising the repository
  layout, prerequisites, the `./quality.sh` local gate (shellcheck,
  cargo-deny, `fmt --check`, clippy, check, build, test, rustdoc, release),
  the coding standards (Australian English, stable positional CLI contract),
  and the per-PR workflow including the automated `version-increment.yml`
  bump.
- **`CHANGELOG.md`** — follows [Keep a Changelog](https://keepachangelog.com/)
  with an `## [Unreleased]` section, noting that the `rust_scorer` version is
  bumped automatically so the changelog is the human-readable record of
  *what* changed between versions.
- **CI enforcement** — `CONTRIBUTING.md` and `CHANGELOG.md` are added to the
  `validation` job's required-files check in `.github/workflows/ci.yml`,
  guarded by a new `tests/scripts/docs_floor.bats` suite.

## Evidence

This is a documentation/CI change with no web interface, so no screenshot
applies. Verification is via the bats suite (run by `./quality.sh`):

```text
ok 1 CONTRIBUTING.md exists at the repository root
ok 2 CHANGELOG.md exists at the repository root
ok 3 CONTRIBUTING.md documents the local quality gate
ok 4 CHANGELOG.md follows Keep a Changelog with an Unreleased section
ok 5 ci.yml required-files check lists CONTRIBUTING.md
ok 6 ci.yml required-files check lists CHANGELOG.md
```

The full `./quality.sh` gate passes cleanly (codespell, markdownlint, all
239 bats tests, cargo-deny, fmt, clippy, check, build, test, rustdoc,
release).

```mermaid
flowchart LR
    A[Contributor] --> B[CONTRIBUTING.md<br/>build &amp; test guide]
    B --> C[./quality.sh local gate]
    C --> D[Open PR to Develop]
    D --> E[version-increment.yml<br/>auto patch bump]
    D --> F[CHANGELOG.md<br/>Unreleased entry]
    D --> G[CI validation<br/>required-files check]
```

## Test Plan

- Added `tests/scripts/docs_floor.bats` (TDD — tests 5 & 6 failed before the
  `ci.yml` change, all pass after):
  - asserts `CONTRIBUTING.md` and `CHANGELOG.md` exist at the repo root;
  - asserts `CONTRIBUTING.md` documents the `./quality.sh` gate;
  - asserts `CHANGELOG.md` uses the Keep a Changelog format with an
    `[Unreleased]` section;
  - asserts `ci.yml` lists both files in the required-files check.
- Ran `./scripts/spell-check.sh` (codespell) and `markdownlint-cli2` on the
  new files — both clean.
- Ran the full `./quality.sh` gate — passes.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq4ye6jf-8526c4`<!-- vibe-worker-issue-178 -->