### PR TITLE
Add coverage for the recurrent (forwardOnly:false) single-creature scoring path (Issue #206)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-206.md
+++ b/docs/archive/pr-summaries/pr-summary-206.md
@@ -1,0 +1,73 @@
+# Add coverage for the recurrent (`forwardOnly:false`) single-creature scoring path
+
+## Summary
+
+The recurrent (non-forward-only) single-creature scoring path had effectively
+no automated coverage. The `else` branch of `score_from_json`
+(`rust_scorer/src/main.rs`) uses a per-record `TrainingDataIterator` plus
+`accumulate_cost_sum(..., forward_only=false)` and reports
+`training_read_backend = "record_iterator"`, but every `make_creature_json`
+test helper hard-coded `"forwardOnly":true`, so this branch — one of the two
+top-level single-creature scoring modes, with distinct packed-buffer assembly
+and per-record state-reset semantics — was never exercised.
+
+This PR adds unit coverage for that branch:
+
+- Parameterised the test helper via `make_creature_json_with_forward_only(...)`;
+  the existing `make_creature_json(...)` now delegates with `forward_only=true`,
+  so no existing test changes behaviour.
+- Added `test_recurrent_single_creature_uses_record_iterator_backend`, which
+  builds a `forwardOnly:false` creature, scores it, and asserts both the
+  numeric result (near-zero error, score ≈ 1.0, record count) **and**
+  `training_read_backend == "record_iterator"`, plus that the
+  fused-stream-only fields stay unset.
+- Added `test_recurrent_matches_forward_only_for_feed_forward_network`, a
+  parity sanity check confirming the recurrent and forward-only paths yield
+  the same error/score for a purely feed-forward network (both reset state per
+  record).
+
+Also refreshed the stale `Cargo.lock` crate version (`0.5.56` → `0.5.57`) so it
+matches `Cargo.toml`.
+
+Closes #206.
+
+```mermaid
+flowchart TD
+    A[score_from_json] --> B{creature.forward_only?}
+    B -- true --> C[fused stream<br/>accumulate_cost_sum_forward_only_fused<br/>backend = native_pipelined]
+    B -- false --> D[TrainingDataIterator per-record<br/>accumulate_cost_sum forward_only=false<br/>backend = record_iterator]
+    D -.->|newly covered by #206| E[test_recurrent_single_creature_uses_record_iterator_backend]
+    D -.->|parity check| F[test_recurrent_matches_forward_only_for_feed_forward_network]
+```
+
+## Evidence
+
+Backend/CLI change with no web interface — no screenshot applicable. Verified
+via the test suite.
+
+New tests pass:
+
+```
+running 2 tests
+test tests::test_recurrent_single_creature_uses_record_iterator_backend ... ok
+test tests::test_recurrent_matches_forward_only_for_feed_forward_network ... ok
+```
+
+Full binary unittest suite: `102 passed; 0 failed`.
+
+Note: `quality.sh` reports one **pre-existing, environment-specific** failure
+unrelated to this change — `gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
+in `tests/directory_mode_tdd.rs`. On a machine with a real Metal GPU the
+oversized-creature directory run scores on `metal` rather than the expected
+`cpu-fallback`. Confirmed failing on the clean tree (before any of these
+changes) by stashing the diff and re-running the test, so it is not introduced
+here.
+
+## Test Plan
+
+- `rust_scorer/src/main.rs::tests::test_recurrent_single_creature_uses_record_iterator_backend`
+  — drives the `forwardOnly:false` branch; asserts numeric score and
+  `training_read_backend == "record_iterator"`.
+- `rust_scorer/src/main.rs::tests::test_recurrent_matches_forward_only_for_feed_forward_network`
+  — parity sanity check across the two scoring modes.
+- Existing tests unchanged and still passing (`cargo test --bin rust_scorer`).

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.58"
+version = "0.5.59"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -529,13 +529,38 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::TempDir;
 
-    /// Helper: create a minimal creature JSON string.
+    /// Helper: create a minimal creature JSON string. Defaults to
+    /// `forwardOnly:true`, matching the feed-forward scoring path most tests
+    /// exercise.
     fn make_creature_json(
         num_inputs: usize,
         num_outputs: usize,
         hidden_neurons: &[(&str, &str, f64)], // (uuid, squash, bias)
         synapses: &[(&str, &str, f64)],       // (from, to, weight)
         version: Option<&str>,
+    ) -> String {
+        make_creature_json_with_forward_only(
+            num_inputs,
+            num_outputs,
+            hidden_neurons,
+            synapses,
+            version,
+            true,
+        )
+    }
+
+    /// Helper: create a minimal creature JSON string with an explicit
+    /// `forwardOnly` flag. Issue #206: setting `forward_only=false` drives the
+    /// recurrent single-creature branch of `score_from_json`, which uses the
+    /// per-record `TrainingDataIterator` and reports the `record_iterator`
+    /// read backend.
+    fn make_creature_json_with_forward_only(
+        num_inputs: usize,
+        num_outputs: usize,
+        hidden_neurons: &[(&str, &str, f64)], // (uuid, squash, bias)
+        synapses: &[(&str, &str, f64)],       // (from, to, weight)
+        version: Option<&str>,
+        forward_only: bool,
     ) -> String {
         let mut neurons = Vec::new();
 
@@ -564,7 +589,7 @@ mod tests {
         };
 
         format!(
-            r#"{{"input":{num_inputs},"output":{num_outputs},"forwardOnly":true,"neurons":[{}],"synapses":[{}]{version_str}}}"#,
+            r#"{{"input":{num_inputs},"output":{num_outputs},"forwardOnly":{forward_only},"neurons":[{}],"synapses":[{}]{version_str}}}"#,
             neurons.join(","),
             syn_strs.join(","),
         )
@@ -683,6 +708,117 @@ mod tests {
         let result = run_single(&cli).unwrap();
         assert_eq!(result.record_count, 3);
         assert!(result.error.abs() < 1e-6);
+    }
+
+    /// Issue #206: the recurrent (`forwardOnly:false`) single-creature branch
+    /// of `score_from_json` must score correctly and report the
+    /// `record_iterator` read backend. Every other test uses the default
+    /// `forwardOnly:true` helper, so without this the `else` branch (distinct
+    /// packed-buffer assembly + per-record state reset) had no coverage.
+    #[test]
+    fn test_recurrent_single_creature_uses_record_iterator_backend() {
+        let tmp = TempDir::new().unwrap();
+        let creature_path = tmp.path().join("creature.json");
+        let data_dir = tmp.path().join("data");
+        fs::create_dir(&data_dir).unwrap();
+
+        // Identity network scored in recurrent mode (forwardOnly:false).
+        let json = make_creature_json_with_forward_only(
+            1,
+            1,
+            &[],
+            &[("input-0", "output-0", 1.0)],
+            Some("4.0.0"),
+            false,
+        );
+        fs::write(&creature_path, &json).unwrap();
+        write_training_data(&data_dir, &[(vec![1.0], vec![1.0]), (vec![0.5], vec![0.5])]);
+
+        let result = run_single(&cli_for(&creature_path, &data_dir)).unwrap();
+
+        // Numeric result: identity network has zero error and score ~1.0.
+        assert!(
+            result.error.abs() < 1e-6,
+            "Expected near-zero error, got {}",
+            result.error
+        );
+        assert!(
+            (result.score - 1.0).abs() < 1e-6,
+            "Expected score near 1.0, got {}",
+            result.score
+        );
+        assert_eq!(result.record_count, 2);
+
+        // Backend label and flag must reflect the recurrent branch.
+        assert!(
+            !result.forward_only,
+            "recurrent creature must report forward_only=false"
+        );
+        assert_eq!(
+            result.training_read_backend, "record_iterator",
+            "recurrent branch must report the record_iterator backend, got {}",
+            result.training_read_backend
+        );
+        // The fused-stream-only fields stay unset on the recurrent path.
+        assert!(result.read_buf_len.is_none());
+        assert!(result.activation_threads.is_none());
+    }
+
+    /// Issue #206: for a purely feed-forward (no recurrent synapses) network,
+    /// the recurrent and forward-only paths reset state per record and so must
+    /// produce the same numeric score — a parity sanity check across the two
+    /// top-level single-creature scoring modes.
+    #[test]
+    fn test_recurrent_matches_forward_only_for_feed_forward_network() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        fs::create_dir(&data_dir).unwrap();
+        write_training_data(
+            &data_dir,
+            &[(vec![0.25], vec![0.0]), (vec![0.75], vec![1.0])],
+        );
+
+        let hidden = [("hidden-0", "TANH", 0.1)];
+        let synapses = [("input-0", "hidden-0", 1.3), ("hidden-0", "output-0", 0.9)];
+
+        let forward_json =
+            make_creature_json_with_forward_only(1, 1, &hidden, &synapses, Some("4.0.0"), true);
+        let recurrent_json =
+            make_creature_json_with_forward_only(1, 1, &hidden, &synapses, Some("4.0.0"), false);
+
+        let forward = score_from_json(
+            &forward_json,
+            &data_dir,
+            GpuBackendLabel::CpuFallback,
+            CostKind::default(),
+        )
+        .unwrap();
+        let recurrent = score_from_json(
+            &recurrent_json,
+            &data_dir,
+            GpuBackendLabel::CpuFallback,
+            CostKind::default(),
+        )
+        .unwrap();
+
+        assert!(forward.forward_only);
+        assert!(!recurrent.forward_only);
+        assert_eq!(recurrent.training_read_backend, "record_iterator");
+
+        // Same error and score across both modes for a feed-forward network.
+        assert!(
+            (forward.error - recurrent.error).abs() < 1e-9,
+            "error mismatch: forward={} recurrent={}",
+            forward.error,
+            recurrent.error
+        );
+        assert!(
+            (forward.score - recurrent.score).abs() < 1e-9,
+            "score mismatch: forward={} recurrent={}",
+            forward.score,
+            recurrent.score
+        );
+        assert_eq!(forward.record_count, recurrent.record_count);
     }
 
     #[test]


### PR DESCRIPTION
# Add coverage for the recurrent (`forwardOnly:false`) single-creature scoring path

## Summary

The recurrent (non-forward-only) single-creature scoring path had effectively
no automated coverage. The `else` branch of `score_from_json`
(`rust_scorer/src/main.rs`) uses a per-record `TrainingDataIterator` plus
`accumulate_cost_sum(..., forward_only=false)` and reports
`training_read_backend = "record_iterator"`, but every `make_creature_json`
test helper hard-coded `"forwardOnly":true`, so this branch — one of the two
top-level single-creature scoring modes, with distinct packed-buffer assembly
and per-record state-reset semantics — was never exercised.

This PR adds unit coverage for that branch:

- Parameterised the test helper via `make_creature_json_with_forward_only(...)`;
  the existing `make_creature_json(...)` now delegates with `forward_only=true`,
  so no existing test changes behaviour.
- Added `test_recurrent_single_creature_uses_record_iterator_backend`, which
  builds a `forwardOnly:false` creature, scores it, and asserts both the
  numeric result (near-zero error, score ≈ 1.0, record count) **and**
  `training_read_backend == "record_iterator"`, plus that the
  fused-stream-only fields stay unset.
- Added `test_recurrent_matches_forward_only_for_feed_forward_network`, a
  parity sanity check confirming the recurrent and forward-only paths yield
  the same error/score for a purely feed-forward network (both reset state per
  record).

Also refreshed the stale `Cargo.lock` crate version (`0.5.56` → `0.5.57`) so it
matches `Cargo.toml`.

Closes #206.

```mermaid
flowchart TD
    A[score_from_json] --> B{creature.forward_only?}
    B -- true --> C[fused stream<br/>accumulate_cost_sum_forward_only_fused<br/>backend = native_pipelined]
    B -- false --> D[TrainingDataIterator per-record<br/>accumulate_cost_sum forward_only=false<br/>backend = record_iterator]
    D -.->|newly covered by #206| E[test_recurrent_single_creature_uses_record_iterator_backend]
    D -.->|parity check| F[test_recurrent_matches_forward_only_for_feed_forward_network]
```

## Evidence

Backend/CLI change with no web interface — no screenshot applicable. Verified
via the test suite.

New tests pass:

```
running 2 tests
test tests::test_recurrent_single_creature_uses_record_iterator_backend ... ok
test tests::test_recurrent_matches_forward_only_for_feed_forward_network ... ok
```

Full binary unittest suite: `102 passed; 0 failed`.

Note: `quality.sh` reports one **pre-existing, environment-specific** failure
unrelated to this change — `gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
in `tests/directory_mode_tdd.rs`. On a machine with a real Metal GPU the
oversized-creature directory run scores on `metal` rather than the expected
`cpu-fallback`. Confirmed failing on the clean tree (before any of these
changes) by stashing the diff and re-running the test, so it is not introduced
here.

## Test Plan

- `rust_scorer/src/main.rs::tests::test_recurrent_single_creature_uses_record_iterator_backend`
  — drives the `forwardOnly:false` branch; asserts numeric score and
  `training_read_backend == "record_iterator"`.
- `rust_scorer/src/main.rs::tests::test_recurrent_matches_forward_only_for_feed_forward_network`
  — parity sanity check across the two scoring modes.
- Existing tests unchanged and still passing (`cargo test --bin rust_scorer`).
