### PR TITLE
Add actionlint CI lint gate for GitHub Actions (Issue #195)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,61 @@
+name: Actionlint
+
+# Standalone GitHub Actions lint gate (Issue #195).
+#
+# Why this exists:
+#   * The repository ships a growing fleet of workflow YAML under
+#     `.github/workflows/` but had no CI job running the standard GitHub
+#     Actions linter (actionlint). actionlint catches workflow regressions
+#     that plain YAML parsing misses — invalid `runs-on` labels, broken
+#     `${{ }}` expressions, unknown `uses:` inputs, shellcheck findings in
+#     `run:` scripts, and more — so lint regressions fail the build before
+#     they reach `Develop`.
+#   * Workflow-sync tooling looks for `actionlint.yml` by filename; the
+#     dedicated file keeps the gate discoverable independent of `ci.yml`.
+#
+# Supply-chain policy (Issues #24, #100, #157, mirrored by
+# `scripts/check-workflow-action-versions.sh`): every `uses:` reference is
+# pinned to a 40-character commit SHA with a trailing `# <version>` comment.
+# actionlint itself is NOT fetched via a third-party action — it is downloaded
+# from a version-pinned upstream release by the official installer script and
+# run as a plain binary, mirroring how `ci.yml` invokes ShellCheck directly
+# (PR #184) rather than through a wrapper action.
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master, Develop]
+  workflow_dispatch:
+
+# Least-privilege default token scope — actionlint only reads the checked-out
+# workflow files, so read-only access is sufficient.
+permissions:
+  contents: read
+
+# Avoid stacking duplicate runs on rapid pushes; PR runs are deduped per ref.
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # Pinned actionlint release — bumped explicitly in a reviewed PR.
+      ACTIONLINT_VERSION: "1.7.7"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Install actionlint
+        run: |
+          curl -fsSL -o download-actionlint.bash \
+            "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash"
+          bash download-actionlint.bash "${ACTIONLINT_VERSION}"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+
+      - name: Run actionlint
+        run: actionlint -color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ section to the released version with its date.
 
 ### Added
 
