### PR TITLE
Fix markdown-lint push trigger to target Develop (Issue #207)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -21,7 +21,10 @@ on:
   pull_request:
     branches: ["*"]
   push:
-    branches: [main, master]
+    # Default branch is `Develop`; include legacy names for symmetry with
+    # actionlint.yml so markdown lint also runs on pushes to the real default
+    # branch (Issue #207).
+    branches: [main, master, Develop]
 
 permissions:
   contents: read

--- a/docs/archive/pr-summaries/pr-summary-207.md
+++ b/docs/archive/pr-summaries/pr-summary-207.md
@@ -1,0 +1,51 @@
+## Summary
+
+The `markdown-lint.yml` workflow's `push` trigger listed `branches: [main, master]`,
+but this repo's default branch is `Develop` (per `.vibe_default_branch` and
+`origin/HEAD`) — neither `main` nor `master` exists. As a result the markdown-lint
+`push` trigger never fired; markdown lint only ran on pull requests, never on pushes
+to the actual default branch.
+
+This change sets the `push` branches to `[main, master, Develop]`, matching the
+existing `actionlint.yml` for symmetry, so markdown lint now runs on pushes to
+`Develop`. The legacy `main`/`master` names are kept harmlessly for parity. Closes #207.
+
+```mermaid
+flowchart LR
+    P[Push to Develop] -->|before: [main, master]| X[Trigger never fires]
+    P -->|after: [main, master, Develop]| R[Markdown Lint runs]
+```
+
+## Evidence
+
+This is a CI/workflow change with no web interface, so no screenshot applies.
+Verification was done via workflow inspection and the validator script:
+
+- `actionlint .github/workflows/markdown-lint.yml` → **OK** (workflow valid).
+- `python3 -c "import yaml; yaml.safe_load(...)"` → **YAML valid**.
+- `scripts/check-markdown-lint-workflow.sh` (no args, validates the real workflow)
+  reports **`OK ... push trigger targets the default branch (Develop)`** and exits 0.
+
+The validator (`scripts/check-markdown-lint-workflow.sh`) gained a new rule (#6)
+that captures the first `branches:` line inside the `push:` block and fails unless
+it lists `Develop`, guarding against this regression recurring.
+
+### Unrelated pre-existing failure
+
+`./quality.sh` reports one failing Rust test,
+`gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
+(`rust_scorer/tests/directory_mode_tdd.rs`). It is environment-specific (a Metal GPU
+is present, so the oversized creature scores on `metal` instead of `cpu-fallback`)
+and was confirmed to fail identically with my changes stashed. It is unrelated to
+this workflow/bash change and out of scope for #207.
+
+## Test Plan
+
+- Added `tests/scripts/markdown_lint_workflow.bats::"fails when the push trigger omits Develop (Issue #207)"`
+  — mutates the canonical fixture back to `[main, master]` and asserts the validator
+  exits non-zero with `push trigger does not target Develop`.
+- Updated the canonical bats fixture's push branches to `[main, master, Develop]` and
+  the "passes on the canonical fixture" assertion to expect
+  `push trigger targets the default branch (Develop)`.
+- All 12 bats tests pass, including test #12 which runs the validator against the real
+  repository workflow.

--- a/scripts/check-markdown-lint-workflow.sh
+++ b/scripts/check-markdown-lint-workflow.sh
@@ -118,4 +118,23 @@ else
   fail "markdownlint-cli2 is not invoked — no 'run: markdownlint-cli2' step found"
 fi
 
+# 6. push trigger targets the default branch (Develop). Issue #207 — the repo
+#    default is `Develop`, so a push trigger limited to main/master never fires.
+#    Capture the first `branches:` line inside the `push:` block and require it
+#    to list `Develop`.
+if grep -qE '^[[:space:]]+push:' "$WORKFLOW"; then
+  push_branches="$(awk '
+    /^[[:space:]]+push:[[:space:]]*$/ { in_push = 1; next }
+    in_push && /branches:/ { print; exit }
+    in_push && /^[^[:space:]#]/ { exit }
+  ' "$WORKFLOW")"
+  if [[ -z "$push_branches" ]]; then
+    fail "push trigger has no branches list — cannot confirm Develop is covered"
+  elif echo "$push_branches" | grep -q 'Develop'; then
+    ok "push trigger targets the default branch (Develop)"
+  else
+    fail "push trigger does not target Develop — pushes to the default branch are not linted"
+  fi
+fi
+
 exit "$EXIT_CODE"

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -28,7 +28,7 @@ on:
   pull_request:
     branches: ["*"]
   push:
-    branches: [main, master]
+    branches: [main, master, Develop]
 
 permissions:
   contents: read
@@ -58,6 +58,16 @@ EOF
   [[ "$output" == *"actions/setup-node pinned"* ]]
   [[ "$output" == *"markdownlint-cli2 install step present"* ]]
   [[ "$output" == *"markdownlint-cli2 invoked"* ]]
+  [[ "$output" == *"push trigger targets the default branch (Develop)"* ]]
+}
+
+@test "fails when the push trigger omits Develop (Issue #207)" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  sed -i.bak 's|branches: \[main, master, Develop\]|branches: [main, master]|' \
+    "$TMP_WF/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"push trigger does not target Develop"* ]]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {


### PR DESCRIPTION
## Summary

The `markdown-lint.yml` workflow's `push` trigger listed `branches: [main, master]`,
but this repo's default branch is `Develop` (per `.vibe_default_branch` and
`origin/HEAD`) — neither `main` nor `master` exists. As a result the markdown-lint
`push` trigger never fired; markdown lint only ran on pull requests, never on pushes
to the actual default branch.

This change sets the `push` branches to `[main, master, Develop]`, matching the
existing `actionlint.yml` for symmetry, so markdown lint now runs on pushes to
`Develop`. The legacy `main`/`master` names are kept harmlessly for parity. Closes #207.

```mermaid
flowchart LR
    P[Push to Develop] -->|before: [main, master]| X[Trigger never fires]
    P -->|after: [main, master, Develop]| R[Markdown Lint runs]
```

## Evidence

This is a CI/workflow change with no web interface, so no screenshot applies.
Verification was done via workflow inspection and the validator script:

- `actionlint .github/workflows/markdown-lint.yml` → **OK** (workflow valid).
- `python3 -c "import yaml; yaml.safe_load(...)"` → **YAML valid**.
- `scripts/check-markdown-lint-workflow.sh` (no args, validates the real workflow)
  reports **`OK ... push trigger targets the default branch (Develop)`** and exits 0.

The validator (`scripts/check-markdown-lint-workflow.sh`) gained a new rule (#6)
that captures the first `branches:` line inside the `push:` block and fails unless
it lists `Develop`, guarding against this regression recurring.

### Unrelated pre-existing failure

`./quality.sh` reports one failing Rust test,
`gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
(`rust_scorer/tests/directory_mode_tdd.rs`). It is environment-specific (a Metal GPU
is present, so the oversized creature scores on `metal` instead of `cpu-fallback`)
and was confirmed to fail identically with my changes stashed. It is unrelated to
this workflow/bash change and out of scope for #207.

## Test Plan

- Added `tests/scripts/markdown_lint_workflow.bats::"fails when the push trigger omits Develop (Issue #207)"`
  — mutates the canonical fixture back to `[main, master]` and asserts the validator
  exits non-zero with `push trigger does not target Develop`.
- Updated the canonical bats fixture's push branches to `[main, master, Develop]` and
  the "passes on the canonical fixture" assertion to expect
  `push trigger targets the default branch (Develop)`.
- All 12 bats tests pass, including test #12 which runs the validator against the real
  repository workflow.
