### PR TITLE
CI: install cargo tools from prebuilt binaries (Issue #208)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -47,8 +47,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+      # Fetch a prebuilt cargo-audit binary instead of compiling from source
+      # on every run (Issue #208). Installs in seconds; no `cargo install`
+      # build. taiki-e/install-action resolves a released binary, matching
+      # the prior unversioned `cargo install` behaviour.
+      - name: Install cargo-audit (prebuilt binary)
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+        with:
+          tool: cargo-audit
 
       - name: Run cargo audit
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+      # Fetch a prebuilt cargo-deny binary instead of compiling from source
+      # on every run (Issue #208). taiki-e/install-action resolves a released
+      # binary in seconds, matching the prior unversioned `cargo install`.
+      - name: Install cargo-deny (prebuilt binary)
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+        with:
+          tool: cargo-deny
 
       - name: cargo deny
         run: cargo deny check

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -66,8 +66,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18
 
-      - name: Install cargo-cyclonedx
-        run: cargo install cargo-cyclonedx --locked
+      # Fetch a prebuilt cargo-cyclonedx binary instead of compiling from
+      # source on every run (Issue #208). taiki-e/install-action resolves a
+      # released binary in seconds, matching the prior unversioned
+      # `cargo install` behaviour.
+      - name: Install cargo-cyclonedx (prebuilt binary)
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+        with:
+          tool: cargo-cyclonedx
 
       - name: Generate CycloneDX SBOM
         # Reads Cargo.lock / resolved workspace metadata and emits a standard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,8 +59,13 @@ jobs:
 
       # Belt-and-braces: run cargo-audit directly so the job fails hard on
       # advisories even if the action's annotation path is disabled.
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+      # Fetch a prebuilt cargo-audit binary instead of compiling from source
+      # on every run (Issue #208). taiki-e/install-action resolves a released
+      # binary in seconds, matching the prior unversioned `cargo install`.
+      - name: Install cargo-audit (prebuilt binary)
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+        with:
+          tool: cargo-audit
 
       - name: Run cargo audit
         run: cargo audit

--- a/README.md
+++ b/README.md
@@ -570,6 +570,16 @@ flowchart LR
     cdx --> art[upload-artifact<br/>name: sbom]
 ```
 
+CI installs its cargo CLI tools from **prebuilt binaries**, not from source
+(Issue #208). `cargo-audit` (`cargo-audit.yml`, `security.yml`),
+`cargo-cyclonedx` (`sbom.yml`), and `cargo-deny` (`ci.yml`) are fetched via
+`taiki-e/install-action` — a released binary downloads in seconds, where
+`cargo install <tool> --locked` recompiled the tool from source on every run
+with no behaviour change. The action is SHA-pinned like every other `uses:`
+(supply-chain policy, Issue #100). The invariant is enforced by
+`scripts/check-prebuilt-tool-install.sh` (invoked from `quality.sh`) and
+covered end-to-end by `tests/scripts/prebuilt_tool_install.bats`.
+
 A standalone Cargo Quality workflow (`.github/workflows/cargo-quality.yml`,
 Issue #66) runs `cargo fmt --check` and `cargo clippy -- -D warnings` on
 pull requests against **any** branch (`branches: ["*"]`). `ci.yml` only

--- a/docs/archive/pr-summaries/pr-summary-208.md
+++ b/docs/archive/pr-summaries/pr-summary-208.md
@@ -1,0 +1,100 @@
+# CI: install cargo tools from prebuilt binaries (Issue #208)
+
+## Summary
+
+Four workflows recompiled a cargo CLI tool from source on every run via
+`cargo install <tool> --locked`, costing minutes of CI wall-clock with no
+behaviour change. They now fetch a **prebuilt release binary** through
+`taiki-e/install-action`, which installs in seconds. Closes #208.
+
+Changed workflows (part of #198):
+
+| Workflow | Tool | Before | After |
+| --- | --- | --- | --- |
+| `cargo-audit.yml` | `cargo-audit` | `cargo install cargo-audit --locked` | `taiki-e/install-action` |
+| `security.yml` | `cargo-audit` | `cargo install cargo-audit --locked` | `taiki-e/install-action` |
+| `sbom.yml` | `cargo-cyclonedx` | `cargo install cargo-cyclonedx --locked` | `taiki-e/install-action` |
+| `ci.yml` | `cargo-deny` | `cargo install cargo-deny --locked` | `taiki-e/install-action` |
+
+All three tools have native prebuilt manifests in `taiki-e/install-action`, so
+no source compile or `cargo-binstall` fallback is needed.
+
+### Acceptance criteria
+
+- **No source compile on a cache hit** — `taiki-e/install-action` downloads a
+  released binary; there is no `cargo install` build step left in any of the
+  four workflows.
+- **Versions stay pinned/`--locked`-equivalent** — the prior steps were
+  unversioned (`--locked` pins the tool's *own* build lockfile, not a tool
+  version), so they installed the latest release. `taiki-e/install-action`
+  with no version resolves the latest release binary — equivalent behaviour.
+- **Supply-chain policy intact** — the action is SHA-pinned to
+  `7a79fe8c3a13344501c80d99cae481c1c9085912` (`v2.81.10`) with a trailing
+  version comment, and added to the Node 24 policy table in
+  `scripts/check-workflow-action-versions.sh` (`required:2`).
+- **CI wall-clock drops** — a `cargo install` of these tools compiles the tool
+  plus its dependency tree (minutes); a prebuilt binary download is seconds.
+  `cargo-audit.yml`, `security.yml`, and `sbom.yml` previously had no
+  `actions/cache` at all, so every run paid the full build cost.
+
+## Evidence
+
+This is a CI/tooling change — no web interface to screenshot. Verified via the
+new validator and the existing workflow-policy gates:
+
+```text
+$ ./scripts/check-prebuilt-tool-install.sh
+OK   .../cargo-audit.yml: no 'cargo install cargo-audit' source compile
+OK   .../cargo-audit.yml: installs cargo-audit via prebuilt taiki-e/install-action
+OK   .../security.yml:   no 'cargo install cargo-audit' source compile
+OK   .../security.yml:   installs cargo-audit via prebuilt taiki-e/install-action
+OK   .../sbom.yml:       no 'cargo install cargo-cyclonedx' source compile
+OK   .../sbom.yml:       installs cargo-cyclonedx via prebuilt taiki-e/install-action
+OK   .../ci.yml:         no 'cargo install cargo-deny' source compile
+OK   .../ci.yml:         installs cargo-deny via prebuilt taiki-e/install-action
+
+$ ./scripts/check-workflow-action-versions.sh   # taiki-e/install-action >= v2, SHA-pinned
+```
+
+`actionlint` passes on all four edited workflows.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        A[cargo install tool --locked] --> B[compile from source<br/>minutes]
+    end
+    subgraph After
+        C[taiki-e/install-action<br/>tool: ...] --> D[download prebuilt binary<br/>seconds]
+    end
+```
+
+## Test Plan
+
+TDD: the validator and its BATS suite were written first (red), then the
+workflows were updated to make them pass (green).
+
+- Added `scripts/check-prebuilt-tool-install.sh` — fails if a workflow
+  compiles a tool via `cargo install <tool>` or lacks a matching
+  `taiki-e/install-action` prebuilt step. Wired into `quality.sh`.
+- Added `tests/scripts/prebuilt_tool_install.bats` — covers the happy path
+  (prebuilt install), the regression (source compile rejected), a missing
+  install step, a missing file, argument validation, a directory of canonical
+  workflows, and the real repository workflows.
+- Updated `scripts/check-workflow-action-versions.sh` policy to require
+  `taiki-e/install-action` at `>= v2` and SHA-pinned; existing
+  `tests/scripts/workflow_action_versions.bats` continues to pass.
+- Existing `tests/scripts/cargo_audit_workflow.bats` and
+  `tests/scripts/sbom_workflow.bats` still pass — the `cargo audit` /
+  `cargo cyclonedx` run steps are unchanged.
+- `./quality.sh` shell/CI gates pass: shellcheck, every workflow validator
+  (including the new one), the full bats suite, cargo-deny, fmt, clippy, check
+  and build. This change touches **no Rust** (only workflow YAML, shell
+  scripts, BATS tests and docs), so the compiled behaviour is unchanged.
+
+  > Note: the unrelated GPU test
+  > `directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
+  > fails on the dev machine because it has a Metal GPU that hosts the
+  > oversized creature (`gpuBackend: "metal"`) instead of taking the
+  > CPU-fallback path the test asserts. It is hardware-specific and
+  > independent of this CI-only change — CI runners (Linux, no Metal) are
+  > unaffected.

--- a/quality.sh
+++ b/quality.sh
@@ -50,6 +50,9 @@ echo "🦀 Validating Cargo Security Audit workflow (Issue #64)..."
 echo "📋 Validating SBOM workflow (Issue #172)..."
 ./scripts/check-sbom-workflow.sh
 
+echo "⚡ Validating prebuilt cargo tool installs in CI (Issue #208)..."
+./scripts/check-prebuilt-tool-install.sh
+
 echo "🧹 Validating Cargo Quality (fmt + clippy) workflow (Issue #66)..."
 ./scripts/check-cargo-quality-workflow.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.62"
+version = "0.5.63"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-prebuilt-tool-install.sh
+++ b/scripts/check-prebuilt-tool-install.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Validate that cargo CLI tools are installed from prebuilt binaries, not
+# compiled from source on every CI run (Issue #208, part of #198).
+#
+# Why this exists:
+#   Four workflows install a cargo CLI tool before using it:
+#     * cargo-audit.yml — cargo-audit
+#     * security.yml    — cargo-audit
+#     * sbom.yml        — cargo-cyclonedx
+#     * ci.yml          — cargo-deny
+#   `cargo install <tool> --locked` recompiles the tool from source on every
+#   run, costing minutes of wasted CI wall-clock with no behaviour change.
+#   `taiki-e/install-action` downloads a prebuilt release binary instead, so
+#   the install step finishes in seconds.
+#
+# Rules enforced per (workflow, tool) pair:
+#   1. The workflow MUST NOT compile the tool from source via
+#      `cargo install <tool>` — that is the regression this issue removes.
+#   2. The workflow MUST install the tool via `taiki-e/install-action` with a
+#      matching `tool:` entry, so a prebuilt binary is fetched instead.
+#
+# Modes:
+#   * `--workflow PATH --tool NAME` — validate a single file/tool pair (used
+#     by BATS fixtures).
+#   * no arguments — validate the four canonical (workflow, tool) pairs under
+#     `.github/workflows` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-prebuilt-tool-install.sh [--workflow PATH --tool NAME] [--workflows DIR]
+
+Options:
+  --workflow PATH   Path to a single workflow YAML file to validate. Requires
+                    --tool. When omitted, the four canonical workflows are
+                    validated.
+  --tool NAME       Cargo tool name expected to be installed as a prebuilt
+                    binary (e.g. cargo-audit). Only valid with --workflow.
+  --workflows DIR   Directory holding the canonical workflows (default:
+                    .github/workflows relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when every checked (workflow, tool) pair installs the tool from a
+prebuilt binary and not from source. Exits non-zero otherwise.
+EOF
+}
+
+WORKFLOW=""
+TOOL=""
+WORKFLOWS_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    --tool)
+      TOOL="$2"
+      shift 2
+      ;;
+    --workflows)
+      WORKFLOWS_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $1: $2" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $1: $2"
+}
+
+# Validate a single (workflow file, tool) pair against the two rules.
+check_pair() {
+  local file="$1"
+  local tool="$2"
+
+  if [[ ! -f "$file" ]]; then
+    fail "$file" "workflow file not found"
+    return
+  fi
+
+  # Rule 1: no source compile via `cargo install <tool>`.
+  if grep -qE "cargo[[:space:]]+install[[:space:]]+${tool}([[:space:]]|$)" "$file"; then
+    fail "$file" "compiles $tool from source via 'cargo install $tool' — use a prebuilt binary"
+  else
+    ok "$file" "no 'cargo install $tool' source compile"
+  fi
+
+  # Rule 2: prebuilt install via taiki-e/install-action with a matching tool.
+  if grep -qE 'uses:[[:space:]]*taiki-e/install-action@' "$file" \
+    && grep -qE "tool:[[:space:]]*${tool}([[:space:]]|,|$)" "$file"; then
+    ok "$file" "installs $tool via prebuilt taiki-e/install-action"
+  else
+    fail "$file" "no prebuilt taiki-e/install-action step for $tool"
+  fi
+}
+
+if [[ -n "$WORKFLOW" || -n "$TOOL" ]]; then
+  if [[ -z "$WORKFLOW" || -z "$TOOL" ]]; then
+    echo "--workflow and --tool must be supplied together" >&2
+    usage >&2
+    exit 2
+  fi
+  check_pair "$WORKFLOW" "$TOOL"
+  exit "$EXIT_CODE"
+fi
+
+if [[ -z "$WORKFLOWS_DIR" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
+fi
+
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
+  exit 2
+fi
+
+# Canonical (workflow, tool) pairs. bash 3.2 has no associative arrays, so a
+# parallel-indexed pair list is used.
+PAIRS=(
+  "cargo-audit.yml:cargo-audit"
+  "security.yml:cargo-audit"
+  "sbom.yml:cargo-cyclonedx"
+  "ci.yml:cargo-deny"
+)
+
+for pair in "${PAIRS[@]}"; do
+  wf="${pair%%:*}"
+  tool="${pair#*:}"
+  check_pair "$WORKFLOWS_DIR/$wf" "$tool"
+done
+
+exit "$EXIT_CODE"

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -121,6 +121,9 @@ lookup_policy() {
     # Node 24, post upstream #48)`. Issue #136 cleared the Node 20 exception
     # when we adopted that SHA.
     rustsec/audit-check)              echo "required:2" ;;
