### PR TITLE
Factor duplicated complexity_penalty into one shared scoring function (#199)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,13 +648,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -773,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "serde",
  "serde_json",
@@ -1109,7 +1108,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.51"
+version = "0.5.52"
 dependencies = [
  "bytemuck",
  "clap",
@@ -1383,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1396,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1406,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1416,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1429,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -1484,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/docs/archive/pr-summaries/pr-summary-199.md
+++ b/docs/archive/pr-summaries/pr-summary-199.md
@@ -1,0 +1,72 @@
+# Refactor: one shared `complexity_penalty` scoring function
+
+## Summary
+
+The `complexityPenalty` arithmetic was hand-copied across three result-assembly
+sites purely to populate the JSON `complexityPenalty` field, while
+`scoring::calculate_score` already computed the identical formula internally —
+so any change to the growth-cost weighting had to be made in four places or the
+reported `complexityPenalty` would silently disagree with `score`. The copies
+also averaged raw `value_penalty(...)` while `calculate_score` routed through
+`calculate_penalty` (which adds finiteness asserts), a subtle inconsistency.
+
+This change exposes a single canonical `pub fn complexity_penalty(components:
+&ScoreComponents, growth_cost: f64) -> f64` in `scoring.rs`, calls it from
+`calculate_score`, and replaces every inline block with that call. All sites now
+share one implementation that routes through `calculate_penalty`. Closes #199.
+
+### Call sites collapsed onto the shared function
+
+- `rust_scorer/src/scoring.rs` — new `complexity_penalty`; `calculate_score`
+  now calls it.
+- `rust_scorer/src/main.rs:447` — single-creature result assembly.
+- `rust_scorer/src/multi_score.rs` — both directory-mode result-assembly sites
+  (CPU and GPU paths). The now-unused `value_penalty` import was replaced with
+  `complexity_penalty`.
+
+```mermaid
+flowchart LR
+    subgraph before["Before — formula duplicated 4×"]
+        A1[main.rs] --> F1[inline formula]
+        A2[multi_score CPU] --> F2[inline formula]
+        A3[multi_score GPU] --> F3[inline formula]
+        A4[calculate_score] --> F4[inline formula]
+    end
+    subgraph after["After — one source of truth"]
+        B1[main.rs] --> S[scoring::complexity_penalty]
+        B2[multi_score CPU] --> S
+        B3[multi_score GPU] --> S
+        B4[calculate_score] --> S
+    end
+```
+
+## Evidence
+
+Backend/CLI refactor — no web interface to screenshot. Verified via the test
+suite. The behaviour is numerically identical (the formula is unchanged); the
+refactor removes duplication and aligns the weight/bias term on
+`calculate_penalty`.
+
+- `cargo test -p rust_scorer --lib --bin rust_scorer` → 63 + 84 tests pass.
+- `cargo fmt --check` and `cargo clippy --all-targets` clean.
+
+The one `quality.sh` failure — `gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
+in `tests/directory_mode_tdd.rs` — is a pre-existing, GPU-hardware-dependent
+test (it expects a CPU fallback but the build host has a Metal GPU). It fails
+identically on the base branch with this change stashed, so it is unrelated to
+this refactor.
+
+## Test Plan
+
+- `scoring::tests::test_complexity_penalty_matches_calculate_score` — asserts
+  the standalone shared function equals the penalty baked into `calculate_score`
+  (for a v4 creature, `score == 1 - cp`).
+- `scoring::tests::test_complexity_penalty_routes_through_calculate_penalty` —
+  asserts the weight/bias term matches `calculate_penalty` rather than a raw
+  `value_penalty` average.
+- `tests::test_complexity_penalty_json_matches_score` (in `main.rs`) — runs a
+  real creature through `run_single`, parses the serialised JSON, and asserts
+  the `complexityPenalty` field equals the value used inside `calculate_score`
+  (`score == 1 - error - complexityPenalty`). This is the acceptance-criterion
+  test.
+- All existing scoring/multi-score tests continue to pass unchanged.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.52"
+version = "0.5.53"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -444,13 +444,7 @@ fn score_from_json(
     let hidden_neurons = components.hidden_neuron_count;
     let synapse_count = components.synapse_count;
 
-    let weight_bias_penalty = (scoring::value_penalty(components.max_weight_bias)
-        + scoring::value_penalty(components.avg_weight_bias))
-        / 2.0;
-    let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
-    let complexity_penalty = hidden_neurons as f64 * GROWTH_COST
-        + synapse_count as f64 * GROWTH_COST / 10.0
-        + total_penalty * GROWTH_COST / 100.0;
+    let complexity_penalty = scoring::complexity_penalty(&components, GROWTH_COST);
 
     let score = calculate_score(
         avg_error,
@@ -783,6 +777,44 @@ mod tests {
             "expected costName in JSON, got: {json}"
         );
         assert!(json.contains("\"MSE\""), "expected costName value 'MSE'");
+    }
+
+    /// Issue #199: the serialised JSON `complexityPenalty` field must equal the
+    /// penalty value baked into `score` by `calculate_score`. With a v4 creature
+    /// the version penalty is zero, so `score == 1 - error - complexityPenalty`
+    /// holds exactly when both use the one shared formula.
+    #[test]
+    fn test_complexity_penalty_json_matches_score() {
+        let tmp = TempDir::new().unwrap();
+        let creature_path = tmp.path().join("creature.json");
+        let data_dir = tmp.path().join("data");
+        fs::create_dir(&data_dir).unwrap();
+
+        // Hidden neuron + weights > 1 so the complexity penalty is non-zero.
+        let json = make_creature_json(
+            1,
+            1,
+            &[("hidden-0", "TANH", 0.5)],
+            &[("input-0", "hidden-0", 1.5), ("hidden-0", "output-0", 2.0)],
+            Some("4.0.0"),
+        );
+        fs::write(&creature_path, &json).unwrap();
+        write_training_data(&data_dir, &[(vec![0.5], vec![0.5])]);
+
+        let result = run_single(&cli_for(&creature_path, &data_dir)).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
+        let json_cp = value["complexityPenalty"]
+            .as_f64()
+            .expect("complexityPenalty must serialise as a number");
+
+        assert!(json_cp > 0.0, "expected a non-zero penalty, got {json_cp}");
+        assert!(
+            (result.score - (1.0 - result.error - json_cp)).abs() < 1e-12,
+            "JSON complexityPenalty {json_cp} disagrees with score {} (error {})",
+            result.score,
+            result.error
+        );
     }
 
     /// Stdin mode must yield the same `ScoreResult` as the default file mode.

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -39,7 +39,7 @@ use crate::cost::{CostKind, accumulate_cost_sum};
 use crate::gpu::forward_mse_batched::{BatchedRunner, build_batched_network_data};
 use crate::gpu::{GpuBackendLabel, GpuContext};
 use crate::read_tuning::{training_read_backend_label, training_read_target_bytes_from_env};
-use crate::scoring::{ScoreResult, calculate_score, compute_score_components, value_penalty};
+use crate::scoring::{ScoreResult, calculate_score, complexity_penalty, compute_score_components};
 use crate::stream_score::{activation_worker_count_for_scorer, effective_fused_read_buf_len};
 
 /// Keep aligned with main scorer formula.
@@ -500,13 +500,7 @@ pub fn score_from_creature_dir(
         let hidden_neurons = components.hidden_neuron_count;
         let synapse_count = components.synapse_count;
 
-        let weight_bias_penalty = (value_penalty(components.max_weight_bias)
-            + value_penalty(components.avg_weight_bias))
-            / 2.0;
-        let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
-        let complexity_penalty = hidden_neurons as f64 * GROWTH_COST
-            + synapse_count as f64 * GROWTH_COST / 10.0
-            + total_penalty * GROWTH_COST / 100.0;
+        let complexity_penalty = complexity_penalty(&components, GROWTH_COST);
 
         let score = calculate_score(
             avg_error,
@@ -833,13 +827,7 @@ pub fn score_from_creature_dir_gpu(
         let hidden_neurons = components.hidden_neuron_count;
         let synapse_count = components.synapse_count;
 
-        let weight_bias_penalty = (value_penalty(components.max_weight_bias)
-            + value_penalty(components.avg_weight_bias))
-            / 2.0;
-        let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
-        let complexity_penalty = hidden_neurons as f64 * GROWTH_COST
-            + synapse_count as f64 * GROWTH_COST / 10.0
-            + total_penalty * GROWTH_COST / 100.0;
+        let complexity_penalty = complexity_penalty(&components, GROWTH_COST);
 
         let score = calculate_score(
             avg_error,

--- a/rust_scorer/src/scoring.rs
+++ b/rust_scorer/src/scoring.rs
@@ -159,13 +159,34 @@ pub fn compute_score_components(creature: &CreatureExport) -> ScoreComponents {
     }
 }
 
+/// Canonical complexity-penalty formula shared across every result-assembly site.
+///
+/// Returns the growth-cost-weighted penalty that `calculate_score` subtracts and
+/// that callers report as the JSON `complexityPenalty` field. Keeping a single
+/// implementation guarantees the reported penalty can never silently disagree
+/// with the value baked into `score`.
+///
+/// `complexityPenalty = hiddenNeurons * growthCost + synapses * growthCost / 10
+///                      + (weightBiasPenalty + squashComplexityPenalty) * growthCost / 100`
+///
+/// The weight/bias term routes through [`calculate_penalty`] (which adds
+/// finiteness asserts), so every call site shares the same numerical behaviour.
+pub fn complexity_penalty(components: &ScoreComponents, growth_cost: f64) -> f64 {
+    let weight_bias_penalty =
+        calculate_penalty(components.max_weight_bias, components.avg_weight_bias);
+    let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
+
+    components.hidden_neuron_count as f64 * growth_cost
+        + components.synapse_count as f64 * growth_cost / 10.0
+        + total_penalty * growth_cost / 100.0
+}
+
 /// Calculates the final score for a creature.
 ///
 /// Formula: `score = 1 - error - complexityPenalty - versionPenalty`
 ///
 /// Where:
-/// - `complexityPenalty = hiddenNeurons * growthCost + synapses * growthCost / 10
-///                        + (weightBiasPenalty + squashComplexityPenalty) * growthCost / 100`
+/// - `complexityPenalty` is computed by [`complexity_penalty`].
 /// - `versionPenalty = 1e-6` if the creature's semantic version doesn't start with "4."
 pub fn calculate_score(
     error: f64,
@@ -177,13 +198,7 @@ pub fn calculate_score(
     assert!(error.is_finite(), "Error is not finite");
     assert!(error >= 0.0, "Error: {error} is negative");
 
-    let weight_bias_penalty =
-        calculate_penalty(components.max_weight_bias, components.avg_weight_bias);
-    let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
-
-    let complexity_penalty = components.hidden_neuron_count as f64 * growth_cost
-        + components.synapse_count as f64 * growth_cost / 10.0
-        + total_penalty * growth_cost / 100.0;
+    let complexity_penalty = complexity_penalty(components, growth_cost);
 
     let version_penalty = match semantic_version {
         Some(v) if v.starts_with(&format!("{SEMANTIC_MAJOR_VERSION}.")) => 0.0,
@@ -403,6 +418,48 @@ mod tests {
         //         = 0.01 + 0.005 + 0 = 0.015
         let score = calculate_score(0.0, &components, growth_cost, Some("4.0.0"));
         assert!((score - (1.0 - 0.015)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_complexity_penalty_matches_calculate_score() {
+        // Issue #199: the standalone shared function must produce exactly the
+        // penalty baked into the score by calculate_score.
+        let components = ScoreComponents {
+            hidden_neuron_count: 10,
+            synapse_count: 50,
+            max_weight_bias: 2.0,
+            avg_weight_bias: 1.5,
+            squash_complexity_penalty: 3.0,
+        };
+        let growth_cost = 0.001;
+
+        let cp = complexity_penalty(&components, growth_cost);
+        assert!(cp > 0.0);
+
+        // v4 creature => zero version penalty, so score = 1 - error - cp.
+        let score = calculate_score(0.0, &components, growth_cost, Some("4.0.0"));
+        assert!((score - (1.0 - cp)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_complexity_penalty_routes_through_calculate_penalty() {
+        // The weight/bias term must match calculate_penalty (not a raw
+        // value_penalty average) so every call site shares one behaviour.
+        let components = ScoreComponents {
+            hidden_neuron_count: 4,
+            synapse_count: 7,
+            max_weight_bias: 5.0,
+            avg_weight_bias: 2.0,
+            squash_complexity_penalty: 0.0,
+        };
+        let growth_cost = 0.01;
+
+        let weight_bias_penalty = calculate_penalty(5.0, 2.0);
+        let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
+        let expected =
+            4.0 * growth_cost + 7.0 * growth_cost / 10.0 + total_penalty * growth_cost / 100.0;
+
+        assert!((complexity_penalty(&components, growth_cost) - expected).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
# Refactor: one shared `complexity_penalty` scoring function

## Summary

The `complexityPenalty` arithmetic was hand-copied across three result-assembly
sites purely to populate the JSON `complexityPenalty` field, while
`scoring::calculate_score` already computed the identical formula internally —
so any change to the growth-cost weighting had to be made in four places or the
reported `complexityPenalty` would silently disagree with `score`. The copies
also averaged raw `value_penalty(...)` while `calculate_score` routed through
`calculate_penalty` (which adds finiteness asserts), a subtle inconsistency.

This change exposes a single canonical `pub fn complexity_penalty(components:
&ScoreComponents, growth_cost: f64) -> f64` in `scoring.rs`, calls it from
`calculate_score`, and replaces every inline block with that call. All sites now
share one implementation that routes through `calculate_penalty`. Closes #199.

### Call sites collapsed onto the shared function

- `rust_scorer/src/scoring.rs` — new `complexity_penalty`; `calculate_score`
  now calls it.
- `rust_scorer/src/main.rs:447` — single-creature result assembly.
- `rust_scorer/src/multi_score.rs` — both directory-mode result-assembly sites
  (CPU and GPU paths). The now-unused `value_penalty` import was replaced with
  `complexity_penalty`.

```mermaid
flowchart LR
    subgraph before["Before — formula duplicated 4×"]
        A1[main.rs] --> F1[inline formula]
        A2[multi_score CPU] --> F2[inline formula]
        A3[multi_score GPU] --> F3[inline formula]
        A4[calculate_score] --> F4[inline formula]
    end
    subgraph after["After — one source of truth"]
        B1[main.rs] --> S[scoring::complexity_penalty]
        B2[multi_score CPU] --> S
        B3[multi_score GPU] --> S
        B4[calculate_score] --> S
    end
```

## Evidence

Backend/CLI refactor — no web interface to screenshot. Verified via the test
suite. The behaviour is numerically identical (the formula is unchanged); the
refactor removes duplication and aligns the weight/bias term on
`calculate_penalty`.

- `cargo test -p rust_scorer --lib --bin rust_scorer` → 63 + 84 tests pass.
- `cargo fmt --check` and `cargo clippy --all-targets` clean.

The one `quality.sh` failure — `gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
in `tests/directory_mode_tdd.rs` — is a pre-existing, GPU-hardware-dependent
test (it expects a CPU fallback but the build host has a Metal GPU). It fails
identically on the base branch with this change stashed, so it is unrelated to
this refactor.

## Test Plan

- `scoring::tests::test_complexity_penalty_matches_calculate_score` — asserts
  the standalone shared function equals the penalty baked into `calculate_score`
  (for a v4 creature, `score == 1 - cp`).
- `scoring::tests::test_complexity_penalty_routes_through_calculate_penalty` —
  asserts the weight/bias term matches `calculate_penalty` rather than a raw
  `value_penalty` average.
- `tests::test_complexity_penalty_json_matches_score` (in `main.rs`) — runs a
  real creature through `run_single`, parses the serialised JSON, and asserts
  the `complexityPenalty` field equals the value used inside `calculate_score`
  (`score == 1 - error - complexityPenalty`). This is the acceptance-criterion
  test.
- All existing scoring/multi-score tests continue to pass unchanged.



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqbqx3gz-f3a387`<!-- vibe-worker-issue-199 -->