### PR TITLE
Surface stderr note when non-MSE --cost forces CPU fallback in directory mode (Issue #205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ section to the released version with its date.
 
 ### Added
 
+- **stderr note when a non-MSE `--cost` forces CPU fallback in directory
+  mode (Issue #205).** Under the default `--gpu auto`, selecting a non-MSE
+  `--cost` makes `auto_should_use_gpu` return false, so the directory path
+  runs on CPU. The fallback was otherwise silent — only the
+  `gpuBackend: "cpu-fallback"` JSON field hinted at it. The scorer now prints
+  one informational `[gpu] auto fallback to CPU directory mode: cost <NAME>
+  is not GPU-supported ...` line to stderr, mirroring the existing
+  `--gpu on` / GPU-runner fallback messages and naming the cost as the reason.
+  MSE / GPU-supported costs and explicit `--gpu on|off` are unaffected
+  (no extra output). New `gpu::auto_cost_fallback_note` helper, unit-tested
+  in `gpu/mod.rs` and end-to-end in `tests/directory_mode_tdd.rs`.
 - **CI lint gate for GitHub Actions (Issue #195).** New
   `.github/workflows/actionlint.yml` runs [actionlint](https://github.com/rhysd/actionlint)
   on every pull request and on pushes to the default branches, so workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.56"
+version = "0.5.57"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -212,9 +212,12 @@ The `forward_mse_batched` GPU kernel currently computes **MSE only**.
 Any non-MSE `--cost` selection forces the CPU pipeline:
 
 - Under `--gpu auto` (the default since Issue #83) a non-MSE cost
-  silently routes to the CPU directory/streaming path — the
-  `gpuBackend` field on the result reports `"cpu-fallback"` so the
-  caller can see what actually ran.
+  routes to the CPU directory/streaming path — the `gpuBackend` field
+  on the result reports `"cpu-fallback"` so the caller can see what
+  actually ran. On the **directory path** the scorer also prints one
+  informational `[gpu] auto fallback ...` line to stderr naming the
+  cost as the reason (Issue #205), so the CPU choice is not silent;
+  MSE / GPU-supported costs print nothing extra.
 - Under `--gpu on` a non-MSE cost is a hard error before any scoring
   runs (no silent downgrade — `--gpu on` is a strict requirement).
 - Under `--gpu off` GPU detection is skipped regardless of `--cost`.

--- a/docs/archive/pr-summaries/pr-summary-205.md
+++ b/docs/archive/pr-summaries/pr-summary-205.md
@@ -1,0 +1,87 @@
+# Surface a stderr note when a non-MSE `--cost` forces CPU fallback in directory mode
+
+## Summary
+
+Under the default `--gpu auto`, selecting a non-MSE `--cost` makes
+`auto_should_use_gpu` (`rust_scorer/src/gpu/mod.rs`) return false, so the
+directory path runs on CPU. Unlike the explicit `--gpu on` hard-error and the
+GPU-runner failure case, that fallback printed nothing — the only signal was
+the `gpuBackend: "cpu-fallback"` JSON field, so users could not tell their
+**cost choice** (not a missing GPU) caused the CPU path.
+
+This PR adds one informational stderr line on the directory path, mirroring the
+existing `[gpu] auto fallback ...` messages and naming the cost as the reason:
+
+```text
+[gpu] auto fallback to CPU directory mode: cost MAE is not GPU-supported (forward_mse_batched only handles MSE); rerun with --gpu off to skip GPU detection
+```
+
+MSE / GPU-supported costs and explicit `--gpu on|off` are unaffected (no extra
+output). Closes #205.
+
+### Changes
+
+- **`rust_scorer/src/gpu/mod.rs`** — new pure helper
+  `auto_cost_fallback_note(mode, path, cost) -> Option<String>` that returns the
+  note only when `mode` is `Auto`, `path` is `CreatureDirectory`, and the cost
+  is not GPU-supported; `None` otherwise.
+- **`rust_scorer/src/main.rs`** — directory branch emits the note via
+  `eprintln!` before dispatch. It is a no-op for MSE and for explicit
+  `--gpu on|off`.
+- **`README.md`** — documents the new stderr note under the GPU constraint
+  section.
+- **`CHANGELOG.md`** — `### Added` entry.
+
+```mermaid
+flowchart LR
+    Dir[directory mode + --gpu auto] --> Q{cost GPU-supported?}
+    Q -->|yes MSE| GPU[try GPU pipeline]
+    Q -->|no non-MSE| Note["stderr: [gpu] auto fallback ... cost NAME not GPU-supported"]
+    Note --> CPU[CPU pipeline · gpuBackend: cpu-fallback]
+```
+
+## Evidence
+
+CLI-only change — no web interface to screenshot. Verified by automated tests
+(real function calls and a spawned-binary stderr assertion).
+
+- Library unit tests (`cargo test -p rust_scorer --lib gpu::`): **27 passed**,
+  including the four new `auto_cost_fallback_note_*` cases.
+- Integration test (`cargo test -p rust_scorer --test directory_mode_tdd`):
+  new `directory_mode_auto_non_mse_cost_notes_cpu_fallback` **passed**.
+
+Example output for a non-MSE cost under the default `--gpu auto`:
+
+```text
+$ rust_scorer --cost MAE creatures/ data/
+[gpu] auto fallback to CPU directory mode: cost MAE is not GPU-supported (forward_mse_batched only handles MSE); rerun with --gpu off to skip GPU detection
+{ ... "gpuBackend": "cpu-fallback" ... }
+```
+
+### Pre-existing unrelated test note
+
+`gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly` fails on the
+local Apple-Silicon dev host (a real Metal adapter hosts the 302-neuron creature
+on GPU rather than the expected CPU fallback). This failure reproduces on a
+clean checkout **without** these changes — it is environmental (GPU-equipped
+host) and outside the scope of #205. CI runs on GPU-less hosts where it passes.
+
+## Test Plan
+
+Added:
+
+- `rust_scorer/src/gpu/mod.rs`
+  - `auto_cost_fallback_note_present_for_non_mse_directory` — note appears and
+    names the cost for every non-MSE cost.
+  - `auto_cost_fallback_note_absent_for_mse_directory` — MSE emits no note.
+  - `auto_cost_fallback_note_absent_for_explicit_modes` — `--gpu on|off` emit
+    no note.
+  - `auto_cost_fallback_note_absent_for_single_creature` — single-creature path
+    emits no note.
+- `rust_scorer/tests/directory_mode_tdd.rs`
+  - `directory_mode_auto_non_mse_cost_notes_cpu_fallback` — spawns the binary
+    with `--cost MAE` (note present on stderr) and `--cost MSE` (note absent).
+
+Quality: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc`
+(`RUSTDOCFLAGS=-D warnings`), codespell and markdownlint on the edited docs all
+pass.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.57"
+version = "0.5.58"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/mod.rs
+++ b/rust_scorer/src/gpu/mod.rs
@@ -218,6 +218,44 @@ pub fn auto_should_use_gpu(path: ScoringPath, cost: crate::cost::CostKind) -> bo
     }
 }
 
+/// Issue #205: one informational stderr note for the otherwise-silent
+/// "non-MSE cost forced the CPU path under `--gpu auto`" fallback.
+///
+/// Under the default `--gpu auto`, selecting a non-MSE `--cost` makes
+/// [`auto_should_use_gpu`] return `false`, so the directory path runs on
+/// CPU. Unlike the explicit `--gpu on` hard-error and the GPU-runner
+/// failure case, that fallback prints nothing — the only signal is the
+/// `gpuBackend: cpu-fallback` JSON field, so users cannot tell their cost
+/// choice (rather than a missing GPU) caused the CPU path.
+///
+/// Returns `Some(note)` — mirroring the existing `[gpu] auto fallback ...`
+/// messages and naming the cost as the reason — only when **all** hold:
+/// * `mode` is [`GpuMode::Auto`] (explicit `on`/`off` are unaffected),
+/// * `path` is [`ScoringPath::CreatureDirectory`] (the only GPU-default
+///   path), and
+/// * `cost` is not GPU-supported ([`crate::cost::CostKind::gpu_supported`]).
+///
+/// Returns `None` otherwise (MSE / GPU-supported costs emit no extra output).
+pub fn auto_cost_fallback_note(
+    mode: GpuMode,
+    path: ScoringPath,
+    cost: crate::cost::CostKind,
+) -> Option<String> {
+    if !matches!(mode, GpuMode::Auto) || cost.gpu_supported() {
+        return None;
+    }
+    match path {
+        ScoringPath::CreatureDirectory => Some(format!(
+            "[gpu] auto fallback to CPU directory mode: cost {} is not GPU-supported \
+             (forward_mse_batched only handles MSE); rerun with --gpu off to skip GPU detection",
+            cost.as_str()
+        )),
+        // The single-creature path is always CPU regardless of cost, so there
+        // is no cost-driven fallback to explain.
+        ScoringPath::SingleCreature => None,
+    }
+}
+
 /// Resolve the final [`GpuMode`] from the CLI flag and the `NEAT_SCORER_GPU`
 /// environment variable. CLI wins; otherwise the env var; otherwise default.
 ///
@@ -398,6 +436,77 @@ mod tests {
                 cost.as_str()
             );
         }
+    }
+
+    /// Issue #205: a non-MSE cost under `--gpu auto` must surface one stderr
+    /// note on the directory path, naming the cost as the reason for the CPU
+    /// fallback.
+    #[test]
+    fn auto_cost_fallback_note_present_for_non_mse_directory() {
+        for cost in [
+            crate::cost::CostKind::Mae,
+            crate::cost::CostKind::Mape,
+            crate::cost::CostKind::Msle,
+            crate::cost::CostKind::Hinge,
+            crate::cost::CostKind::CrossEntropy,
+            crate::cost::CostKind::CategoricalError,
+        ] {
+            let note = auto_cost_fallback_note(GpuMode::Auto, ScoringPath::CreatureDirectory, cost)
+                .unwrap_or_else(|| panic!("expected a fallback note for cost {}", cost.as_str()));
+            assert!(
+                note.contains("[gpu] auto fallback"),
+                "note should mirror the existing fallback messages: {note}"
+            );
+            assert!(
+                note.contains(cost.as_str()),
+                "note should name the cost {} as the reason: {note}",
+                cost.as_str()
+            );
+        }
+    }
+
+    /// Issue #205: MSE (the GPU-supported cost) must not emit any note.
+    #[test]
+    fn auto_cost_fallback_note_absent_for_mse_directory() {
+        assert_eq!(
+            auto_cost_fallback_note(
+                GpuMode::Auto,
+                ScoringPath::CreatureDirectory,
+                crate::cost::CostKind::Mse
+            ),
+            None
+        );
+    }
+
+    /// Issue #205: explicit `--gpu on|off` are unaffected — no note even for a
+    /// non-MSE cost (`on` hard-errors elsewhere; `off` never touches the GPU).
+    #[test]
+    fn auto_cost_fallback_note_absent_for_explicit_modes() {
+        for mode in [GpuMode::On, GpuMode::Off] {
+            assert_eq!(
+                auto_cost_fallback_note(
+                    mode,
+                    ScoringPath::CreatureDirectory,
+                    crate::cost::CostKind::Mae
+                ),
+                None,
+                "explicit mode {mode:?} must not emit the auto fallback note"
+            );
+        }
+    }
+
+    /// Issue #205: the single-creature path is always CPU regardless of cost,
+    /// so there is no cost-driven fallback to explain.
+    #[test]
+    fn auto_cost_fallback_note_absent_for_single_creature() {
+        assert_eq!(
+            auto_cost_fallback_note(
+                GpuMode::Auto,
+                ScoringPath::SingleCreature,
+                crate::cost::CostKind::Mae
+            ),
+            None
+        );
     }
 
     #[test]

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -242,6 +242,18 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
     let creature_path = &cli.args[0];
     let data_path = &cli.args[1];
     if creature_path.is_dir() {
+        // Issue #205: under `--gpu auto`, a non-MSE cost makes
+        // `auto_should_use_gpu` return false, so the directory path runs on
+        // CPU. That fallback was otherwise silent (only the
+        // `gpuBackend: cpu-fallback` JSON field hinted at it). Emit one
+        // informational stderr note naming the cost as the reason, mirroring
+        // the other `[gpu] auto fallback ...` messages. No-op for MSE and for
+        // explicit `--gpu on|off`.
+        if let Some(note) =
+            gpu::auto_cost_fallback_note(mode, ScoringPath::CreatureDirectory, cli.cost)
+        {
+            eprintln!("{note}");
+        }
         // Directory mode: per Issue #82+#83 use the GPU multi-creature
         // batched kernel when (a) an adapter is available and (b) the mode
         // wants GPU for this path (`Auto` ⇒ yes, `On` ⇒ yes, `Off` ⇒ no).

--- a/rust_scorer/tests/directory_mode_tdd.rs
+++ b/rust_scorer/tests/directory_mode_tdd.rs
@@ -314,6 +314,63 @@ fn directory_mode_emits_compile_time_secs() {
     }
 }
 
+/// Issue #205: under the default `--gpu auto`, a non-MSE `--cost` forces the
+/// directory path onto CPU (`auto_should_use_gpu` returns false). That
+/// fallback was otherwise silent — only the `gpuBackend: cpu-fallback` JSON
+/// field hinted at it. Assert the CPU run now prints one informational stderr
+/// note naming the cost as the reason, while MSE prints nothing extra.
+#[test]
+fn directory_mode_auto_non_mse_cost_notes_cpu_fallback() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let creatures_dir = tmp.path().join("creatures");
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir(&data_dir).expect("create data dir");
+
+    std::fs::write(creatures_dir.join("a.json"), minimal_creature(1, 1, true)).expect("write a");
+    write_training_data(&data_dir, &[(vec![0.5], vec![0.5]), (vec![1.0], vec![1.0])]);
+
+    // Non-MSE cost under the default `--gpu auto` ⇒ CPU fallback + stderr note.
+    let non_mse = Command::new(bin)
+        .arg("--cost")
+        .arg("MAE")
+        .arg(&creatures_dir)
+        .arg(&data_dir)
+        .output()
+        .expect("spawn scorer (MAE)");
+    assert!(
+        non_mse.status.success(),
+        "auto MAE directory run should succeed, stderr:\n{}",
+        String::from_utf8_lossy(&non_mse.stderr),
+    );
+    let non_mse_stderr = String::from_utf8_lossy(&non_mse.stderr);
+    assert!(
+        non_mse_stderr.contains("[gpu] auto fallback to CPU directory mode")
+            && non_mse_stderr.contains("MAE"),
+        "non-MSE cost must print a CPU-fallback note naming the cost, got: {non_mse_stderr}",
+    );
+
+    // MSE (the GPU-supported cost) must not print the cost-fallback note.
+    let mse = Command::new(bin)
+        .arg("--cost")
+        .arg("MSE")
+        .arg(&creatures_dir)
+        .arg(&data_dir)
+        .output()
+        .expect("spawn scorer (MSE)");
+    assert!(
+        mse.status.success(),
+        "auto MSE directory run should succeed, stderr:\n{}",
+        String::from_utf8_lossy(&mse.stderr),
+    );
+    let mse_stderr = String::from_utf8_lossy(&mse.stderr);
+    assert!(
+        !mse_stderr.contains("cost MSE is not GPU-supported"),
+        "MSE must not print the cost CPU-fallback note, got: {mse_stderr}",
+    );
+}
+
 #[test]
 fn directory_mode_rejects_forward_only_false() {
     let bin = env!("CARGO_BIN_EXE_rust_scorer");


### PR DESCRIPTION
# Surface a stderr note when a non-MSE `--cost` forces CPU fallback in directory mode

## Summary

Under the default `--gpu auto`, selecting a non-MSE `--cost` makes
`auto_should_use_gpu` (`rust_scorer/src/gpu/mod.rs`) return false, so the
directory path runs on CPU. Unlike the explicit `--gpu on` hard-error and the
GPU-runner failure case, that fallback printed nothing — the only signal was
the `gpuBackend: "cpu-fallback"` JSON field, so users could not tell their
**cost choice** (not a missing GPU) caused the CPU path.

This PR adds one informational stderr line on the directory path, mirroring the
existing `[gpu] auto fallback ...` messages and naming the cost as the reason:

```text
[gpu] auto fallback to CPU directory mode: cost MAE is not GPU-supported (forward_mse_batched only handles MSE); rerun with --gpu off to skip GPU detection
```

MSE / GPU-supported costs and explicit `--gpu on|off` are unaffected (no extra
output). Closes #205.

### Changes

- **`rust_scorer/src/gpu/mod.rs`** — new pure helper
  `auto_cost_fallback_note(mode, path, cost) -> Option<String>` that returns the
  note only when `mode` is `Auto`, `path` is `CreatureDirectory`, and the cost
  is not GPU-supported; `None` otherwise.
- **`rust_scorer/src/main.rs`** — directory branch emits the note via
  `eprintln!` before dispatch. It is a no-op for MSE and for explicit
  `--gpu on|off`.
- **`README.md`** — documents the new stderr note under the GPU constraint
  section.
- **`CHANGELOG.md`** — `### Added` entry.

```mermaid
flowchart LR
    Dir[directory mode + --gpu auto] --> Q{cost GPU-supported?}
    Q -->|yes MSE| GPU[try GPU pipeline]
    Q -->|no non-MSE| Note["stderr: [gpu] auto fallback ... cost NAME not GPU-supported"]
    Note --> CPU[CPU pipeline · gpuBackend: cpu-fallback]
```

## Evidence

CLI-only change — no web interface to screenshot. Verified by automated tests
(real function calls and a spawned-binary stderr assertion).

- Library unit tests (`cargo test -p rust_scorer --lib gpu::`): **27 passed**,
  including the four new `auto_cost_fallback_note_*` cases.
- Integration test (`cargo test -p rust_scorer --test directory_mode_tdd`):
  new `directory_mode_auto_non_mse_cost_notes_cpu_fallback` **passed**.

Example output for a non-MSE cost under the default `--gpu auto`:

```text
$ rust_scorer --cost MAE creatures/ data/
[gpu] auto fallback to CPU directory mode: cost MAE is not GPU-supported (forward_mse_batched only handles MSE); rerun with --gpu off to skip GPU detection
{ ... "gpuBackend": "cpu-fallback" ... }
```

### Pre-existing unrelated test note

`gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly` fails on the
local Apple-Silicon dev host (a real Metal adapter hosts the 302-neuron creature
on GPU rather than the expected CPU fallback). This failure reproduces on a
clean checkout **without** these changes — it is environmental (GPU-equipped
host) and outside the scope of #205. CI runs on GPU-less hosts where it passes.

## Test Plan

Added:

- `rust_scorer/src/gpu/mod.rs`
  - `auto_cost_fallback_note_present_for_non_mse_directory` — note appears and
    names the cost for every non-MSE cost.
  - `auto_cost_fallback_note_absent_for_mse_directory` — MSE emits no note.
  - `auto_cost_fallback_note_absent_for_explicit_modes` — `--gpu on|off` emit
    no note.
  - `auto_cost_fallback_note_absent_for_single_creature` — single-creature path
    emits no note.
- `rust_scorer/tests/directory_mode_tdd.rs`
  - `directory_mode_auto_non_mse_cost_notes_cpu_fallback` — spawns the binary
    with `--cost MAE` (note present on stderr) and `--cost MSE` (note absent).

Quality: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc`
(`RUSTDOCFLAGS=-D warnings`), codespell and markdownlint on the edited docs all
pass.



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqcbuqiq-d67912`<!-- vibe-worker-issue-205 -->