### PR TITLE
Align README "matches CI" block with the CI quality job (Issue #212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ Or step-by-step (matches CI):
 export RUSTFLAGS="-D warnings"
 cargo deny check
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::filter_next -D clippy::collapsible_if
-cargo test --workspace --all-features
-cargo build --release -p rust_scorer
+cargo clippy --all-targets --all-features -- \
+  -D warnings \
+  -D clippy::filter_next \
+  -D clippy::collapsible_if
+cargo check --all-targets --all-features
+cargo build --workspace
+cargo test --workspace --all-features --verbose -- --test-threads=2
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 ```
 
 Requires **shellcheck**, **cargo-deny** (`cargo install cargo-deny --locked`), **codespell** (`pip install --user codespell`, used by `scripts/spell-check.sh`), and optionally **cargo-edit** for the **opt-in** upgrade step in `./quality.sh`

--- a/docs/archive/pr-summaries/pr-summary-212.md
+++ b/docs/archive/pr-summaries/pr-summary-212.md
@@ -1,0 +1,87 @@
+# Align README "step-by-step (matches CI)" block with the CI quality job
+
+## Summary
+
+The README "Or step-by-step (matches CI):" command block (README.md:19-31)
+drifted from the CI `quality` job in `.github/workflows/ci.yml`. A contributor
+copy-pasting it to "reproduce CI" got a **weaker** gate: it omitted
+`cargo check`, the rustdoc gate (`RUSTDOCFLAGS="-D warnings" cargo doc`), and the
+workspace debug build, and it ran `cargo clippy --workspace …` instead of CI's
+`cargo clippy --all-targets --all-features …`.
+
+This PR realigns the README block **step-for-step** with the CI `quality` job
+and adds a drift guard so the two cannot silently diverge again. Closes #212.
+
+Changes:
+
+- **README.md** — the block now matches the CI quality steps exactly, in order:
+  `RUSTFLAGS="-D warnings"`, `cargo deny check`, `cargo fmt --all -- --check`,
+  `cargo clippy --all-targets --all-features -- -D warnings -D clippy::filter_next -D clippy::collapsible_if`,
+  `cargo check --all-targets --all-features`, `cargo build --workspace`,
+  `cargo test --workspace --all-features --verbose -- --test-threads=2`, and
+  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`.
+- **scripts/check-readme-ci-alignment.sh** — new validator (matching the repo's
+  `check-*.sh` convention) that extracts the README "matches CI" block and
+  asserts every canonical CI quality command is present, and that the weaker
+  `cargo clippy --workspace` form is not used. Exits non-zero on drift.
+- **quality.sh** — invokes the new validator alongside the other workflow
+  checks, so local runs and CI catch future drift.
+- **tests/scripts/readme_ci_alignment.bats** — behavioural bats tests for the
+  validator.
+
+### Drift guard flow
+
+```mermaid
+flowchart LR
+    A[README<br/>matches-CI block] --> V[check-readme-ci-alignment.sh]
+    B[ci.yml quality job<br/>canonical commands] --> V
+    V -->|aligned| OK[exit 0]
+    V -->|drift / weaker clippy| FAIL[exit 1]
+    Q[quality.sh] --> V
+```
+
+## Evidence
+
+CLI/docs change — no web interface to screenshot.
+
+- `./scripts/check-readme-ci-alignment.sh` passes against the updated README:
+
+  ```text
+  OK   README block includes: RUSTFLAGS="-D warnings"
+  OK   README block includes: cargo deny check
+  OK   README block includes: cargo fmt --all -- --check
+  OK   README block includes: cargo clippy --all-targets --all-features -- -D warnings -D clippy::filter_next -D clippy::collapsible_if
+  OK   README block includes: cargo check --all-targets --all-features
+  OK   README block includes: cargo build --workspace
+  OK   README block includes: cargo test --workspace --all-features
+  OK   README block includes: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+  README 'matches CI' block matches the CI quality job.
+  ```
+
+- Before the README fix, the same validator reported the missing `cargo check`,
+  `cargo doc`, `cargo build --workspace`, and the weaker clippy invocation
+  (`FAIL README clippy uses '--workspace'`).
+- `bats tests/scripts` — all 293 tests pass (9 new in
+  `readme_ci_alignment.bats`).
+- `shellcheck --severity=warning` clean on the new script and `quality.sh`.
+- `./scripts/spell-check.sh` (codespell) — no typos.
+
+### Note on a pre-existing, unrelated test failure
+
+`./quality.sh` was run locally. The Rust suite reports one failure,
+`directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`,
+which is **unrelated to this PR** — this change touches only documentation and
+shell tooling, no Rust. The test asserts an oversized creature falls back to
+`cpu-fallback`, but on the local Apple **Metal** GPU the scratch kernel
+(Issue #182) hosts it on the GPU (`gpuBackend: "metal"`). CI runs on GPU-less
+`ubuntu-latest`, where the CPU fallback path is taken and the test passes.
+
+## Test Plan
+
+- Added `tests/scripts/readme_ci_alignment.bats` (9 cases): aligned README
+  passes; missing rustdoc gate / `cargo check` / workspace build each fail;
+  weaker `--workspace` clippy fails; absent block fails; missing file errors;
+  unknown flag exits 2; and the real repository README satisfies the check.
+- Verified the validator fails against the pre-fix README and passes after the
+  fix.
+- Full `bats tests/scripts` suite passes (293 tests).

--- a/quality.sh
+++ b/quality.sh
@@ -92,6 +92,9 @@ echo "⏱️  Validating per-job timeout-minutes across workflows (Issue #154)..
 echo "🔁 Validating concurrency groups on pile-up-prone workflows (Issue #156)..."
 ./scripts/check-workflow-concurrency.sh
 
+echo "📖 Validating README 'matches CI' block aligns with the CI quality job (Issue #212)..."
+./scripts/check-readme-ci-alignment.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.63"
+version = "0.5.64"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-readme-ci-alignment.sh
+++ b/scripts/check-readme-ci-alignment.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# check-readme-ci-alignment.sh — Issue #212.
+#
+# Guards against drift between the README "step-by-step (matches CI)" command
+# block and the CI `quality` job in .github/workflows/ci.yml. A contributor
+# copy-pasting the README block to "reproduce CI" must run the same gate CI
+# runs — no weaker, no different.
+#
+# The check extracts the fenced bash block that follows the
+# "Or step-by-step (matches CI):" heading in README.md, collapses line
+# continuations and whitespace, and asserts every canonical CI quality command
+# is present. It does NOT parse ci.yml — the canonical command list below is
+# the single source of truth, kept deliberately small and explicit so a drift
+# in either file is obvious in review.
+#
+# Usage:
+#   check-readme-ci-alignment.sh [--readme PATH]
+#
+# Exit codes:
+#   0  README block matches every canonical CI quality command
+#   1  one or more commands missing, or the block could not be found
+#   2  usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+README="$REPO_ROOT/README.md"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --readme)
+      [ $# -ge 2 ] || { echo "Usage: $0 [--readme PATH]" >&2; exit 2; }
+      README="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--readme PATH]"
+      exit 0
+      ;;
+    *)
+      echo "Usage: $0 [--readme PATH]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "$README" ]; then
+  echo "FAIL: README not found: $README" >&2
+  exit 1
+fi
+
+# Canonical CI `quality` job commands (see .github/workflows/ci.yml). Each entry
+# is matched as a substring against the whitespace-collapsed README block.
+# Keep this list aligned with the workflow when CI steps change.
+canonical_commands=(
+  'RUSTFLAGS="-D warnings"'
+  'cargo deny check'
+  'cargo fmt --all -- --check'
+  'cargo clippy --all-targets --all-features -- -D warnings -D clippy::filter_next -D clippy::collapsible_if'
+  'cargo check --all-targets --all-features'
+  'cargo build --workspace'
+  'cargo test --workspace --all-features'
+  'RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps'
+)
+
+# Extract the bash code block immediately following the "matches CI" heading.
+block="$(awk '
+  /Or step-by-step \(matches CI\):/ { seen = 1; next }
+  seen && /^```/ { if (infence) { exit } else { infence = 1; next } }
+  seen && infence { print }
+' "$README")"
+
+if [ -z "$block" ]; then
+  echo "FAIL: could not find the 'matches CI' bash block in $README" >&2
+  exit 1
+fi
+
+# Collapse backslash line continuations and runs of whitespace to single spaces
+# so multi-line invocations (e.g. clippy) match the canonical single-line form.
+collapsed="$(printf '%s\n' "$block" | tr '\n' ' ' | sed 's/\\ / /g' | tr -s ' ')"
+
+fail=0
+for cmd in "${canonical_commands[@]}"; do
+  if [[ "$collapsed" == *"$cmd"* ]]; then
+    echo "OK   README block includes: $cmd"
+  else
+    echo "FAIL README block missing CI command: $cmd" >&2
+    fail=1
+  fi
+done
+
+# The standalone `--workspace` clippy form is weaker than CI's invocation and
+# must not be the one a contributor copies. CI runs clippy without --workspace.
+if [[ "$collapsed" == *"cargo clippy --workspace"* ]]; then
+  echo "FAIL README clippy uses '--workspace'; CI uses '--all-targets --all-features'" >&2
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "README 'matches CI' block has drifted from the CI quality job." >&2
+  exit 1
+fi
+
+echo "README 'matches CI' block matches the CI quality job."

--- a/tests/scripts/readme_ci_alignment.bats
+++ b/tests/scripts/readme_ci_alignment.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-readme-ci-alignment.sh — Issue #212.
+#
+# Verifies the validator that keeps the README "step-by-step (matches CI)"
+# block aligned with the CI `quality` job. Synthetic README fixtures in a temp
+# directory exercise the pass/fail behaviour (exit codes, reported output) so
+# the real README is not mutated by the tests.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-readme-ci-alignment.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export REPO_ROOT
+
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Canonical README fixture whose "matches CI" block lists every CI quality
+# command. Failure tests mutate this to drop or weaken one command at a time.
+write_aligned_readme() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+# Title
+
+Or step-by-step (matches CI):
+
+```bash
+export RUSTFLAGS="-D warnings"
+cargo deny check
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- \
+  -D warnings \
+  -D clippy::filter_next \
+  -D clippy::collapsible_if
+cargo check --all-targets --all-features
+cargo build --workspace
+cargo test --workspace --all-features --verbose -- --test-threads=2
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+```
+
+Trailing prose.
+EOF
+}
+
+@test "passes on a fully aligned README block" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"matches the CI quality job"* ]]
+}
+
+@test "fails when the rustdoc gate is missing" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  sed -i.bak '/cargo doc/d' "$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cargo doc"* ]]
+}
+
+@test "fails when cargo check is missing" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  sed -i.bak '/cargo check/d' "$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cargo check --all-targets --all-features"* ]]
+}
+
+@test "fails when the workspace debug build is missing" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  sed -i.bak '/cargo build --workspace/d' "$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cargo build --workspace"* ]]
+}
+
+@test "fails when clippy uses the weaker --workspace form instead of CI's" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  # Replace the CI clippy invocation with the weaker --workspace-only variant.
+  python3 - "$TMP_DIR/README.md" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "cargo clippy --all-targets --all-features -- \\\n"
+    "  -D warnings \\\n"
+    "  -D clippy::filter_next \\\n"
+    "  -D clippy::collapsible_if",
+    "cargo clippy --workspace -- -D warnings",
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--workspace"* ]]
+}
+
+@test "fails when the matches-CI block is absent" {
+  cat >"$TMP_DIR/README.md" <<'EOF'
+# Title
+
+No matching block here.
+EOF
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not find"* ]]
+}
+
+@test "reports an error when the README file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/does-not-exist.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "the real repository README satisfies the alignment check" {
+  run "$SCRIPT_UNDER_TEST" --readme "$REPO_ROOT/README.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Align README "step-by-step (matches CI)" block with the CI quality job

## Summary

The README "Or step-by-step (matches CI):" command block (README.md:19-31)
drifted from the CI `quality` job in `.github/workflows/ci.yml`. A contributor
copy-pasting it to "reproduce CI" got a **weaker** gate: it omitted
`cargo check`, the rustdoc gate (`RUSTDOCFLAGS="-D warnings" cargo doc`), and the
workspace debug build, and it ran `cargo clippy --workspace …` instead of CI's
`cargo clippy --all-targets --all-features …`.

This PR realigns the README block **step-for-step** with the CI `quality` job
and adds a drift guard so the two cannot silently diverge again. Closes #212.

Changes:

- **README.md** — the block now matches the CI quality steps exactly, in order:
  `RUSTFLAGS="-D warnings"`, `cargo deny check`, `cargo fmt --all -- --check`,
  `cargo clippy --all-targets --all-features -- -D warnings -D clippy::filter_next -D clippy::collapsible_if`,
  `cargo check --all-targets --all-features`, `cargo build --workspace`,
  `cargo test --workspace --all-features --verbose -- --test-threads=2`, and
  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`.
- **scripts/check-readme-ci-alignment.sh** — new validator (matching the repo's
  `check-*.sh` convention) that extracts the README "matches CI" block and
  asserts every canonical CI quality command is present, and that the weaker
  `cargo clippy --workspace` form is not used. Exits non-zero on drift.
- **quality.sh** — invokes the new validator alongside the other workflow
  checks, so local runs and CI catch future drift.
- **tests/scripts/readme_ci_alignment.bats** — behavioural bats tests for the
  validator.

### Drift guard flow

```mermaid
flowchart LR
    A[README<br/>matches-CI block] --> V[check-readme-ci-alignment.sh]
    B[ci.yml quality job<br/>canonical commands] --> V
    V -->|aligned| OK[exit 0]
    V -->|drift / weaker clippy| FAIL[exit 1]
    Q[quality.sh] --> V
```

## Evidence

CLI/docs change — no web interface to screenshot.

- `./scripts/check-readme-ci-alignment.sh` passes against the updated README:

  ```text
  OK   README block includes: RUSTFLAGS="-D warnings"
  OK   README block includes: cargo deny check
  OK   README block includes: cargo fmt --all -- --check
  OK   README block includes: cargo clippy --all-targets --all-features -- -D warnings -D clippy::filter_next -D clippy::collapsible_if
  OK   README block includes: cargo check --all-targets --all-features
  OK   README block includes: cargo build --workspace
  OK   README block includes: cargo test --workspace --all-features
  OK   README block includes: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
  README 'matches CI' block matches the CI quality job.
  ```

- Before the README fix, the same validator reported the missing `cargo check`,
  `cargo doc`, `cargo build --workspace`, and the weaker clippy invocation
  (`FAIL README clippy uses '--workspace'`).
- `bats tests/scripts` — all 293 tests pass (9 new in
  `readme_ci_alignment.bats`).
- `shellcheck --severity=warning` clean on the new script and `quality.sh`.
- `./scripts/spell-check.sh` (codespell) — no typos.

### Note on a pre-existing, unrelated test failure

`./quality.sh` was run locally. The Rust suite reports one failure,
`directory_mode_tdd::gpu_auto_directory_above_shader_cap_falls_back_to_cpu_cleanly`,
which is **unrelated to this PR** — this change touches only documentation and
shell tooling, no Rust. The test asserts an oversized creature falls back to
`cpu-fallback`, but on the local Apple **Metal** GPU the scratch kernel
(Issue #182) hosts it on the GPU (`gpuBackend: "metal"`). CI runs on GPU-less
`ubuntu-latest`, where the CPU fallback path is taken and the test passes.

## Test Plan

- Added `tests/scripts/readme_ci_alignment.bats` (9 cases): aligned README
  passes; missing rustdoc gate / `cargo check` / workspace build each fail;
  weaker `--workspace` clippy fails; absent block fails; missing file errors;
  unknown flag exits 2; and the real repository README satisfies the check.
- Verified the validator fails against the pre-fix README and passes after the
  fix.
- Full `bats tests/scripts` suite passes (293 tests).
