### PR TITLE
Eliminate per-chunk to_vec() clone in pipelined GPU path (Issue #202)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Configuration (ignore list, skip paths, check-filenames / check-hidden flags) is
 - `renderD` — DRM device node name (e.g. `renderD128`).
 - `mape` / `MAPE` — Mean Absolute Percentage Error (a `neat-core` loss function).
 
-Binaries: `rust_scorer`, `float_scan_bench`, `cost_scan_bench` (see `rust_scorer/Cargo.toml`). `cost_scan_bench` (Issue #124) sweeps every supported [`CostKind`](rust_scorer/src/cost.rs) through the forward-only fused path against a single creature and a `.bin` corpus, emitting a JSON summary for per-cost CPU baseline comparison.
+Binaries: `rust_scorer`, `float_scan_bench`, `cost_scan_bench`, `gpu_pipeline_alloc_bench` (see `rust_scorer/Cargo.toml`). `cost_scan_bench` (Issue #124) sweeps every supported [`CostKind`](rust_scorer/src/cost.rs) through the forward-only fused path against a single creature and a `.bin` corpus, emitting a JSON summary for per-cost CPU baseline comparison. `gpu_pipeline_alloc_bench` (Issue #202) counts heap allocations during a multi-chunk pipelined (`inflight_chunks == 2`) GPU directory run; it skips cleanly on CPU-only hosts.
 
 ## CLI
 

--- a/docs/archive/pr-summaries/pr-summary-202.md
+++ b/docs/archive/pr-summaries/pr-summary-202.md
@@ -1,0 +1,92 @@
+# Eliminate the per-chunk `to_vec()` copy in the pipelined GPU path
+
+## Summary
+
+The pipelined GPU directory path (`inflight_chunks == 2`) cloned every unpacked
+chunk via `floats.to_vec()` on the hot I/O thread before handing it to the GPU
+worker — a full heap allocation + memcpy for **every** chunk, work the
+synchronous path never pays and which partly defeats the point of pipelining.
+
+This PR transfers ownership of the unpack buffer to the worker instead of
+cloning it. The shared `ScoreChunkFn` callback now receives `&mut Vec<f32>`, so
+the pipelined submit step swaps a recycled (or fresh) buffer into the unpack
+slot via `std::mem::replace`. The GPU worker hands each consumed buffer back
+through a recycle channel into a small `FloatBufPool`; at steady state the path
+reuses a couple of buffers with **no per-chunk allocation**. Read-only consumers
+(CPU multi-creature, GPU synchronous, fused single-creature stream) simply borrow
+the buffer as a slice in place — behaviour unchanged.
+
+Closes #202.
+
+## Evidence
+
+This is a backend/CLI performance change — no UI to screenshot. Evidence is the
+allocator-pressure benchmark and the parity test.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    subgraph IO[I/O thread]
+        U[unpack_f32s_le into unpack buffer]
+        S{submit_chunk}
+    end
+    subgraph W[GPU worker thread]
+        G[score_chunk on GPU]
+    end
+    U --> S
+    S -->|move buffer via work_tx| G
+    S -.->|swap recycled buffer in| U
+    G -->|return consumed buffer via recycle_tx| P[FloatBufPool]
+    P -.->|take| S
+```
+
+Before: `submit_chunk` sent `floats.to_vec()` (allocate + copy per chunk).
+After: `submit_chunk` sends the buffer itself and swaps a pooled buffer back in.
+
+### Benchmark — `gpu_pipeline_alloc_bench` (new)
+
+Counts heap allocations during a multi-chunk pipelined (`inflight_chunks == 2`)
+GPU directory run. Fixture: 8 creatures, 100 000 records, `NEAT_SCORER_READ_BYTES`
+forced small to stream **1563 chunks**, Metal backend. Allocation counts are
+deterministic across runs.
+
+| Metric                | Before (`to_vec`) | After (buffer swap) | Delta            |
+|-----------------------|-------------------|---------------------|------------------|
+| allocations (scored)  | 115 826           | 114 320             | **−1 506**       |
+| alloc bytes (scored)  | 25 115 928        | 21 175 296          | **−3.94 MB (−15.7%)** |
+| gpu dispatch count    | 1 563             | 1 563               | unchanged        |
+| wall time (s)         | ~3.3–3.6          | ~2.9–3.9            | unchanged (noise) |
+
+The ~1 506-allocation drop matches the streamed chunk count (1 563) minus a
+handful of warm-up allocations before the recycle pool fills. No throughput
+regression; reduced allocator pressure as the issue targeted.
+
+Reproduce:
+
+```bash
+cargo build --release -p rust_scorer --bin gpu_pipeline_alloc_bench
+./target/release/gpu_pipeline_alloc_bench   # skips cleanly on CPU-only hosts
+```
+
+## Test Plan
+
+- **`rust_scorer/tests/gpu_pipelined_parity.rs`** (new) —
+  `pipelined_matches_synchronous_scores_over_many_chunks`: scores the same
+  multi-chunk fixture through `inflight_chunks == 1` and `== 2` and asserts every
+  creature's `error`/`score` is **bit-identical** (`to_bits()`), guarding the
+  ownership-transfer refactor. Skips cleanly when no GPU adapter is present.
+- **`rust_scorer/src/stream_io.rs`** — added `FloatBufPool` unit tests:
+  `float_buf_pool_reuses_recycled_buffer_allocation`,
+  `float_buf_pool_take_on_empty_yields_fresh_empty_buffer`,
+  `float_buf_pool_take_swaps_into_unpack_slot_without_cloning`. Existing
+  `run_io_loop` tests updated to the new `&mut Vec<f32>` callback signature (no
+  assertions weakened).
+- Existing **`gpu_multi_score_parity`** CPU↔GPU parity tests still pass (6/6).
+- Full workspace suite passes except one **pre-existing, environment-specific**
+  failure unrelated to this change:
+  `directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`.
+  It expects an oversized creature to fall back to CPU, but on a host with a real
+  Metal GPU the scratch kernel hosts it on the GPU instead. Verified this test
+  fails identically on the base commit (before any change in this PR); CI runners
+  are CPU-only, so it passes there.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.59"
+version = "0.5.60"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -34,6 +34,13 @@ path = "src/bin/float_scan_bench.rs"
 name = "cost_scan_bench"
 path = "src/bin/cost_scan_bench.rs"
 
+# Allocator-pressure bench for the pipelined GPU directory path (Issue #202).
+# Counts heap allocations during a multi-chunk `inflight_chunks == 2` run so the
+# per-chunk `to_vec()` removal can be measured before/after. Skips on CPU hosts.
+[[bin]]
+name = "gpu_pipeline_alloc_bench"
+path = "src/bin/gpu_pipeline_alloc_bench.rs"
+
 # Criterion bench harness — see `benches/scoring.rs` and
 # `docs/performance-baseline.md`. Not wired into `quality.sh` (Criterion runs
 # are slow and non-deterministic enough to be unsuitable as a merge gate);

--- a/rust_scorer/src/bin/gpu_pipeline_alloc_bench.rs
+++ b/rust_scorer/src/bin/gpu_pipeline_alloc_bench.rs
@@ -1,0 +1,189 @@
+//! Allocator-pressure benchmark for the pipelined GPU directory path (Issue #202).
+//!
+//! Builds a small synthetic creatures directory plus a multi-chunk `.bin` file,
+//! then scores it through [`rust_scorer::multi_score::score_from_creature_dir_gpu`]
+//! with `inflight_chunks == 2` (the pipelined worker-thread path). A counting
+//! global allocator records how many heap allocations the run performs.
+//!
+//! The pipelined path used to clone every chunk via `floats.to_vec()` on the hot
+//! I/O thread — one allocation + memcpy per chunk. Issue #202 swaps a recycled
+//! buffer into the unpack slot instead, so the per-chunk allocation disappears.
+//! Run this bench before and after the change to see the allocation count drop by
+//! roughly the number of streamed chunks.
+//!
+//! Build: `cargo build --release -p rust_scorer --bin gpu_pipeline_alloc_bench`
+//! Run:   `./target/release/gpu_pipeline_alloc_bench`
+//!
+//! Skips cleanly (exit 0, prints a notice) when no GPU adapter is available, so
+//! it is safe to invoke on CPU-only hosts.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Instant;
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::gpu::{GpuBackendLabel, select_adapter};
+use rust_scorer::multi_score::score_from_creature_dir_gpu;
+
+/// Global allocator that tallies allocation count and bytes while `ACTIVE` is set.
+struct CountingAllocator;
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: every method forwards to the System allocator unchanged; the only
+// added behaviour is two relaxed atomic counters, which cannot affect memory
+// safety of the returned pointers.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ACTIVE.load(Ordering::Relaxed) {
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if ACTIVE.load(Ordering::Relaxed) {
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        unsafe { System.alloc_zeroed(layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const NUM_INPUTS: usize = 8;
+const NUM_OUTPUTS: usize = 2;
+const NUM_CREATURES: usize = 8;
+const NUM_RECORDS: usize = 100_000;
+const HIDDEN: usize = 8;
+// Small read buffer → many streamed chunks → many per-chunk submissions.
+const READ_BYTES: usize = (NUM_INPUTS + NUM_OUTPUTS) * 4 * 64;
+
+fn synthetic_creature_json() -> String {
+    let mut neurons: Vec<String> = Vec::new();
+    for h in 0..HIDDEN {
+        neurons.push(format!(
+            r#"{{"type":"hidden","uuid":"hidden-{h}","bias":0.05,"squash":"TANH"}}"#
+        ));
+    }
+    for o in 0..NUM_OUTPUTS {
+        neurons.push(format!(
+            r#"{{"type":"output","uuid":"output-{o}","bias":0.0,"squash":"IDENTITY"}}"#
+        ));
+    }
+    let mut synapses: Vec<String> = Vec::new();
+    for i in 0..NUM_INPUTS {
+        for h in 0..HIDDEN {
+            let w = 0.05 + 0.001 * ((i * HIDDEN + h) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"input-{i}","toUUID":"hidden-{h}","weight":{w}}}"#
+            ));
+        }
+    }
+    for h in 0..HIDDEN {
+        for o in 0..NUM_OUTPUTS {
+            let w = 0.1 + 0.001 * ((h * NUM_OUTPUTS + o) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"hidden-{h}","toUUID":"output-{o}","weight":{w}}}"#
+            ));
+        }
+    }
+    format!(
+        r#"{{"input":{NUM_INPUTS},"output":{NUM_OUTPUTS},"forwardOnly":true,"semanticVersion":"4.0.0","neurons":[{}],"synapses":[{}]}}"#,
+        neurons.join(","),
+        synapses.join(","),
+    )
+}
+
+fn build_fixture(root: &Path) -> std::io::Result<(std::path::PathBuf, std::path::PathBuf)> {
+    let creatures_dir = root.join("creatures");
+    let data_dir = root.join("data");
+    std::fs::create_dir_all(&creatures_dir)?;
+    std::fs::create_dir_all(&data_dir)?;
+
+    let json = synthetic_creature_json();
+    for c in 0..NUM_CREATURES {
+        std::fs::write(creatures_dir.join(format!("creature-{c}.json")), &json)?;
+    }
+
+    let mut bytes = Vec::with_capacity(NUM_RECORDS * (NUM_INPUTS + NUM_OUTPUTS) * 4);
+    for i in 0..NUM_RECORDS {
+        for k in 0..(NUM_INPUTS + NUM_OUTPUTS) {
+            let v = ((i.wrapping_mul(31) + k) as f32 * 1.0e-3).sin();
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    let mut f = std::fs::File::create(data_dir.join("0.bin"))?;
+    f.write_all(&bytes)?;
+    f.flush()?;
+
+    Ok((creatures_dir, data_dir))
+}
+
+fn main() {
+    // Probe for a GPU first; skip cleanly on CPU-only hosts.
+    let ctx = match select_adapter() {
+        Ok(Some(c)) if c.backend != GpuBackendLabel::CpuFallback => Arc::new(c),
+        _ => {
+            println!("gpu_pipeline_alloc_bench: no compatible GPU adapter — skipping");
+            return;
+        }
+    };
+    let backend = ctx.backend;
+
+    let root = std::env::temp_dir().join("gpu_pipeline_alloc_bench");
+    let _ = std::fs::remove_dir_all(&root);
+    let (creatures_dir, data_dir) = build_fixture(&root).expect("build fixture");
+
+    // Force many streamed chunks so the per-chunk allocation dominates the delta.
+    // SAFETY: single-threaded setup before any worker threads are spawned.
+    unsafe {
+        std::env::set_var("NEAT_SCORER_READ_BYTES", READ_BYTES.to_string());
+    }
+
+    // Start counting only around the scored run, excluding fixture + adapter setup.
+    ALLOC_COUNT.store(0, Ordering::Relaxed);
+    ALLOC_BYTES.store(0, Ordering::Relaxed);
+    ACTIVE.store(true, Ordering::Relaxed);
+    let started = Instant::now();
+    let results = score_from_creature_dir_gpu(
+        &creatures_dir,
+        &data_dir,
+        backend,
+        ctx,
+        2, // pipelined path
+        CostKind::Mse,
+    )
+    .expect("score directory on GPU");
+    let elapsed = started.elapsed().as_secs_f64();
+    ACTIVE.store(false, Ordering::Relaxed);
+
+    let allocs = ALLOC_COUNT.load(Ordering::Relaxed);
+    let bytes = ALLOC_BYTES.load(Ordering::Relaxed);
+    let dispatches = results
+        .values()
+        .next()
+        .and_then(|r| r.gpu_dispatch_count)
+        .unwrap_or(0);
+
+    let _ = std::fs::remove_dir_all(&root);
+
+    println!("gpu_pipeline_alloc_bench ({} backend)", backend.as_str());
+    println!("  creatures           : {NUM_CREATURES}");
+    println!("  records             : {NUM_RECORDS}");
+    println!("  read_bytes          : {READ_BYTES}");
+    println!("  gpu_dispatch_count  : {dispatches}");
+    println!("  allocations (scored): {allocs}");
+    println!("  alloc_bytes (scored): {bytes}");
+    println!("  elapsed_secs        : {elapsed:.4}");
+}

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -40,7 +40,7 @@ use crate::gpu::forward_mse_batched::{BatchedRunner, build_batched_network_data}
 use crate::gpu::{GpuBackendLabel, GpuContext};
 use crate::read_tuning::{training_read_backend_label, training_read_target_bytes_from_env};
 use crate::scoring::{ScoreResult, calculate_score, complexity_penalty, compute_score_components};
-use crate::stream_io::run_io_loop;
+use crate::stream_io::{FloatBufPool, run_io_loop};
 use crate::stream_score::{activation_worker_count_for_scorer, effective_fused_read_buf_len};
 
 /// Keep aligned with main scorer formula.
@@ -308,7 +308,9 @@ pub fn score_from_creature_dir(
     let mut work_ranges: Vec<Option<Range<usize>>> = vec![None; total_workers];
     let mut worker_sums: Vec<f64> = vec![0.0; total_workers];
 
-    let mut score_chunk = |floats: &[f32], n_records: usize| -> Result<(), String> {
+    let mut score_chunk = |floats: &mut Vec<f32>, n_records: usize| -> Result<(), String> {
+        // Read-only consumer: borrow the unpack buffer as a slice in place.
+        let floats: &[f32] = floats;
         if floats.len() != n_records * values_per_record {
             return Err("Internal float unpack length mismatch".to_string());
         }
@@ -600,7 +602,9 @@ pub fn score_from_creature_dir_gpu(
 
     if inflight_chunks <= 1 {
         // Synchronous: one chunk in flight at a time.
-        let mut score_chunk = |floats: &[f32], n_records: usize| -> Result<(), String> {
+        let mut score_chunk = |floats: &mut Vec<f32>, n_records: usize| -> Result<(), String> {
+            // Synchronous path borrows the unpack buffer in place — no handoff.
+            let floats: &[f32] = floats;
             if floats.len() != n_records * values_per_record {
                 return Err("Internal float unpack length mismatch".to_string());
             }
@@ -630,9 +634,12 @@ pub fn score_from_creature_dir_gpu(
         use std::thread;
 
         // Move runner into worker thread; results come back through `result_rx`.
+        // Consumed unpack buffers return through `recycle_rx` so the I/O thread
+        // can reuse them instead of cloning each chunk (Issue #202).
         let n_creatures = loaded.len();
         let (work_tx, work_rx) = mpsc::sync_channel::<Option<(Vec<f32>, usize)>>(inflight_chunks);
         let (result_tx, result_rx) = mpsc::channel::<Result<(usize, Vec<f64>), String>>();
+        let (recycle_tx, recycle_rx) = mpsc::channel::<Vec<f32>>();
 
         let worker = thread::spawn(move || {
             while let Ok(Some((floats, n_records))) = work_rx.recv() {
@@ -645,6 +652,9 @@ pub fn score_from_creature_dir_gpu(
                 if result_tx.send(Ok((n_records, sums))).is_err() {
                     break;
                 }
+                // Hand the consumed buffer back for reuse. A send error just
+                // means the I/O thread has gone away, so drop the buffer.
+                let _ = recycle_tx.send(floats);
             }
             runner
         });
@@ -668,15 +678,24 @@ pub fn score_from_creature_dir_gpu(
             }
         };
 
-        let mut submit_chunk = |floats: &[f32], n_records: usize| -> Result<(), String> {
+        let mut pool = FloatBufPool::new();
+        let mut submit_chunk = |floats: &mut Vec<f32>, n_records: usize| -> Result<(), String> {
             // Cap in-flight so the channel never queues more than `inflight_chunks`
             // chunks. When already at the cap, drain one result first.
             while pending_results >= inflight_chunks {
                 drain_one(&mut total_records, &mut total_mse, &mut pending_results)?;
             }
-            // Send a copy — the worker thread takes ownership of the Vec.
+            // Reclaim any buffers the worker has finished with.
+            while let Ok(buf) = recycle_rx.try_recv() {
+                pool.recycle(buf);
+            }
+            // Transfer ownership of the freshly-unpacked buffer to the worker and
+            // swap a recycled (or fresh) buffer into the unpack slot. No per-chunk
+            // clone — the I/O thread keeps streaming into the new buffer while the
+            // worker scores the old one (Issue #202).
+            let outgoing = std::mem::replace(floats, pool.take());
             work_tx
-                .send(Some((floats.to_vec(), n_records)))
+                .send(Some((outgoing, n_records)))
                 .map_err(|_| "GPU worker hung up before chunk submission".to_string())?;
             pending_results += 1;
             Ok(())

--- a/rust_scorer/src/stream_io.rs
+++ b/rust_scorer/src/stream_io.rs
@@ -79,7 +79,45 @@ pub(crate) fn compact_pending_if_needed(pending: &mut Vec<u8>, head: &mut usize)
 
 /// Callback that scores one chunk of decoded packed records. The callee is
 /// expected to update its own running totals.
-pub(crate) type ScoreChunkFn<'a> = dyn FnMut(&[f32], usize) -> Result<(), String> + 'a;
+///
+/// The buffer is passed as `&mut Vec<f32>` (not `&[f32]`) so a consumer that
+/// hands the chunk off to another thread can take ownership via
+/// [`std::mem::replace`] and swap a recycled buffer back in, avoiding a
+/// per-chunk clone (Issue #202). Read-only consumers simply borrow it as a
+/// slice and leave it in place.
+pub(crate) type ScoreChunkFn<'a> = dyn FnMut(&mut Vec<f32>, usize) -> Result<(), String> + 'a;
+
+/// Small free-list of reusable `Vec<f32>` unpack buffers for the pipelined GPU
+/// path (Issue #202). The GPU worker hands consumed buffers back here so the
+/// I/O thread can swap a recycled buffer into the unpack slot instead of
+/// allocating + copying a fresh `Vec` for every streamed chunk.
+pub(crate) struct FloatBufPool {
+    free: Vec<Vec<f32>>,
+}
+
+impl FloatBufPool {
+    pub(crate) fn new() -> Self {
+        Self { free: Vec::new() }
+    }
+
+    /// Hand out a buffer for the next unpack. Reuses a recycled buffer (keeping
+    /// its heap allocation) when one is available, otherwise yields a fresh
+    /// empty `Vec`. The caller's `unpack_f32s_le` clears it before filling, so
+    /// returned buffers need not be empty.
+    pub(crate) fn take(&mut self) -> Vec<f32> {
+        self.free.pop().unwrap_or_default()
+    }
+
+    /// Return a consumed buffer for later reuse.
+    pub(crate) fn recycle(&mut self, buf: Vec<f32>) {
+        self.free.push(buf);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn free_len(&self) -> usize {
+        self.free.len()
+    }
+}
 
 /// Shared head-and-compact I/O loop reused by both the multi-creature and fused
 /// forward-only streaming paths. Calls `score_chunk(floats, n_records)` for each
@@ -143,7 +181,55 @@ pub(crate) fn run_io_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::{compact_pending_if_needed, run_io_loop, unpack_f32s_le};
+    use super::{FloatBufPool, compact_pending_if_needed, run_io_loop, unpack_f32s_le};
+
+    #[test]
+    fn float_buf_pool_reuses_recycled_buffer_allocation() {
+        let mut pool = FloatBufPool::new();
+        assert_eq!(pool.free_len(), 0);
+
+        // Empty pool hands out a fresh buffer; fill it and note its allocation.
+        let mut buf = pool.take();
+        buf.extend_from_slice(&[1.0, 2.0, 3.0, 4.0]);
+        let cap = buf.capacity();
+        assert!(cap >= 4);
+
+        // Recycling returns it to the free list...
+        pool.recycle(buf);
+        assert_eq!(pool.free_len(), 1);
+
+        // ...and the next take reuses the same heap allocation (capacity kept),
+        // so no fresh allocation is needed for the next chunk.
+        let reused = pool.take();
+        assert_eq!(reused.capacity(), cap);
+        assert_eq!(pool.free_len(), 0);
+    }
+
+    #[test]
+    fn float_buf_pool_take_on_empty_yields_fresh_empty_buffer() {
+        let mut pool = FloatBufPool::new();
+        let a = pool.take();
+        assert!(a.is_empty());
+        // Nothing recycled yet, so the pool is still empty.
+        assert_eq!(pool.free_len(), 0);
+    }
+
+    #[test]
+    fn float_buf_pool_take_swaps_into_unpack_slot_without_cloning() {
+        // Mirrors the pipelined submit: swap the freshly-unpacked buffer out and
+        // a recycled buffer in via `mem::replace`, then recycle it next round.
+        let mut pool = FloatBufPool::new();
+        let mut unpack = vec![10.0_f32, 20.0, 30.0];
+
+        let outgoing = std::mem::replace(&mut unpack, pool.take());
+        // The data left with `outgoing`; the unpack slot now holds a fresh Vec.
+        assert_eq!(outgoing, vec![10.0_f32, 20.0, 30.0]);
+        assert!(unpack.is_empty());
+
+        // The consumer hands the buffer back once scored.
+        pool.recycle(outgoing);
+        assert_eq!(pool.free_len(), 1);
+    }
 
     #[test]
     fn unpack_f32s_le_decodes_exact_length_buffer() {
@@ -208,8 +294,8 @@ mod tests {
         let mut head = 0_usize;
         let mut floats = Vec::new();
         let mut scored: Vec<(Vec<f32>, usize)> = Vec::new();
-        let mut score_chunk = |f: &[f32], n: usize| -> Result<(), String> {
-            scored.push((f.to_vec(), n));
+        let mut score_chunk = |f: &mut Vec<f32>, n: usize| -> Result<(), String> {
+            scored.push((f.clone(), n));
             Ok(())
         };
 
@@ -245,8 +331,8 @@ mod tests {
         let chunk_b = 4.0_f32.to_le_bytes().to_vec();
 
         {
-            let mut score_chunk = |f: &[f32], n: usize| -> Result<(), String> {
-                scored.push((f.to_vec(), n));
+            let mut score_chunk = |f: &mut Vec<f32>, n: usize| -> Result<(), String> {
+                scored.push((f.clone(), n));
                 Ok(())
             };
             run_io_loop(
@@ -292,7 +378,7 @@ mod tests {
         let mut head = 0_usize;
         let mut floats = Vec::new();
         let mut score_chunk =
-            |_f: &[f32], _n: usize| -> Result<(), String> { Err("boom".to_string()) };
+            |_f: &mut Vec<f32>, _n: usize| -> Result<(), String> { Err("boom".to_string()) };
 
         let err = run_io_loop(
             &chunk,

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -165,7 +165,9 @@ pub fn accumulate_cost_sum_forward_only_fused(
     // loop (`run_io_loop`, Issue #203). Issue #121 dispatches every supported
     // cost through `accumulate_cost_sum`; Issue #200 propagates a per-slice cost
     // error via `?` rather than `.expect` across a Rayon worker.
-    let mut score_chunk = |floats: &[f32], n_records: usize| -> Result<(), String> {
+    let mut score_chunk = |floats: &mut Vec<f32>, n_records: usize| -> Result<(), String> {
+        // Read-only consumer: borrow the unpack buffer as a slice in place.
+        let floats: &[f32] = floats;
         if floats.len() != n_records * values_per_record {
             return Err("Internal float unpack length mismatch".to_string());
         }

--- a/rust_scorer/tests/gpu_pipelined_parity.rs
+++ b/rust_scorer/tests/gpu_pipelined_parity.rs
@@ -1,0 +1,180 @@
+//! Issue #202 — the pipelined GPU directory path (`inflight_chunks == 2`) must
+//! produce byte-for-byte the same per-creature scores as the synchronous path
+//! (`inflight_chunks == 1`).
+//!
+//! The pipelined path now hands each unpacked chunk to the GPU worker by
+//! swapping a recycled buffer into the unpack slot (instead of cloning via
+//! `to_vec()`). This test guards that the ownership-transfer + buffer-recycling
+//! refactor did not change the streamed data: both modes are scored over a
+//! multi-chunk `.bin` file and every creature's `error`/`score` must match
+//! exactly.
+//!
+//! Skips cleanly when no GPU adapter is available so CPU-only CI still passes.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::gpu::{GpuBackendLabel, GpuMode, resolve_backend, select_adapter};
+use rust_scorer::multi_score::score_from_creature_dir_gpu;
+
+const NUM_INPUTS: usize = 8;
+const NUM_OUTPUTS: usize = 2;
+
+fn synthetic_creature_json(hidden: usize) -> String {
+    let mut neurons: Vec<String> = Vec::new();
+    for h in 0..hidden {
+        neurons.push(format!(
+            r#"{{"type":"hidden","uuid":"hidden-{h}","bias":0.05,"squash":"TANH"}}"#
+        ));
+    }
+    for o in 0..NUM_OUTPUTS {
+        neurons.push(format!(
+            r#"{{"type":"output","uuid":"output-{o}","bias":0.0,"squash":"IDENTITY"}}"#
+        ));
+    }
+    let mut synapses: Vec<String> = Vec::new();
+    for i in 0..NUM_INPUTS {
+        for h in 0..hidden {
+            let w = 0.05 + 0.001 * ((i * hidden + h) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"input-{i}","toUUID":"hidden-{h}","weight":{w}}}"#
+            ));
+        }
+    }
+    for h in 0..hidden {
+        for o in 0..NUM_OUTPUTS {
+            let w = 0.1 + 0.001 * ((h * NUM_OUTPUTS + o) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"hidden-{h}","toUUID":"output-{o}","weight":{w}}}"#
+            ));
+        }
+    }
+    format!(
+        r#"{{"input":{NUM_INPUTS},"output":{NUM_OUTPUTS},"forwardOnly":true,"semanticVersion":"4.0.0","neurons":[{}],"synapses":[{}]}}"#,
+        neurons.join(","),
+        synapses.join(","),
+    )
+}
+
+fn write_fixture(
+    root: &Path,
+    num_creatures: usize,
+    n_records: usize,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let creatures_dir = root.join("creatures");
+    let data_dir = root.join("data");
+    std::fs::create_dir_all(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+
+    let json = synthetic_creature_json(8);
+    for c in 0..num_creatures {
+        std::fs::write(creatures_dir.join(format!("creature-{c}.json")), &json)
+            .expect("write creature");
+    }
+
+    let mut bytes = Vec::with_capacity(n_records * (NUM_INPUTS + NUM_OUTPUTS) * 4);
+    for i in 0..n_records {
+        for k in 0..(NUM_INPUTS + NUM_OUTPUTS) {
+            let v = ((i.wrapping_mul(31) + k) as f32 * 1.0e-3).sin();
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    let mut f = std::fs::File::create(data_dir.join("0.bin")).expect("create bin");
+    f.write_all(&bytes).expect("write bin");
+    f.flush().expect("flush bin");
+
+    (creatures_dir, data_dir)
+}
+
+#[test]
+fn pipelined_matches_synchronous_scores_over_many_chunks() {
+    // Skip cleanly when no GPU is available — CI runners are CPU-only.
+    if resolve_backend(GpuMode::Auto)
+        .map(|b| b.as_str() == "cpu-fallback")
+        .unwrap_or(true)
+    {
+        eprintln!("skipping pipelined parity: no compatible adapter");
+        return;
+    }
+    let ctx = match select_adapter() {
+        Ok(Some(c)) if c.backend != GpuBackendLabel::CpuFallback => Arc::new(c),
+        _ => {
+            eprintln!("skipping pipelined parity: select_adapter returned no context");
+            return;
+        }
+    };
+    let backend = ctx.backend;
+
+    // Force many streamed chunks so the pipelined buffer-recycling path runs
+    // for real (multiple submit/recycle cycles), not just a single chunk.
+    let read_bytes = (NUM_INPUTS + NUM_OUTPUTS) * 4 * 64;
+    // SAFETY: set before any worker threads are spawned by the scorer.
+    unsafe {
+        std::env::set_var("NEAT_SCORER_READ_BYTES", read_bytes.to_string());
+    }
+
+    let root = std::env::temp_dir().join("gpu_pipelined_parity_fixture");
+    let _ = std::fs::remove_dir_all(&root);
+    let (creatures_dir, data_dir) = write_fixture(&root, 6, 20_000);
+
+    let sync = score_from_creature_dir_gpu(
+        &creatures_dir,
+        &data_dir,
+        backend,
+        ctx.clone(),
+        1, // synchronous
+        CostKind::Mse,
+    )
+    .expect("synchronous GPU scoring");
+
+    let pipelined = score_from_creature_dir_gpu(
+        &creatures_dir,
+        &data_dir,
+        backend,
+        ctx,
+        2, // pipelined
+        CostKind::Mse,
+    )
+    .expect("pipelined GPU scoring");
+
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert_eq!(
+        sync.len(),
+        pipelined.len(),
+        "creature counts differ between sync and pipelined runs"
+    );
+    assert!(!sync.is_empty(), "expected at least one scored creature");
+
+    for (key, sync_res) in &sync {
+        let pipe_res = pipelined
+            .get(key)
+            .unwrap_or_else(|| panic!("creature '{key}' missing from pipelined results"));
+        // Both paths stream identical records through the same kernel, so the
+        // accumulated error and final score must be bit-identical.
+        assert_eq!(
+            sync_res.error.to_bits(),
+            pipe_res.error.to_bits(),
+            "creature '{key}': error differs (sync={}, pipelined={})",
+            sync_res.error,
+            pipe_res.error
+        );
+        assert_eq!(
+            sync_res.score.to_bits(),
+            pipe_res.score.to_bits(),
+            "creature '{key}': score differs (sync={}, pipelined={})",
+            sync_res.score,
+            pipe_res.score
+        );
+        assert_eq!(
+            sync_res.record_count, pipe_res.record_count,
+            "creature '{key}': record_count differs"
+        );
+    }
+
+    // Sanity: the pipelined path reported the pipelined inflight setting.
+    let any = pipelined.values().next().expect("at least one result");
+    assert_eq!(any.gpu_inflight_chunks, Some(2));
+}


### PR DESCRIPTION
# Eliminate the per-chunk `to_vec()` copy in the pipelined GPU path

## Summary

The pipelined GPU directory path (`inflight_chunks == 2`) cloned every unpacked
chunk via `floats.to_vec()` on the hot I/O thread before handing it to the GPU
worker — a full heap allocation + memcpy for **every** chunk, work the
synchronous path never pays and which partly defeats the point of pipelining.

This PR transfers ownership of the unpack buffer to the worker instead of
cloning it. The shared `ScoreChunkFn` callback now receives `&mut Vec<f32>`, so
the pipelined submit step swaps a recycled (or fresh) buffer into the unpack
slot via `std::mem::replace`. The GPU worker hands each consumed buffer back
through a recycle channel into a small `FloatBufPool`; at steady state the path
reuses a couple of buffers with **no per-chunk allocation**. Read-only consumers
(CPU multi-creature, GPU synchronous, fused single-creature stream) simply borrow
the buffer as a slice in place — behaviour unchanged.

Closes #202.

## Evidence

This is a backend/CLI performance change — no UI to screenshot. Evidence is the
allocator-pressure benchmark and the parity test.

### Data flow

```mermaid
flowchart LR
    subgraph IO[I/O thread]
        U[unpack_f32s_le into unpack buffer]
        S{submit_chunk}
    end
    subgraph W[GPU worker thread]
        G[score_chunk on GPU]
    end
    U --> S
    S -->|move buffer via work_tx| G
    S -.->|swap recycled buffer in| U
    G -->|return consumed buffer via recycle_tx| P[FloatBufPool]
    P -.->|take| S
```

Before: `submit_chunk` sent `floats.to_vec()` (allocate + copy per chunk).
After: `submit_chunk` sends the buffer itself and swaps a pooled buffer back in.

### Benchmark — `gpu_pipeline_alloc_bench` (new)

Counts heap allocations during a multi-chunk pipelined (`inflight_chunks == 2`)
GPU directory run. Fixture: 8 creatures, 100 000 records, `NEAT_SCORER_READ_BYTES`
forced small to stream **1563 chunks**, Metal backend. Allocation counts are
deterministic across runs.

| Metric                | Before (`to_vec`) | After (buffer swap) | Delta            |
|-----------------------|-------------------|---------------------|------------------|
| allocations (scored)  | 115 826           | 114 320             | **−1 506**       |
| alloc bytes (scored)  | 25 115 928        | 21 175 296          | **−3.94 MB (−15.7%)** |
| gpu dispatch count    | 1 563             | 1 563               | unchanged        |
| wall time (s)         | ~3.3–3.6          | ~2.9–3.9            | unchanged (noise) |

The ~1 506-allocation drop matches the streamed chunk count (1 563) minus a
handful of warm-up allocations before the recycle pool fills. No throughput
regression; reduced allocator pressure as the issue targeted.

Reproduce:

```bash
cargo build --release -p rust_scorer --bin gpu_pipeline_alloc_bench
./target/release/gpu_pipeline_alloc_bench   # skips cleanly on CPU-only hosts
```

## Test Plan

- **`rust_scorer/tests/gpu_pipelined_parity.rs`** (new) —
  `pipelined_matches_synchronous_scores_over_many_chunks`: scores the same
  multi-chunk fixture through `inflight_chunks == 1` and `== 2` and asserts every
  creature's `error`/`score` is **bit-identical** (`to_bits()`), guarding the
  ownership-transfer refactor. Skips cleanly when no GPU adapter is present.
- **`rust_scorer/src/stream_io.rs`** — added `FloatBufPool` unit tests:
  `float_buf_pool_reuses_recycled_buffer_allocation`,
  `float_buf_pool_take_on_empty_yields_fresh_empty_buffer`,
  `float_buf_pool_take_swaps_into_unpack_slot_without_cloning`. Existing
  `run_io_loop` tests updated to the new `&mut Vec<f32>` callback signature (no
  assertions weakened).
- Existing **`gpu_multi_score_parity`** CPU↔GPU parity tests still pass (6/6).
- Full workspace suite passes except one **pre-existing, environment-specific**
  failure unrelated to this change:
  `directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`.
  It expects an oversized creature to fall back to CPU, but on a host with a real
  Metal GPU the scratch kernel hosts it on the GPU instead. Verified this test
  fails identically on the base commit (before any change in this PR); CI runners
  are CPU-only, so it passes there.



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqcbuqiq-d67912`<!-- vibe-worker-issue-202 -->