### PR TITLE
Convert input-reachable scoring panics to structured errors (Issue #201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ section to the released version with its date.
 
 ### Changed
 
+- **Input-reachable `assert!`/serialise `expect` panics are now structured
+  errors (Issue #201).** `scoring::value_penalty`, `compute_score_components`,
+  `complexity_penalty` and `calculate_score` return `Result<_, String>` and
+  emit a clear message for negative/non-finite weights, biases or average
+  errors instead of aborting the process via a release-build panic. The
+  `main` serialisation step routes `serde_json` failures through the standard
+  `eprintln!("Error: ...")` + `exit(1)` path rather than `expect`. Pure
+  internal-math invariants (penalty/score bounds) stay as `debug_assert!`.
 - The GPU pre-flight (`multi_score::gpu_directory_compatible`) and
   `build_batched_network_data` no longer reject creatures above 256 neurons —
   they route to `forward_mse_scratch`. Only an unsupported squash, a shape

--- a/docs/archive/pr-summaries/pr-summary-201.md
+++ b/docs/archive/pr-summaries/pr-summary-201.md
@@ -1,0 +1,99 @@
+# Robustness: convert input-reachable `assert!`/serialise `expect` panics to structured errors
+
+## Summary
+
+Several `assert!` guards in `rust_scorer/src/scoring.rs` (not `debug_assert!`,
+so they fire in release builds) protected values reachable from arbitrary
+user-supplied creature JSON / stdin. A non-finite/NaN weight or bias, a
+negative or non-finite average error, or a serialisation failure aborted the
+process via panic instead of returning the binary's standard
+`Err(String)` → `eprintln!("Error: ...")` → `exit(1)` result.
+
+This change converts the input-derived checks to early `Result::Err` returns
+with clear messages, and routes serialisation failures through the same error
+path. Pure internal-math invariants stay as `debug_assert!`.
+
+**Closes #201.**
+
+### What changed
+
+- `scoring::value_penalty`, `compute_score_components`, `complexity_penalty`
+  and `calculate_score` now return `Result<_, String>`:
+  - `value_penalty` → `Err` for negative or non-finite `value`.
+  - `compute_score_components` → `Err` for a non-finite synapse weight or
+    neuron bias (naming the offending UUID/edge).
+  - `calculate_score` → `Err` for a non-finite or negative average error.
+- `main()` routes `serde_json::to_string_pretty` failures (single- and
+  multi-creature) through `eprintln!("Error: ...")` + `process::exit(1)`
+  instead of `.expect(...)`.
+- Pure internal-math invariants (`primary/compressed penalty < 1`,
+  `penalty` finite/`>= 0`/`< 1`, `score <= 1.0`) downgraded to
+  `debug_assert!` — they cannot be violated once the input checks pass.
+- `ScoreComponents` derives `Debug` (needed so tests can `unwrap_err`).
+- Call sites in `main.rs` and `multi_score.rs` (both CPU and GPU directory
+  paths) propagate the new `Result` via `?` — all are already inside
+  `Result<_, String>`-returning functions.
+
+### Error-flow
+
+```mermaid
+flowchart LR
+    A[Creature JSON / stdin] --> B[compute_score_components]
+    B -- non-finite weight/bias --> E[Err String]
+    A --> C[score over data]
+    C --> D[calculate_score]
+    D -- non-finite / negative error --> E
+    D -- ok --> F[ScoreResult]
+    F --> G[serde_json::to_string_pretty]
+    G -- serialise error --> E
+    G -- ok --> H[println! JSON]
+    E --> I["eprintln!(Error: ...) + exit(1)"]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the Rust
+test suite. New and updated unit tests deterministically exercise each
+converted error path by calling the real functions with malformed numeric
+input and asserting a structured `Err`:
+
+```text
+running 22 tests (scoring) ... ok
+test result: ok. 91 passed; 0 failed (rust_scorer lib + bin)
+```
+
+### Pre-existing, unrelated failure
+
+`tests/directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
+fails on this machine because it has a real Metal GPU (the test asserts a
+`cpu-fallback` backend). Confirmed it fails identically on the base branch
+with my changes stashed, so it is environmental and unrelated to this work.
+
+## Test Plan
+
+Added to `rust_scorer/src/scoring.rs`:
+
+- `test_value_penalty_rejects_non_finite` — NaN/inf → `Err("not finite")`.
+- `test_compute_score_components_rejects_non_finite_weight` — NaN/inf weight →
+  structured `Err`.
+- `test_compute_score_components_rejects_non_finite_bias` — NaN/-inf bias →
+  structured `Err`.
+- `test_calculate_score_rejects_non_finite_error` — NaN/inf average error →
+  structured `Err`.
+- `test_calculate_score_rejects_negative_error` — negative average error →
+  structured `Err`.
+
+Modified (documented business-logic change — panic → `Result`):
+
+- `test_value_penalty_rejects_negative` — was `#[should_panic(expected = "negative")]`;
+  now asserts `value_penalty(-1.0)` returns `Err` containing `"negative"`.
+- All other `value_penalty` / `calculate_penalty` / `calculate_score` /
+  `complexity_penalty` / `compute_score_components` call sites in the existing
+  tests updated to `unwrap()` the new `Result` (no assertions removed).
+
+Note: a true non-finite weight cannot reach `compute_score_components` through
+the CLI because `parse_creature_json` rejects out-of-range JSON numbers and the
+scoring data pipeline is `f32` (saturating at `f32::MAX`, whose square fits in
+`f64`). The conversions remain the correct defensive fix for these `pub`
+functions and any in-memory `CreatureExport` callers, and the error branches
+are covered directly at the function level.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.54"
+version = "0.5.55"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -440,18 +440,18 @@ fn score_from_json(
 
     let avg_error = total_error / record_count as f64;
 
-    let components = compute_score_components(&creature);
+    let components = compute_score_components(&creature)?;
     let hidden_neurons = components.hidden_neuron_count;
     let synapse_count = components.synapse_count;
 
-    let complexity_penalty = scoring::complexity_penalty(&components, GROWTH_COST);
+    let complexity_penalty = scoring::complexity_penalty(&components, GROWTH_COST)?;
 
     let score = calculate_score(
         avg_error,
         &components,
         GROWTH_COST,
         creature.semantic_version.as_deref(),
-    );
+    )?;
 
     Ok(ScoreResult {
         score,
@@ -481,17 +481,19 @@ fn score_from_json(
 fn main() {
     let cli = Cli::parse();
 
-    match run(&cli) {
-        Ok(RunOutput::Single(result)) => {
-            let json =
-                serde_json::to_string_pretty(&result).expect("Failed to serialise result to JSON");
-            println!("{json}");
-        }
-        Ok(RunOutput::Multi(result_map)) => {
-            let json = serde_json::to_string_pretty(&result_map)
-                .expect("Failed to serialise multi-creature result to JSON");
-            println!("{json}");
-        }
+    // Issue #201: route serialisation failures through the same
+    // `eprintln!("Error: ...")` + `exit(1)` path as scoring errors, instead of
+    // panicking via `expect`. `serde_json` errors on non-finite floats, so a
+    // malformed result must exit cleanly rather than abort the process.
+    let output = run(&cli).and_then(|out| match out {
+        RunOutput::Single(result) => serde_json::to_string_pretty(&result)
+            .map_err(|e| format!("Failed to serialise result to JSON: {e}")),
+        RunOutput::Multi(result_map) => serde_json::to_string_pretty(&result_map)
+            .map_err(|e| format!("Failed to serialise multi-creature result to JSON: {e}")),
+    });
+
+    match output {
+        Ok(json) => println!("{json}"),
         Err(e) => {
             eprintln!("Error: {e}");
             process::exit(1);

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -499,18 +499,18 @@ pub fn score_from_creature_dir(
     let mut results = BTreeMap::new();
     for (loaded_creature, mse_sum) in loaded.iter().zip(total_mse.iter()) {
         let avg_error = *mse_sum / total_records as f64;
-        let components = compute_score_components(&loaded_creature.creature);
+        let components = compute_score_components(&loaded_creature.creature)?;
         let hidden_neurons = components.hidden_neuron_count;
         let synapse_count = components.synapse_count;
 
-        let complexity_penalty = complexity_penalty(&components, GROWTH_COST);
+        let complexity_penalty = complexity_penalty(&components, GROWTH_COST)?;
 
         let score = calculate_score(
             avg_error,
             &components,
             GROWTH_COST,
             loaded_creature.creature.semantic_version.as_deref(),
-        );
+        )?;
 
         results.insert(
             loaded_creature.key.clone(),
@@ -826,18 +826,18 @@ pub fn score_from_creature_dir_gpu(
     let mut results = BTreeMap::new();
     for (loaded_creature, mse_sum) in loaded.iter().zip(total_mse.iter()) {
         let avg_error = *mse_sum / total_records as f64;
-        let components = compute_score_components(&loaded_creature.creature);
+        let components = compute_score_components(&loaded_creature.creature)?;
         let hidden_neurons = components.hidden_neuron_count;
         let synapse_count = components.synapse_count;
 
-        let complexity_penalty = complexity_penalty(&components, GROWTH_COST);
+        let complexity_penalty = complexity_penalty(&components, GROWTH_COST)?;
 
         let score = calculate_score(
             avg_error,
             &components,
             GROWTH_COST,
             loaded_creature.creature.semantic_version.as_deref(),
-        );
+        )?;
 
         results.insert(
             loaded_creature.key.clone(),

--- a/rust_scorer/src/scoring.rs
+++ b/rust_scorer/src/scoring.rs
@@ -19,40 +19,49 @@ pub const SEMANTIC_MAJOR_VERSION: u32 = 4;
 /// Uses recursive logarithmic compression for very large values.
 ///
 /// Matches the TypeScript `valuePenalty()` in `src/architecture/Score.ts`.
-pub fn value_penalty(value: f64) -> f64 {
-    assert!(value >= 0.0, "Value: {value} is negative");
-
-    if value <= 1.0 {
-        return 0.0;
+///
+/// Returns `Err` when `value` is negative or non-finite — both reachable from
+/// arbitrary creature JSON — so malformed input yields a structured error
+/// rather than a release-build panic (Issue #201). The remaining bounds are
+/// pure internal-math invariants and stay as `debug_assert!`.
+pub fn value_penalty(value: f64) -> Result<f64, String> {
+    if value < 0.0 {
+        return Err(format!("value_penalty: value {value} is negative"));
     }
 
-    assert!(value.is_finite(), "Value: {value} is not finite");
+    if value <= 1.0 {
+        return Ok(0.0);
+    }
+
+    if !value.is_finite() {
+        return Err(format!("value_penalty: value {value} is not finite"));
+    }
 
     let primary_penalty = 1.0 / (1.0 + 1.0 / value);
 
     if primary_penalty > 0.999 {
-        let compress_penalty = 0.999 + value_penalty(value.ln()) / 1000.0;
-        assert!(
+        let compress_penalty = 0.999 + value_penalty(value.ln())? / 1000.0;
+        debug_assert!(
             compress_penalty < 1.0,
             "Compressed Penalty: {compress_penalty} is >= 1"
         );
-        return compress_penalty;
+        return Ok(compress_penalty);
     }
 
-    assert!(
+    debug_assert!(
         primary_penalty < 1.0,
         "Primary Penalty: {primary_penalty} is >= 1"
     );
-    primary_penalty
+    Ok(primary_penalty)
 }
 
 /// Calculates the combined weight/bias penalty from max and average absolute values.
-fn calculate_penalty(max: f64, avg: f64) -> f64 {
-    let penalty = (value_penalty(max) + value_penalty(avg)) / 2.0;
-    assert!(penalty.is_finite(), "Penalty: {penalty} is not finite");
-    assert!(penalty >= 0.0, "Penalty: {penalty} is negative");
-    assert!(penalty < 1.0, "Penalty: {penalty} is >= 1");
-    penalty
+fn calculate_penalty(max: f64, avg: f64) -> Result<f64, String> {
+    let penalty = (value_penalty(max)? + value_penalty(avg)?) / 2.0;
+    debug_assert!(penalty.is_finite(), "Penalty: {penalty} is not finite");
+    debug_assert!(penalty >= 0.0, "Penalty: {penalty} is negative");
+    debug_assert!(penalty < 1.0, "Penalty: {penalty} is >= 1");
+    Ok(penalty)
 }
 
 /// Returns the squash function complexity penalty for a given squash type.
@@ -67,6 +76,7 @@ fn squash_complexity_penalty(squash_type: SquashType) -> f64 {
 }
 
 /// Components extracted from a creature for score calculation.
+#[derive(Debug)]
 pub struct ScoreComponents {
     /// Number of hidden neurons (excluding input and output).
     pub hidden_neuron_count: usize,
@@ -84,7 +94,12 @@ pub struct ScoreComponents {
 ///
 /// Iterates over synapses and neurons to gather weight/bias statistics
 /// and squash complexity penalties.
-pub fn compute_score_components(creature: &CreatureExport) -> ScoreComponents {
+///
+/// Returns `Err` when any synapse weight or neuron bias is non-finite. These
+/// values come straight from user-supplied creature JSON, so a NaN/inf weight
+/// or bias yields a structured error instead of a release-build panic
+/// (Issue #201).
+pub fn compute_score_components(creature: &CreatureExport) -> Result<ScoreComponents, String> {
     let mut max_weight_bias: f64 = 0.0;
     let mut total_weight_bias: f64 = 0.0;
     let mut count_weight_bias: usize = 0;
@@ -92,11 +107,12 @@ pub fn compute_score_components(creature: &CreatureExport) -> ScoreComponents {
 
     // Gather weight statistics from synapses
     for synapse in &creature.synapses {
-        assert!(
-            synapse.weight.is_finite(),
-            "Weight: {} is not finite",
-            synapse.weight
-        );
+        if !synapse.weight.is_finite() {
+            return Err(format!(
+                "Synapse weight {} (from {} to {}) is not finite",
+                synapse.weight, synapse.from_uuid, synapse.to_uuid
+            ));
+        }
         let w = synapse.weight.abs();
         if w > max_weight_bias {
             max_weight_bias = w;
@@ -107,11 +123,12 @@ pub fn compute_score_components(creature: &CreatureExport) -> ScoreComponents {
 
     // Gather bias statistics and squash complexity from non-input neurons
     for neuron in &creature.neurons {
-        assert!(
-            neuron.bias.is_finite(),
-            "Bias: {} is not finite",
-            neuron.bias
-        );
+        if !neuron.bias.is_finite() {
+            return Err(format!(
+                "Neuron bias {} (uuid {}) is not finite",
+                neuron.bias, neuron.uuid
+            ));
+        }
         let b = neuron.bias.abs();
         if b > max_weight_bias {
             max_weight_bias = b;
@@ -150,13 +167,13 @@ pub fn compute_score_components(creature: &CreatureExport) -> ScoreComponents {
         .filter(|n| n.neuron_type == "hidden" || n.neuron_type == "constant")
         .count();
 
-    ScoreComponents {
+    Ok(ScoreComponents {
         hidden_neuron_count,
         synapse_count: creature.synapses.len(),
         max_weight_bias: safe_max,
         avg_weight_bias,
         squash_complexity_penalty: squash_penalty,
-    }
+    })
 }
 
 /// Canonical complexity-penalty formula shared across every result-assembly site.
@@ -169,16 +186,17 @@ pub fn compute_score_components(creature: &CreatureExport) -> ScoreComponents {
 /// `complexityPenalty = hiddenNeurons * growthCost + synapses * growthCost / 10
 ///                      + (weightBiasPenalty + squashComplexityPenalty) * growthCost / 100`
 ///
-/// The weight/bias term routes through `calculate_penalty` (which adds
-/// finiteness asserts), so every call site shares the same numerical behaviour.
-pub fn complexity_penalty(components: &ScoreComponents, growth_cost: f64) -> f64 {
+/// The weight/bias term routes through `calculate_penalty` (which validates
+/// finiteness), so every call site shares the same numerical behaviour and the
+/// same structured-error propagation (Issue #201).
+pub fn complexity_penalty(components: &ScoreComponents, growth_cost: f64) -> Result<f64, String> {
     let weight_bias_penalty =
-        calculate_penalty(components.max_weight_bias, components.avg_weight_bias);
+        calculate_penalty(components.max_weight_bias, components.avg_weight_bias)?;
     let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
 
-    components.hidden_neuron_count as f64 * growth_cost
+    Ok(components.hidden_neuron_count as f64 * growth_cost
         + components.synapse_count as f64 * growth_cost / 10.0
-        + total_penalty * growth_cost / 100.0
+        + total_penalty * growth_cost / 100.0)
 }
 
 /// Calculates the final score for a creature.
@@ -188,17 +206,30 @@ pub fn complexity_penalty(components: &ScoreComponents, growth_cost: f64) -> f64
 /// Where:
 /// - `complexityPenalty` is computed by [`complexity_penalty`].
 /// - `versionPenalty = 1e-6` if the creature's semantic version doesn't start with "4."
+///
+/// Returns `Err` when `error` is non-finite or negative. The average error is
+/// derived from the chosen cost over user-supplied training data, so a cost
+/// that yields a non-finite or negative average produces a structured error
+/// rather than a release-build panic (Issue #201). The `score <= 1.0` bound is
+/// a pure internal-math invariant (guaranteed once `error >= 0` and the
+/// penalties are non-negative) and stays as `debug_assert!`.
 pub fn calculate_score(
     error: f64,
     components: &ScoreComponents,
     growth_cost: f64,
     semantic_version: Option<&str>,
-) -> f64 {
-    assert!(!error.is_nan(), "Error is NaN");
-    assert!(error.is_finite(), "Error is not finite");
-    assert!(error >= 0.0, "Error: {error} is negative");
+) -> Result<f64, String> {
+    if error.is_nan() {
+        return Err("Average error is NaN".to_string());
+    }
+    if !error.is_finite() {
+        return Err(format!("Average error {error} is not finite"));
+    }
+    if error < 0.0 {
+        return Err(format!("Average error {error} is negative"));
+    }
 
-    let complexity_penalty = complexity_penalty(components, growth_cost);
+    let complexity_penalty = complexity_penalty(components, growth_cost)?;
 
     let version_penalty = match semantic_version {
         Some(v) if v.starts_with(&format!("{SEMANTIC_MAJOR_VERSION}.")) => 0.0,
@@ -206,8 +237,8 @@ pub fn calculate_score(
     };
 
     let score = 1.0 - error - complexity_penalty - version_penalty;
-    assert!(score <= 1.0, "Score: {score} is greater than 1");
-    score
+    debug_assert!(score <= 1.0, "Score: {score} is greater than 1");
+    Ok(score)
 }
 
 /// Result of scoring a creature against training data.
@@ -278,16 +309,16 @@ mod tests {
 
     #[test]
     fn test_value_penalty_zero_for_small_values() {
-        assert_eq!(value_penalty(0.0), 0.0);
-        assert_eq!(value_penalty(0.5), 0.0);
-        assert_eq!(value_penalty(1.0), 0.0);
+        assert_eq!(value_penalty(0.0).unwrap(), 0.0);
+        assert_eq!(value_penalty(0.5).unwrap(), 0.0);
+        assert_eq!(value_penalty(1.0).unwrap(), 0.0);
     }
 
     #[test]
     fn test_value_penalty_increases_with_magnitude() {
-        let p2 = value_penalty(2.0);
-        let p10 = value_penalty(10.0);
-        let p100 = value_penalty(100.0);
+        let p2 = value_penalty(2.0).unwrap();
+        let p10 = value_penalty(10.0).unwrap();
+        let p100 = value_penalty(100.0).unwrap();
 
         assert!(p2 > 0.0);
         assert!(p10 > p2);
@@ -296,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_value_penalty_never_reaches_one() {
-        let p = value_penalty(1_000_000.0);
+        let p = value_penalty(1_000_000.0).unwrap();
         assert!(p < 1.0);
         assert!(p > 0.999);
     }
@@ -304,11 +335,11 @@ mod tests {
     #[test]
     fn test_value_penalty_known_values() {
         // valuePenalty(10) = 1 / (1 + 1/10) = 1 / 1.1 ≈ 0.9090909...
-        let p = value_penalty(10.0);
+        let p = value_penalty(10.0).unwrap();
         assert!((p - 0.909_090_909_090_909_1).abs() < 1e-12);
 
         // valuePenalty(2) = 1 / (1 + 1/2) = 1/1.5 ≈ 0.6666...
-        let p2 = value_penalty(2.0);
+        let p2 = value_penalty(2.0).unwrap();
         assert!((p2 - 2.0 / 3.0).abs() < 1e-12);
     }
 
@@ -316,32 +347,43 @@ mod tests {
     fn test_value_penalty_compression() {
         // Values large enough to trigger compression (primary_penalty > 0.999)
         // 1/(1+1/v) > 0.999  =>  v > 999
-        let p = value_penalty(1000.0);
+        let p = value_penalty(1000.0).unwrap();
         assert!(p >= 0.999);
         assert!(p < 1.0);
 
-        let p2 = value_penalty(10_000.0);
+        let p2 = value_penalty(10_000.0).unwrap();
         assert!(p2 >= 0.999);
         assert!(p2 < 1.0);
         assert!(p2 > p);
     }
 
     #[test]
-    #[should_panic(expected = "negative")]
     fn test_value_penalty_rejects_negative() {
-        value_penalty(-1.0);
+        // Issue #201: a negative value now returns a structured error rather
+        // than panicking (previously a `#[should_panic]` test).
+        let err = value_penalty(-1.0).unwrap_err();
+        assert!(err.contains("negative"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn test_value_penalty_rejects_non_finite() {
+        // Issue #201: NaN/inf return a structured error instead of panicking.
+        let nan = value_penalty(f64::NAN).unwrap_err();
+        assert!(nan.contains("not finite"), "unexpected message: {nan}");
+        let inf = value_penalty(f64::INFINITY).unwrap_err();
+        assert!(inf.contains("not finite"), "unexpected message: {inf}");
     }
 
     #[test]
     fn test_calculate_penalty_symmetric() {
-        let penalty = calculate_penalty(5.0, 2.0);
-        let expected = (value_penalty(5.0) + value_penalty(2.0)) / 2.0;
+        let penalty = calculate_penalty(5.0, 2.0).unwrap();
+        let expected = (value_penalty(5.0).unwrap() + value_penalty(2.0).unwrap()) / 2.0;
         assert!((penalty - expected).abs() < 1e-12);
     }
 
     #[test]
     fn test_calculate_penalty_zero_for_small() {
-        let penalty = calculate_penalty(0.5, 0.3);
+        let penalty = calculate_penalty(0.5, 0.3).unwrap();
         assert_eq!(penalty, 0.0);
     }
 
@@ -368,7 +410,7 @@ mod tests {
             squash_complexity_penalty: 0.0,
         };
         // Error=0, version matched => score close to 1 (minus small synapse penalty)
-        let score = calculate_score(0.0, &components, 0.0001, Some("4.0.0"));
+        let score = calculate_score(0.0, &components, 0.0001, Some("4.0.0")).unwrap();
         assert!(score > 0.99);
         assert!(score <= 1.0);
     }
@@ -382,7 +424,7 @@ mod tests {
             avg_weight_bias: 0.3,
             squash_complexity_penalty: 0.0,
         };
-        let score = calculate_score(0.5, &components, 0.0, Some("4.0.0"));
+        let score = calculate_score(0.5, &components, 0.0, Some("4.0.0")).unwrap();
         assert!((score - 0.5).abs() < 1e-12);
     }
 
@@ -395,9 +437,9 @@ mod tests {
             avg_weight_bias: 0.3,
             squash_complexity_penalty: 0.0,
         };
-        let score_v4 = calculate_score(0.0, &components, 0.0, Some("4.1.0"));
-        let score_v3 = calculate_score(0.0, &components, 0.0, Some("3.0.0"));
-        let score_none = calculate_score(0.0, &components, 0.0, None);
+        let score_v4 = calculate_score(0.0, &components, 0.0, Some("4.1.0")).unwrap();
+        let score_v3 = calculate_score(0.0, &components, 0.0, Some("3.0.0")).unwrap();
+        let score_none = calculate_score(0.0, &components, 0.0, None).unwrap();
 
         assert!((score_v4 - 1.0).abs() < 1e-12);
         assert!((score_v3 - (1.0 - 1e-6)).abs() < 1e-12);
@@ -416,7 +458,7 @@ mod tests {
         let growth_cost = 0.001;
         // Expected: 10 * 0.001 + 50 * 0.001 / 10 + 0 * 0.001 / 100
         //         = 0.01 + 0.005 + 0 = 0.015
-        let score = calculate_score(0.0, &components, growth_cost, Some("4.0.0"));
+        let score = calculate_score(0.0, &components, growth_cost, Some("4.0.0")).unwrap();
         assert!((score - (1.0 - 0.015)).abs() < 1e-12);
     }
 
@@ -433,11 +475,11 @@ mod tests {
         };
         let growth_cost = 0.001;
 
-        let cp = complexity_penalty(&components, growth_cost);
+        let cp = complexity_penalty(&components, growth_cost).unwrap();
         assert!(cp > 0.0);
 
         // v4 creature => zero version penalty, so score = 1 - error - cp.
-        let score = calculate_score(0.0, &components, growth_cost, Some("4.0.0"));
+        let score = calculate_score(0.0, &components, growth_cost, Some("4.0.0")).unwrap();
         assert!((score - (1.0 - cp)).abs() < 1e-12);
     }
 
@@ -454,12 +496,12 @@ mod tests {
         };
         let growth_cost = 0.01;
 
-        let weight_bias_penalty = calculate_penalty(5.0, 2.0);
+        let weight_bias_penalty = calculate_penalty(5.0, 2.0).unwrap();
         let total_penalty = weight_bias_penalty + components.squash_complexity_penalty;
         let expected =
             4.0 * growth_cost + 7.0 * growth_cost / 10.0 + total_penalty * growth_cost / 100.0;
 
-        assert!((complexity_penalty(&components, growth_cost) - expected).abs() < 1e-12);
+        assert!((complexity_penalty(&components, growth_cost).unwrap() - expected).abs() < 1e-12);
     }
 
     #[test]
@@ -505,7 +547,7 @@ mod tests {
             forward_only: false,
         };
 
-        let components = compute_score_components(&creature);
+        let components = compute_score_components(&creature).unwrap();
         assert_eq!(components.hidden_neuron_count, 1);
         assert_eq!(components.synapse_count, 3);
         // Max abs: max(1.5, 0.8, 2.0, 0.5, 0.3) = 2.0
@@ -513,5 +555,80 @@ mod tests {
         // Total abs: 1.5 + 0.8 + 2.0 + 0.5 + 0.3 = 5.1, count = 5
         assert!((components.avg_weight_bias - 5.1 / 5.0).abs() < 1e-12);
         assert_eq!(components.squash_complexity_penalty, 0.0);
+    }
+
+    /// Builds a single-neuron, single-synapse creature for error-path tests.
+    fn creature_with(weight: f64, bias: f64) -> CreatureExport {
+        CreatureExport {
+            input: 1,
+            output: 1,
+            neurons: vec![neat_core::creature::NeuronExport {
+                neuron_type: "output".to_string(),
+                uuid: "output-0".to_string(),
+                bias,
+                squash: Some("IDENTITY".to_string()),
+            }],
+            synapses: vec![neat_core::creature::SynapseExport {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight,
+                synapse_type: None,
+            }],
+            semantic_version: Some("4.0.0".to_string()),
+            forward_only: false,
+        }
+    }
+
+    #[test]
+    fn test_compute_score_components_rejects_non_finite_weight() {
+        // Issue #201: a NaN weight from user JSON returns a structured error.
+        let nan = compute_score_components(&creature_with(f64::NAN, 0.0)).unwrap_err();
+        assert!(nan.contains("Synapse weight"), "unexpected message: {nan}");
+        assert!(nan.contains("not finite"), "unexpected message: {nan}");
+
+        let inf = compute_score_components(&creature_with(f64::INFINITY, 0.0)).unwrap_err();
+        assert!(inf.contains("not finite"), "unexpected message: {inf}");
+    }
+
+    #[test]
+    fn test_compute_score_components_rejects_non_finite_bias() {
+        // Issue #201: a non-finite bias from user JSON returns a structured error.
+        let nan = compute_score_components(&creature_with(0.5, f64::NAN)).unwrap_err();
+        assert!(nan.contains("Neuron bias"), "unexpected message: {nan}");
+        assert!(nan.contains("not finite"), "unexpected message: {nan}");
+
+        let inf = compute_score_components(&creature_with(0.5, f64::NEG_INFINITY)).unwrap_err();
+        assert!(inf.contains("not finite"), "unexpected message: {inf}");
+    }
+
+    #[test]
+    fn test_calculate_score_rejects_non_finite_error() {
+        // Issue #201: a non-finite average error returns a structured error
+        // rather than panicking in release builds.
+        let components = ScoreComponents {
+            hidden_neuron_count: 0,
+            synapse_count: 0,
+            max_weight_bias: 0.5,
+            avg_weight_bias: 0.3,
+            squash_complexity_penalty: 0.0,
+        };
+        let nan = calculate_score(f64::NAN, &components, 0.0, Some("4.0.0")).unwrap_err();
+        assert!(nan.contains("NaN"), "unexpected message: {nan}");
+        let inf = calculate_score(f64::INFINITY, &components, 0.0, Some("4.0.0")).unwrap_err();
+        assert!(inf.contains("not finite"), "unexpected message: {inf}");
+    }
+
+    #[test]
+    fn test_calculate_score_rejects_negative_error() {
+        // Issue #201: a negative average error returns a structured error.
+        let components = ScoreComponents {
+            hidden_neuron_count: 0,
+            synapse_count: 0,
+            max_weight_bias: 0.5,
+            avg_weight_bias: 0.3,
+            squash_complexity_penalty: 0.0,
+        };
+        let err = calculate_score(-0.1, &components, 0.0, Some("4.0.0")).unwrap_err();
+        assert!(err.contains("negative"), "unexpected message: {err}");
     }
 }


### PR DESCRIPTION
# Robustness: convert input-reachable `assert!`/serialise `expect` panics to structured errors

## Summary

Several `assert!` guards in `rust_scorer/src/scoring.rs` (not `debug_assert!`,
so they fire in release builds) protected values reachable from arbitrary
user-supplied creature JSON / stdin. A non-finite/NaN weight or bias, a
negative or non-finite average error, or a serialisation failure aborted the
process via panic instead of returning the binary's standard
`Err(String)` → `eprintln!("Error: ...")` → `exit(1)` result.

This change converts the input-derived checks to early `Result::Err` returns
with clear messages, and routes serialisation failures through the same error
path. Pure internal-math invariants stay as `debug_assert!`.

**Closes #201.**

### What changed

- `scoring::value_penalty`, `compute_score_components`, `complexity_penalty`
  and `calculate_score` now return `Result<_, String>`:
  - `value_penalty` → `Err` for negative or non-finite `value`.
  - `compute_score_components` → `Err` for a non-finite synapse weight or
    neuron bias (naming the offending UUID/edge).
  - `calculate_score` → `Err` for a non-finite or negative average error.
- `main()` routes `serde_json::to_string_pretty` failures (single- and
  multi-creature) through `eprintln!("Error: ...")` + `process::exit(1)`
  instead of `.expect(...)`.
- Pure internal-math invariants (`primary/compressed penalty < 1`,
  `penalty` finite/`>= 0`/`< 1`, `score <= 1.0`) downgraded to
  `debug_assert!` — they cannot be violated once the input checks pass.
- `ScoreComponents` derives `Debug` (needed so tests can `unwrap_err`).
- Call sites in `main.rs` and `multi_score.rs` (both CPU and GPU directory
  paths) propagate the new `Result` via `?` — all are already inside
  `Result<_, String>`-returning functions.

### Error-flow

```mermaid
flowchart LR
    A[Creature JSON / stdin] --> B[compute_score_components]
    B -- non-finite weight/bias --> E[Err String]
    A --> C[score over data]
    C --> D[calculate_score]
    D -- non-finite / negative error --> E
    D -- ok --> F[ScoreResult]
    F --> G[serde_json::to_string_pretty]
    G -- serialise error --> E
    G -- ok --> H[println! JSON]
    E --> I["eprintln!(Error: ...) + exit(1)"]
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the Rust
test suite. New and updated unit tests deterministically exercise each
converted error path by calling the real functions with malformed numeric
input and asserting a structured `Err`:

```text
running 22 tests (scoring) ... ok
test result: ok. 91 passed; 0 failed (rust_scorer lib + bin)
```

### Pre-existing, unrelated failure

`tests/directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
fails on this machine because it has a real Metal GPU (the test asserts a
`cpu-fallback` backend). Confirmed it fails identically on the base branch
with my changes stashed, so it is environmental and unrelated to this work.

## Test Plan

Added to `rust_scorer/src/scoring.rs`:

- `test_value_penalty_rejects_non_finite` — NaN/inf → `Err("not finite")`.
- `test_compute_score_components_rejects_non_finite_weight` — NaN/inf weight →
  structured `Err`.
- `test_compute_score_components_rejects_non_finite_bias` — NaN/-inf bias →
  structured `Err`.
- `test_calculate_score_rejects_non_finite_error` — NaN/inf average error →
  structured `Err`.
- `test_calculate_score_rejects_negative_error` — negative average error →
  structured `Err`.

Modified (documented business-logic change — panic → `Result`):

- `test_value_penalty_rejects_negative` — was `#[should_panic(expected = "negative")]`;
  now asserts `value_penalty(-1.0)` returns `Err` containing `"negative"`.
- All other `value_penalty` / `calculate_penalty` / `calculate_score` /
  `complexity_penalty` / `compute_score_components` call sites in the existing
  tests updated to `unwrap()` the new `Result` (no assertions removed).

Note: a true non-finite weight cannot reach `compute_score_components` through
the CLI because `parse_creature_json` rejects out-of-range JSON numbers and the
scoring data pipeline is `f32` (saturating at `f32::MAX`, whose square fits in
`f64`). The conversions remain the correct defensive fix for these `pub`
functions and any in-memory `CreatureExport` callers, and the error branches
are covered directly at the function level.