+- **CI lint gate for GitHub Actions (Issue #195).** New
+  `.github/workflows/actionlint.yml` runs [actionlint](https://github.com/rhysd/actionlint)
+  on every pull request and on pushes to the default branches, so workflow
+  regressions (invalid `runs-on` labels, broken `${{ }}` expressions, unknown
+  `uses:` inputs, shellcheck findings in `run:` scripts) fail the build. The
+  actionlint binary is downloaded from a version-pinned upstream release — no
+  third-party wrapper action enters the supply chain. The workflow is validated
+  by `scripts/check-actionlint-workflow.sh` (invoked from `quality.sh`) and
+  covered end-to-end by `tests/scripts/actionlint_workflow.bats`.
 - **Large creatures now run on the GPU (Issue #182).** New
   `forward_mse_scratch` WGSL kernel holds each thread's activations in a
   runtime-sized `storage` buffer instead of the 256-element `private` array of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "serde",
  "serde_json",
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1097,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "renderdoc-sys"
@@ -1109,7 +1109,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.50"
+version = "0.5.51"
 dependencies = [
  "bytemuck",
  "clap",
@@ -1912,18 +1912,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -551,6 +551,19 @@ validated by `scripts/check-dependency-review-workflow.sh` (invoked from
 `quality.sh`) and covered end-to-end by
 `tests/scripts/dependency_review_workflow.bats`.
 
+A standalone Actionlint workflow (`.github/workflows/actionlint.yml`,
+Issue #195) runs [actionlint](https://github.com/rhysd/actionlint) — the
+standard GitHub Actions linter — on every pull request and on pushes to the
+default branches. actionlint catches workflow regressions that a plain YAML
+parse misses: invalid `runs-on` labels, broken `${{ }}` expressions, unknown
+`uses:` inputs, and shellcheck findings inside `run:` scripts. The binary is
+downloaded from a version-pinned upstream release by the official
+`download-actionlint.bash` installer and run directly — no third-party wrapper
+action enters the supply chain, mirroring how `ci.yml` invokes ShellCheck
+(PR #184). The workflow is validated by
+`scripts/check-actionlint-workflow.sh` (invoked from `quality.sh`) and covered
+end-to-end by `tests/scripts/actionlint_workflow.bats`.
+
 A standalone Gitleaks Secrets Detection workflow
 (`.github/workflows/gitleaks.yml`, Issue #21) runs the pinned
 `gitleaks` binary on every pull request against any branch. The scan is

--- a/docs/archive/pr-summaries/pr-summary-195.md
+++ b/docs/archive/pr-summaries/pr-summary-195.md
@@ -1,0 +1,66 @@
+## Summary
+
+Added a CI lint gate for GitHub Actions workflows. The repository shipped a
+growing fleet of workflow YAML under `.github/workflows/` but had no CI job
+running the standard GitHub Actions linter (actionlint), so workflow
+regressions — invalid `runs-on` labels, broken `${{ }}` expressions, unknown
+`uses:` inputs, shellcheck findings in `run:` scripts — could reach `Develop`
+undetected.
+
+This change adds a standalone `actionlint.yml` workflow that runs actionlint on
+every pull request and on pushes to the default branches, following the
+established standalone-linter pattern in this repo (validator script +
+`quality.sh` wiring + bats coverage). The actionlint binary is downloaded from
+a version-pinned upstream release by the official `download-actionlint.bash`
+installer and run directly — no third-party wrapper action enters the supply
+chain, mirroring how `ci.yml` invokes ShellCheck (PR #184).
+
+Closes #195.
+
+## Changes
+
+- `.github/workflows/actionlint.yml` — new lint gate. Triggers on
+  `pull_request` and pushes to `main`/`master`/`Develop`; least-privilege
+  `contents: read`; `concurrency` group keyed by `github.ref`; per-job
+  `timeout-minutes`; `actions/checkout` SHA-pinned. Passes actionlint itself.
+- `scripts/check-actionlint-workflow.sh` — validator asserting the workflow
+  triggers on `pull_request`, declares read-only permissions, SHA/major-pins
+  `actions/checkout`, installs actionlint, and invokes it.
+- `tests/scripts/actionlint_workflow.bats` — 10 end-to-end tests exercising the
+  validator against synthetic fixtures (happy path, each failure mode, missing
+  file, unknown flag, and the real repository workflow).
+- `quality.sh` — invokes the new validator alongside the other workflow checks.
+- `README.md`, `CHANGELOG.md` — document the new gate.
+
+## Evidence
+
+Backend/CI change — no web UI to screenshot. Verified locally:
+
+- `actionlint` (v1.7.12) over all workflows including the new one: exit 0.
+- `scripts/check-actionlint-workflow.sh`: all rules report `OK`, exit 0.
+- `bats tests/scripts`: 261 tests pass (10 new in
+  `actionlint_workflow.bats`).
+- Existing workflow-iterating validators (timeouts, action-versions,
+  concurrency, shellcheck-dedup, codeowners, ci-permissions, ci-job-graph) all
+  pass with the new workflow present.
+- `scripts/spell-check.sh`: no typos. `markdownlint-cli2`: 0 errors.
+  `shellcheck`: clean.
+
+```mermaid
+flowchart LR
+    PR[Pull request / push] --> WF[actionlint.yml]
+    WF --> DL[Download pinned actionlint]
+    DL --> RUN["actionlint -color"]
+    RUN -->|findings| FAIL[Build fails]
+    RUN -->|clean| PASS[Build passes]
+```
+
+## Test Plan
+
+- Added `tests/scripts/actionlint_workflow.bats` (10 cases) covering the
+  validator's happy path, every individual failure mode (no `pull_request`
+  trigger, missing permissions, unpinned/missing checkout, missing install
+  step, actionlint not invoked), a missing workflow file, an unknown flag, and
+  the real repository workflow.
+- Wired `scripts/check-actionlint-workflow.sh` into `quality.sh` so the gate is
+  enforced on every local run and in CI's bats job.

--- a/quality.sh
+++ b/quality.sh
@@ -56,6 +56,9 @@ echo "🐚 Guarding against duplicated ShellCheck across workflows (Issue #157).
 echo "📝 Validating Markdown Lint workflow (Issue #63)..."
 ./scripts/check-markdown-lint-workflow.sh
 
+echo "🎬 Validating Actionlint workflow (Issue #195)..."
+./scripts/check-actionlint-workflow.sh
+
 echo "📦 Validating Dependency Review workflow (Issue #62)..."
 ./scripts/check-dependency-review-workflow.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.51"
+version = "0.5.52"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-actionlint-workflow.sh
+++ b/scripts/check-actionlint-workflow.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Validate the standalone Actionlint workflow (Issue #195).
+#
+# The actionlint workflow must:
+#   1. Trigger on pull_request so every change is linted before merge.
+#   2. Declare an explicit `permissions:` block (least privilege —
+#      `contents: read` is sufficient because actionlint only reads source).
+#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy —
+#      see scripts/check-workflow-action-versions.sh).
+#   4. Install the actionlint binary at a pinned version (the official
+#      download-actionlint.bash installer fetched from a version-pinned
+#      upstream ref — no third-party wrapper action).
+#   5. Invoke `actionlint` so the lint gate actually runs.
+#
+# The script takes a single optional `--workflow PATH` argument so BATS tests
+# can exercise it against fixtures. When called with no argument it validates
+# `.github/workflows/actionlint.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-actionlint-workflow.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the actionlint workflow YAML file (default:
+                    .github/workflows/actionlint.yml relative to the repo
+                    root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow satisfies every rule listed in the script header.
+Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/actionlint.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# 1. Triggered on pull_request events.
+if grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW" \
+  || grep -qE '^on:[[:space:]]*\[?.*pull_request' "$WORKFLOW"; then
+  ok "triggers on pull_request"
+else
+  fail "workflow is not triggered on pull_request"
+fi
+
+# 2. Explicit permissions block (least privilege).
+if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
+  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
+  ok "permissions block grants only contents: read"
+else
+  fail "no 'permissions: contents: read' block — least-privilege required"
+fi
+
+# 3. actions/checkout pinned to a numeric major (vN) or SHA. Branch refs
+#    disallowed (SHA pins carry a trailing `# vN` label).
+checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
+if [[ -z "$checkout_line" ]]; then
+  fail "actions/checkout step missing — workflow cannot fetch the repo"
+elif echo "$checkout_line" | grep -qE 'actions/checkout@([0-9a-f]{40}|v?[0-9]+)'; then
+  ok "actions/checkout pinned to a numeric major or SHA"
+else
+  fail "actions/checkout is not pinned — branch refs disallowed"
+fi
+
+# 4. actionlint must be installed. The official installer is
+#    download-actionlint.bash; require a reference to it so the binary is
+#    actually provisioned before the gate runs.
+if grep -qE 'download-actionlint\.bash' "$WORKFLOW"; then
+  ok "actionlint install step present"
+else
+  fail "actionlint install step missing — gate cannot run without the binary"
+fi
+
+# 5. actionlint must be invoked in a run step.
+if grep -qE '^[[:space:]]+(- )?run:[[:space:]]*actionlint' "$WORKFLOW" \
+  || grep -qE '^[[:space:]]+actionlint( |$)' "$WORKFLOW"; then
+  ok "actionlint invoked"
+else
+  fail "actionlint is not invoked — no 'run: actionlint' step found"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-actionlint-workflow.sh — Issue #195.
+#
+# Exercises the standalone Actionlint workflow validator with synthetic
+# workflow YAML in temporary directories so behaviour (exit codes, reported
+# failures) is verified end-to-end without mutating the real workflow file.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-actionlint-workflow.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical hardened workflow. Failure tests mutate this fixture to drop or
+# break one rule at a time.
+write_actionlint_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Actionlint
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master, Develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      ACTIONLINT_VERSION: "1.7.7"
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Install actionlint
+        run: |
+          curl -fsSL -o download-actionlint.bash \
+            "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash"
+          bash download-actionlint.bash "${ACTIONLINT_VERSION}"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Run actionlint
+        run: actionlint -color
+EOF
+}
+
+@test "passes on the canonical fixture" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"triggers on pull_request"* ]]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+  [[ "$output" == *"actionlint install step present"* ]]
+  [[ "$output" == *"actionlint invoked"* ]]
+}
+
+@test "fails when the workflow is not triggered on pull_request" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  python3 - "$TMP_WF/actionlint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not triggered on pull_request"* ]]
+}
+
+@test "fails when the permissions block is missing" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  python3 - "$TMP_WF/actionlint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("permissions:\n  contents: read\n\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read'"* ]]
+}
+
+@test "fails when actions/checkout is unpinned" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  sed -i.bak 's|actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5|actions/checkout@main|' "$TMP_WF/actionlint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "fails when actions/checkout step is missing" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  sed -i.bak '/actions\/checkout/d' "$TMP_WF/actionlint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails when the actionlint install step is missing" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  sed -i.bak '/download-actionlint\.bash/d' "$TMP_WF/actionlint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"install step missing"* ]]
+}
+
+@test "fails when actionlint is not invoked" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  python3 - "$TMP_WF/actionlint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace("      - name: Run actionlint\n        run: actionlint -color\n", "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not invoked"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository actionlint workflow satisfies every rule" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

