### PR TITLE
Warn on malformed NEAT_SCORER_* env-var values (Issue #204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -731,9 +731,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "naga"
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.39"
+version = "0.1.42"
 dependencies = [
  "serde",
  "serde_json",
@@ -1108,7 +1108,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "bytemuck",
  "clap",
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spirv"
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]

--- a/README.md
+++ b/README.md
@@ -270,6 +270,22 @@ For forward-only single-creature fused scoring, activation parallelism also
 defaults to all available CPU cores. Set `NEAT_SCORER_ACTIVATION_THREADS` only
 when you want to tune down/up manually.
 
+### Malformed tuning values are reported, not silently ignored (Issue #204)
+
+The numeric performance knobs `NEAT_SCORER_READ_BYTES`,
+`NEAT_SCORER_ACTIVATION_THREADS` and `NEAT_SCORER_GPU_SCRATCH_BYTES` used to
+fall back to their default on an invalid value with no feedback, so a typo
+such as `NEAT_SCORER_READ_BYTES=2MB` looked like it took effect when it was
+ignored. Each now prints a single diagnostic to stderr and continues with the
+default, mirroring how `NEAT_SCORER_GPU` already rejects invalid values:
+
+```text
+[scorer] ignoring invalid NEAT_SCORER_READ_BYTES='2MB', using default 2097152
+```
+
+Unset or blank values stay silent, and a valid value is honoured without any
+warning.
+
 ## Local layout
 
 Place **NEAT-AI-core** and **NEAT-AI-scorer** as **siblings** (e.g. `…/src/NEAT-AI-core` and `…/src/NEAT-AI-scorer`). The path in `rust_scorer/Cargo.toml` is `../../NEAT-AI-core/neat-core` so `cargo build` resolves `neat-core` from your local **NEAT-AI-core** tree. CI does the same via a second checkout (`../NEAT-AI-core`).

--- a/docs/archive/pr-summaries/pr-summary-204.md
+++ b/docs/archive/pr-summaries/pr-summary-204.md
@@ -1,0 +1,79 @@
+# Warn on malformed `NEAT_SCORER_*` env-var values (Issue #204)
+
+## Summary
+
+Three numeric performance-tuning env vars used to fall back to their default on
+a malformed value with **zero** feedback, so a typo like
+`NEAT_SCORER_READ_BYTES=2MB` was silently treated as "unset". This was
+inconsistent with `NEAT_SCORER_GPU`, which already errors on an invalid value.
+
+Each knob now emits **one** diagnostic line to stderr on the parse-failure
+branch and continues with the default:
+
+```text
+[scorer] ignoring invalid NEAT_SCORER_READ_BYTES='2MB', using default 2097152
+```
+
+Affected vars:
+
+- `NEAT_SCORER_READ_BYTES` — `rust_scorer/src/read_tuning.rs`
+- `NEAT_SCORER_ACTIVATION_THREADS` — `rust_scorer/src/stream_score.rs`
+- `NEAT_SCORER_GPU_SCRATCH_BYTES` — `rust_scorer/src/gpu/forward_mse_batched.rs`
+
+The shared logic lives in a new `rust_scorer/src/env_tuning.rs` module
+(`parse_tuning_var`), keeping it pure and unit-testable: it returns the
+resolved value plus an `Option<String>` warning, and the caller does the
+`eprintln!`. *Unset* and *blank* values stay silent; a *valid* value is
+honoured silently; only a *set-but-malformed* value warns.
+
+Closes #204.
+
+### Behaviour notes
+
+- `NEAT_SCORER_GPU_SCRATCH_BYTES=0` was already rejected (it has a `> 0`
+  predicate); it now warns rather than falling back silently, matching the
+  "invalid value" contract.
+- **Minor behaviour change:** a *malformed* `NEAT_SCORER_ACTIVATION_THREADS`
+  previously fell back to `1`; it now falls back to the same default as the
+  *unset* case (all available CPU cores), which is the documented default and
+  is what `parse_tuning_var` reports in its warning. Valid values are still
+  clamped to `[1, 64]` as before.
+
+```mermaid
+flowchart TD
+    A["NEAT_SCORER_* read"] --> B{set?}
+    B -->|no / blank| D[use default, silent]
+    B -->|yes| C{parses?}
+    C -->|yes| E[honour value, silent]
+    C -->|no| F["eprintln one diagnostic<br/>+ use default"]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests
+(`cargo test -p rust_scorer env_tuning`): all 7 cases pass in every
+compilation context (lib, main, both bench bins).
+
+Pre-existing unrelated failure: `directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
+fails on this Apple-Silicon/Metal machine on the **clean tree too** (it expects
+`cpu-fallback` but post-#182 large creatures run on the GPU `forward_mse_scratch`
+kernel, reported as `metal`). It is independent of this change and unaffected by it.
+
+## Test Plan
+
+New `rust_scorer/src/env_tuning.rs` unit tests for `parse_tuning_var`:
+
+- `unset_value_uses_default_silently` — `None` → default, no warning.
+- `blank_value_uses_default_silently` — `""`, whitespace → default, no warning.
+- `valid_value_is_honoured_silently` — parses, no warning.
+- `surrounding_whitespace_is_trimmed_before_parsing` — `"  4096  "` honoured.
+- `malformed_value_warns_and_falls_back` — `"2MB"` → default + warning that
+  echoes the var name, raw value, and default.
+- `warning_preserves_untrimmed_raw_for_context` — warning shows the raw value
+  verbatim.
+- `custom_predicate_rejection_warns` — `NEAT_SCORER_GPU_SCRATCH_BYTES=0` warns.
+
+The three public env-reading functions are thin wrappers (read env → call
+`parse_tuning_var` → `eprintln!` the warning), so the pure-helper tests cover
+the warning behaviour without racing on process-global env vars under parallel
+test execution.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.56"
+version = "0.5.57"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/bin/cost_scan_bench.rs
+++ b/rust_scorer/src/bin/cost_scan_bench.rs
@@ -27,6 +27,9 @@
 //! existing `float_scan_bench` defaults to 7 runs, this bin defaults to 5 so
 //! a 6-cost sweep stays within ~1 minute on a small corpus.
 
+#[path = "../env_tuning.rs"]
+#[allow(dead_code)] // helper module shared with read_tuning; only the parser is used here.
+mod env_tuning;
 #[path = "../read_tuning.rs"]
 #[allow(dead_code)] // selectively used by the bench; the rest mirrors float_scan_bench.
 mod read_tuning;

--- a/rust_scorer/src/bin/float_scan_bench.rs
+++ b/rust_scorer/src/bin/float_scan_bench.rs
@@ -4,6 +4,8 @@
 //!
 //! Build: `cargo build --release -p rust_scorer --bin float_scan_bench`
 
+#[path = "../env_tuning.rs"]
+mod env_tuning;
 #[path = "../read_tuning.rs"]
 mod read_tuning;
 

--- a/rust_scorer/src/env_tuning.rs
+++ b/rust_scorer/src/env_tuning.rs
@@ -1,0 +1,134 @@
+//! Shared parsing for the numeric `NEAT_SCORER_*` performance-tuning env vars.
+//!
+//! These knobs previously fell back to their default on a malformed value with
+//! **zero** feedback, so a typo like `NEAT_SCORER_READ_BYTES=2MB` was silently
+//! ignored. [`parse_tuning_var`] distinguishes *unset/blank* (silent default)
+//! from *set-but-malformed* (one stderr diagnostic + default), matching the
+//! behaviour of `NEAT_SCORER_GPU` which already rejects invalid values
+//! (Issue #204).
+
+/// Parse a raw env-var value into `T`, reporting malformed input.
+///
+/// Returns the resolved value plus an optional warning message. The warning is
+/// `Some` **only** when `raw` is present and non-blank yet fails to parse — a
+/// value the user clearly intended to set but got wrong. An unset (`None`) or
+/// blank value falls back to `default` silently, preserving the "knob is
+/// optional" contract.
+///
+/// The caller is responsible for emitting the warning (so this stays pure and
+/// unit-testable without touching process state or capturing stderr).
+pub fn parse_tuning_var<T, F>(
+    name: &str,
+    raw: Option<&str>,
+    default: T,
+    parse: F,
+) -> (T, Option<String>)
+where
+    T: std::fmt::Display,
+    F: FnOnce(&str) -> Option<T>,
+{
+    let Some(raw) = raw else {
+        return (default, None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return (default, None);
+    }
+    match parse(trimmed) {
+        Some(value) => (value, None),
+        None => {
+            let warning =
+                format!("[scorer] ignoring invalid {name}='{raw}', using default {default}");
+            (default, Some(warning))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_usize(s: &str) -> Option<usize> {
+        s.parse::<usize>().ok()
+    }
+
+    #[test]
+    fn unset_value_uses_default_silently() {
+        let (value, warning) =
+            parse_tuning_var("NEAT_SCORER_READ_BYTES", None, 42usize, parse_usize);
+        assert_eq!(value, 42);
+        assert!(warning.is_none(), "unset must not warn");
+    }
+
+    #[test]
+    fn blank_value_uses_default_silently() {
+        for raw in ["", "   ", "\t\n"] {
+            let (value, warning) =
+                parse_tuning_var("NEAT_SCORER_READ_BYTES", Some(raw), 42usize, parse_usize);
+            assert_eq!(value, 42);
+            assert!(warning.is_none(), "blank {raw:?} must not warn");
+        }
+    }
+
+    #[test]
+    fn valid_value_is_honoured_silently() {
+        let (value, warning) =
+            parse_tuning_var("NEAT_SCORER_READ_BYTES", Some("4096"), 42usize, parse_usize);
+        assert_eq!(value, 4096);
+        assert!(warning.is_none(), "valid value must not warn");
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed_before_parsing() {
+        let (value, warning) = parse_tuning_var(
+            "NEAT_SCORER_READ_BYTES",
+            Some("  4096  "),
+            42usize,
+            parse_usize,
+        );
+        assert_eq!(value, 4096);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn malformed_value_warns_and_falls_back() {
+        let (value, warning) =
+            parse_tuning_var("NEAT_SCORER_READ_BYTES", Some("2MB"), 42usize, parse_usize);
+        assert_eq!(value, 42, "must fall back to the default");
+        let warning = warning.expect("malformed value must warn");
+        assert!(warning.contains("NEAT_SCORER_READ_BYTES"));
+        assert!(warning.contains("2MB"), "warning echoes the raw value");
+        assert!(warning.contains("42"), "warning echoes the default");
+        assert!(warning.starts_with("[scorer] ignoring invalid"));
+    }
+
+    #[test]
+    fn warning_preserves_untrimmed_raw_for_context() {
+        // The echoed raw keeps surrounding whitespace so the user sees exactly
+        // what they set.
+        let (_value, warning) = parse_tuning_var(
+            "NEAT_SCORER_READ_BYTES",
+            Some(" oops "),
+            7usize,
+            parse_usize,
+        );
+        let warning = warning.expect("malformed value must warn");
+        assert!(warning.contains("' oops '"));
+    }
+
+    #[test]
+    fn custom_predicate_rejection_warns() {
+        // A value that parses but is semantically invalid (e.g. zero budget)
+        // must also warn, not fall back silently.
+        let parse_positive = |s: &str| s.parse::<u64>().ok().filter(|&b| b > 0);
+        let (value, warning) = parse_tuning_var(
+            "NEAT_SCORER_GPU_SCRATCH_BYTES",
+            Some("0"),
+            99u64,
+            parse_positive,
+        );
+        assert_eq!(value, 99);
+        let warning = warning.expect("zero must warn");
+        assert!(warning.contains("='0'"));
+    }
+}

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -814,11 +814,19 @@ pub fn scratch_workgroups_x_for(
 /// Resolve the scratch-kernel memory budget from `NEAT_SCORER_GPU_SCRATCH_BYTES`,
 /// falling back to [`DEFAULT_SCRATCH_BUDGET_BYTES`] (Issue #182).
 fn scratch_budget_bytes_from_env() -> u64 {
-    std::env::var("NEAT_SCORER_GPU_SCRATCH_BYTES")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .filter(|&b| b > 0)
-        .unwrap_or(DEFAULT_SCRATCH_BUDGET_BYTES)
+    let env = std::env::var("NEAT_SCORER_GPU_SCRATCH_BYTES").ok();
+    let (parsed, warning) = crate::env_tuning::parse_tuning_var(
+        "NEAT_SCORER_GPU_SCRATCH_BYTES",
+        env.as_deref(),
+        DEFAULT_SCRATCH_BUDGET_BYTES,
+        // A zero budget is semantically invalid, so treat it like a parse
+        // failure (warn + default) rather than a silent fallback.
+        |s| s.parse::<u64>().ok().filter(|&b| b > 0),
+    );
+    if let Some(warning) = warning {
+        eprintln!("{warning}");
+    }
+    parsed
 }
 
 /// Pad a `Vec<T>` so its byte length is non-zero — wgpu rejects zero-sized

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -9,6 +9,7 @@
 //! Issue #36 — Criterion benchmark infrastructure.
 
 pub mod cost;
+pub mod env_tuning;
 pub mod gpu;
 pub mod multi_score;
 pub mod read_tuning;

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -11,6 +11,7 @@
 //! Issue #1967 - Build Rust CLI scorer application.
 
 mod cost;
+mod env_tuning;
 mod gpu;
 mod multi_score;
 mod read_tuning;

--- a/rust_scorer/src/read_tuning.rs
+++ b/rust_scorer/src/read_tuning.rs
@@ -13,11 +13,17 @@ pub const MAX_READ_BYTES: usize = 64 * 1024 * 1024;
 /// Target bytes per `read` (rounded down to a multiple of `record_bytes`).
 pub fn training_read_target_bytes_from_env(record_bytes: usize) -> usize {
     let rb = record_bytes.max(1);
-    let raw = std::env::var("NEAT_SCORER_READ_BYTES")
-        .ok()
-        .and_then(|s| s.trim().parse::<usize>().ok())
-        .unwrap_or(DEFAULT_READ_BYTES)
-        .clamp(rb, MAX_READ_BYTES);
+    let env = std::env::var("NEAT_SCORER_READ_BYTES").ok();
+    let (parsed, warning) = crate::env_tuning::parse_tuning_var(
+        "NEAT_SCORER_READ_BYTES",
+        env.as_deref(),
+        DEFAULT_READ_BYTES,
+        |s| s.parse::<usize>().ok(),
+    );
+    if let Some(warning) = warning {
+        eprintln!("{warning}");
+    }
+    let raw = parsed.clamp(rb, MAX_READ_BYTES);
     (raw / rb) * rb
 }
 

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -29,16 +29,22 @@ const MAX_ACTIVATION_WORKERS: usize = 64;
 /// Parsed `NEAT_SCORER_ACTIVATION_THREADS`: missing defaults to all available CPUs.
 /// Clamped to `[1, MAX_ACTIVATION_WORKERS]`.
 pub fn activation_worker_count_for_scorer() -> usize {
-    match std::env::var("NEAT_SCORER_ACTIVATION_THREADS") {
-        Ok(s) => {
-            let t = s.trim().parse::<usize>().unwrap_or(1);
-            t.clamp(1, MAX_ACTIVATION_WORKERS)
-        }
-        Err(_) => std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .clamp(1, MAX_ACTIVATION_WORKERS),
+    // Unset/blank/malformed all resolve to "all available CPUs"; a malformed
+    // value additionally warns instead of falling back silently (Issue #204).
+    let default = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let env = std::env::var("NEAT_SCORER_ACTIVATION_THREADS").ok();
+    let (parsed, warning) = crate::env_tuning::parse_tuning_var(
+        "NEAT_SCORER_ACTIVATION_THREADS",
+        env.as_deref(),
+        default,
+        |s| s.parse::<usize>().ok(),
+    );
+    if let Some(warning) = warning {
+        eprintln!("{warning}");
     }
+    parsed.clamp(1, MAX_ACTIVATION_WORKERS)
 }
 
 /// Aligned fused read size (same rounding as [`training_read_target_bytes_from_env`]).


### PR DESCRIPTION
# Warn on malformed `NEAT_SCORER_*` env-var values (Issue #204)

## Summary

Three numeric performance-tuning env vars used to fall back to their default on
a malformed value with **zero** feedback, so a typo like
`NEAT_SCORER_READ_BYTES=2MB` was silently treated as "unset". This was
inconsistent with `NEAT_SCORER_GPU`, which already errors on an invalid value.

Each knob now emits **one** diagnostic line to stderr on the parse-failure
branch and continues with the default:

```text
[scorer] ignoring invalid NEAT_SCORER_READ_BYTES='2MB', using default 2097152
```

Affected vars:

- `NEAT_SCORER_READ_BYTES` — `rust_scorer/src/read_tuning.rs`
- `NEAT_SCORER_ACTIVATION_THREADS` — `rust_scorer/src/stream_score.rs`
- `NEAT_SCORER_GPU_SCRATCH_BYTES` — `rust_scorer/src/gpu/forward_mse_batched.rs`

The shared logic lives in a new `rust_scorer/src/env_tuning.rs` module
(`parse_tuning_var`), keeping it pure and unit-testable: it returns the
resolved value plus an `Option<String>` warning, and the caller does the
`eprintln!`. *Unset* and *blank* values stay silent; a *valid* value is
honoured silently; only a *set-but-malformed* value warns.

Closes #204.

### Behaviour notes

- `NEAT_SCORER_GPU_SCRATCH_BYTES=0` was already rejected (it has a `> 0`
  predicate); it now warns rather than falling back silently, matching the
  "invalid value" contract.
- **Minor behaviour change:** a *malformed* `NEAT_SCORER_ACTIVATION_THREADS`
  previously fell back to `1`; it now falls back to the same default as the
  *unset* case (all available CPU cores), which is the documented default and
  is what `parse_tuning_var` reports in its warning. Valid values are still
  clamped to `[1, 64]` as before.

```mermaid
flowchart TD
    A["NEAT_SCORER_* read"] --> B{set?}
    B -->|no / blank| D[use default, silent]
    B -->|yes| C{parses?}
    C -->|yes| E[honour value, silent]
    C -->|no| F["eprintln one diagnostic<br/>+ use default"]
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via unit tests
(`cargo test -p rust_scorer env_tuning`): all 7 cases pass in every
compilation context (lib, main, both bench bins).

Pre-existing unrelated failure: `directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
fails on this Apple-Silicon/Metal machine on the **clean tree too** (it expects
`cpu-fallback` but post-#182 large creatures run on the GPU `forward_mse_scratch`
kernel, reported as `metal`). It is independent of this change and unaffected by it.

## Test Plan

New `rust_scorer/src/env_tuning.rs` unit tests for `parse_tuning_var`:

- `unset_value_uses_default_silently` — `None` → default, no warning.
- `blank_value_uses_default_silently` — `""`, whitespace → default, no warning.
- `valid_value_is_honoured_silently` — parses, no warning.
- `surrounding_whitespace_is_trimmed_before_parsing` — `"  4096  "` honoured.
- `malformed_value_warns_and_falls_back` — `"2MB"` → default + warning that
  echoes the var name, raw value, and default.
- `warning_preserves_untrimmed_raw_for_context` — warning shows the raw value
  verbatim.
- `custom_predicate_rejection_warns` — `NEAT_SCORER_GPU_SCRATCH_BYTES=0` warns.

The three public env-reading functions are thin wrappers (read env → call
`parse_tuning_var` → `eprintln!` the warning), so the pure-helper tests cover
the warning behaviour without racing on process-global env vars under parallel
test execution.



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqcbuqiq-d67912`<!-- vibe-worker-issue-204 -->