+    # taiki-e/install-action installs prebuilt cargo tool binaries (Issue
+    # #208), replacing source compiles. The v2 line ships a Node 24 runtime.
+    taiki-e/install-action)           echo "required:2" ;;
     # dtolnay/rust-toolchain is a composite/shell action. No Node runtime,
     # so the Node 24 deprecation does not apply.
     dtolnay/rust-toolchain)           echo "no-node" ;;

--- a/tests/scripts/prebuilt_tool_install.bats
+++ b/tests/scripts/prebuilt_tool_install.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-prebuilt-tool-install.sh — Issue #208.
+#
+# Verifies that the validator distinguishes a prebuilt-binary install
+# (taiki-e/install-action) from a source compile (cargo install <tool>) using
+# synthetic workflow YAML, so the real workflows can change without coupling
+# the unit tests to their exact contents.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-prebuilt-tool-install.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# A workflow that installs the tool from a prebuilt binary (the desired state).
+write_prebuilt_workflow() {
+  local file="$1"
+  local tool="$2"
+  cat >"$file" <<EOF
+name: Example
+on: [push]
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+        with:
+          tool: ${tool}
+EOF
+}
+
+# A workflow that compiles the tool from source (the regression to reject).
+write_source_workflow() {
+  local file="$1"
+  local tool="$2"
+  cat >"$file" <<EOF
+name: Example
+on: [push]
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - run: cargo install ${tool} --locked
+EOF
+}
+
+@test "passes when the tool is installed via taiki-e/install-action" {
+  write_prebuilt_workflow "$TMP_WF/wf.yml" "cargo-audit"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml" --tool cargo-audit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"installs cargo-audit via prebuilt taiki-e/install-action"* ]]
+  [[ "$output" == *"no 'cargo install cargo-audit' source compile"* ]]
+}
+
+@test "fails when the tool is compiled from source via cargo install" {
+  write_source_workflow "$TMP_WF/wf.yml" "cargo-cyclonedx"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml" --tool cargo-cyclonedx
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"compiles cargo-cyclonedx from source"* ]]
+}
+
+@test "fails when no prebuilt install step is present" {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+on: [push]
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml" --tool cargo-deny
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no prebuilt taiki-e/install-action step for cargo-deny"* ]]
+}
+
+@test "reports a missing workflow file" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/nope.yml" --tool cargo-audit
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "requires --tool alongside --workflow" {
+  write_prebuilt_workflow "$TMP_WF/wf.yml" "cargo-audit"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be supplied together"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "validates a directory of canonical workflows" {
+  mkdir -p "$TMP_WF/wf"
+  write_prebuilt_workflow "$TMP_WF/wf/cargo-audit.yml" "cargo-audit"
+  write_prebuilt_workflow "$TMP_WF/wf/security.yml" "cargo-audit"
+  write_prebuilt_workflow "$TMP_WF/wf/sbom.yml" "cargo-cyclonedx"
+  write_prebuilt_workflow "$TMP_WF/wf/ci.yml" "cargo-deny"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/wf"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "real repository workflows install tools from prebuilt binaries" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# CI: install cargo tools from prebuilt binaries (Issue #208)

## Summary

Four workflows recompiled a cargo CLI tool from source on every run via
`cargo install <tool> --locked`, costing minutes of CI wall-clock with no
behaviour change. They now fetch a **prebuilt release binary** through
`taiki-e/install-action`, which installs in seconds. Closes #208.

Changed workflows (part of #198):

| Workflow | Tool | Before | After |
| --- | --- | --- | --- |
| `cargo-audit.yml` | `cargo-audit` | `cargo install cargo-audit --locked` | `taiki-e/install-action` |
| `security.yml` | `cargo-audit` | `cargo install cargo-audit --locked` | `taiki-e/install-action` |
| `sbom.yml` | `cargo-cyclonedx` | `cargo install cargo-cyclonedx --locked` | `taiki-e/install-action` |
| `ci.yml` | `cargo-deny` | `cargo install cargo-deny --locked` | `taiki-e/install-action` |

All three tools have native prebuilt manifests in `taiki-e/install-action`, so
no source compile or `cargo-binstall` fallback is needed.

### Acceptance criteria

- **No source compile on a cache hit** — `taiki-e/install-action` downloads a
  released binary; there is no `cargo install` build step left in any of the
  four workflows.
- **Versions stay pinned/`--locked`-equivalent** — the prior steps were
  unversioned (`--locked` pins the tool's *own* build lockfile, not a tool
  version), so they installed the latest release. `taiki-e/install-action`
  with no version resolves the latest release binary — equivalent behaviour.
- **Supply-chain policy intact** — the action is SHA-pinned to
  `7a79fe8c3a13344501c80d99cae481c1c9085912` (`v2.81.10`) with a trailing
  version comment, and added to the Node 24 policy table in
  `scripts/check-workflow-action-versions.sh` (`required:2`).
- **CI wall-clock drops** — a `cargo install` of these tools compiles the tool
  plus its dependency tree (minutes); a prebuilt binary download is seconds.
  `cargo-audit.yml`, `security.yml`, and `sbom.yml` previously had no
  `actions/cache` at all, so every run paid the full build cost.

## Evidence

This is a CI/tooling change — no web interface to screenshot. Verified via the
new validator and the existing workflow-policy gates:

```text
$ ./scripts/check-prebuilt-tool-install.sh
OK   .../cargo-audit.yml: no 'cargo install cargo-audit' source compile
OK   .../cargo-audit.yml: installs cargo-audit via prebuilt taiki-e/install-action
OK   .../security.yml:   no 'cargo install cargo-audit' source compile
OK   .../security.yml:   installs cargo-audit via prebuilt taiki-e/install-action
OK   .../sbom.yml:       no 'cargo install cargo-cyclonedx' source compile
OK   .../sbom.yml:       installs cargo-cyclonedx via prebuilt taiki-e/install-action
OK   .../ci.yml:         no 'cargo install cargo-deny' source compile
OK   .../ci.yml:         installs cargo-deny via prebuilt taiki-e/install-action

$ ./scripts/check-workflow-action-versions.sh   # taiki-e/install-action >= v2, SHA-pinned
```

`actionlint` passes on all four edited workflows.

```mermaid
flowchart LR
    subgraph Before
        A[cargo install tool --locked] --> B[compile from source<br/>minutes]
    end
    subgraph After
        C[taiki-e/install-action<br/>tool: ...] --> D[download prebuilt binary<br/>seconds]
    end
```

## Test Plan

TDD: the validator and its BATS suite were written first (red), then the
workflows were updated to make them pass (green).

- Added `scripts/check-prebuilt-tool-install.sh` — fails if a workflow
  compiles a tool via `cargo install <tool>` or lacks a matching
  `taiki-e/install-action` prebuilt step. Wired into `quality.sh`.
- Added `tests/scripts/prebuilt_tool_install.bats` — covers the happy path
  (prebuilt install), the regression (source compile rejected), a missing
  install step, a missing file, argument validation, a directory of canonical
  workflows, and the real repository workflows.
- Updated `scripts/check-workflow-action-versions.sh` policy to require
  `taiki-e/install-action` at `>= v2` and SHA-pinned; existing
  `tests/scripts/workflow_action_versions.bats` continues to pass.
- Existing `tests/scripts/cargo_audit_workflow.bats` and
  `tests/scripts/sbom_workflow.bats` still pass — the `cargo audit` /
  `cargo cyclonedx` run steps are unchanged.
- `./quality.sh` shell/CI gates pass: shellcheck, every workflow validator
  (including the new one), the full bats suite, cargo-deny, fmt, clippy, check
  and build. This change touches **no Rust** (only workflow YAML, shell
  scripts, BATS tests and docs), so the compiled behaviour is unchanged.

  > Note: the unrelated GPU test
  > `directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`
  > fails on the dev machine because it has a Metal GPU that hosts the
  > oversized creature (`gpuBackend: "metal"`) instead of taking the
  > CPU-fallback path the test asserts. It is hardware-specific and
  > independent of this CI-only change — CI runners (Linux, no Metal) are
  > unaffected.