Added a CI lint gate for GitHub Actions workflows. The repository shipped a
growing fleet of workflow YAML under `.github/workflows/` but had no CI job
running the standard GitHub Actions linter (actionlint), so workflow
regressions — invalid `runs-on` labels, broken `${{ }}` expressions, unknown
`uses:` inputs, shellcheck findings in `run:` scripts — could reach `Develop`
undetected.

This change adds a standalone `actionlint.yml` workflow that runs actionlint on
every pull request and on pushes to the default branches, following the
established standalone-linter pattern in this repo (validator script +
`quality.sh` wiring + bats coverage). The actionlint binary is downloaded from
a version-pinned upstream release by the official `download-actionlint.bash`
installer and run directly — no third-party wrapper action enters the supply
chain, mirroring how `ci.yml` invokes ShellCheck (PR #184).

Closes #195.

## Changes

- `.github/workflows/actionlint.yml` — new lint gate. Triggers on
  `pull_request` and pushes to `main`/`master`/`Develop`; least-privilege
  `contents: read`; `concurrency` group keyed by `github.ref`; per-job
  `timeout-minutes`; `actions/checkout` SHA-pinned. Passes actionlint itself.
- `scripts/check-actionlint-workflow.sh` — validator asserting the workflow
  triggers on `pull_request`, declares read-only permissions, SHA/major-pins
  `actions/checkout`, installs actionlint, and invokes it.
- `tests/scripts/actionlint_workflow.bats` — 10 end-to-end tests exercising the
  validator against synthetic fixtures (happy path, each failure mode, missing
  file, unknown flag, and the real repository workflow).
- `quality.sh` — invokes the new validator alongside the other workflow checks.
- `README.md`, `CHANGELOG.md` — document the new gate.

## Evidence

Backend/CI change — no web UI to screenshot. Verified locally:

- `actionlint` (v1.7.12) over all workflows including the new one: exit 0.
- `scripts/check-actionlint-workflow.sh`: all rules report `OK`, exit 0.
- `bats tests/scripts`: 261 tests pass (10 new in
  `actionlint_workflow.bats`).
- Existing workflow-iterating validators (timeouts, action-versions,
  concurrency, shellcheck-dedup, codeowners, ci-permissions, ci-job-graph) all
  pass with the new workflow present.
- `scripts/spell-check.sh`: no typos. `markdownlint-cli2`: 0 errors.
  `shellcheck`: clean.

```mermaid
flowchart LR
    PR[Pull request / push] --> WF[actionlint.yml]
    WF --> DL[Download pinned actionlint]
    DL --> RUN["actionlint -color"]
    RUN -->|findings| FAIL[Build fails]
    RUN -->|clean| PASS[Build passes]
```

## Test Plan

- Added `tests/scripts/actionlint_workflow.bats` (10 cases) covering the
  validator's happy path, every individual failure mode (no `pull_request`
  trigger, missing permissions, unpinned/missing checkout, missing install
  step, actionlint not invoked), a missing workflow file, an unknown flag, and
  the real repository workflow.
- Wired `scripts/check-actionlint-workflow.sh` into `quality.sh` so the gate is
  enforced on every local run and in CI's bats job.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9x5tis-6e3d4f`<!-- vibe-worker-issue-195 -->