### PR TITLE
fix: widen synapse from_index u16→u32 for GPU mirror

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core stores `from_index` as u16 (≤ u16::MAX); the GPU
+                // mirror and WGSL shader use u32, so widen explicitly.
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Summary

The `rust_scorer` release build was failing with `E0308: mismatched types` at `rust_scorer/src/gpu/forward_mse_batched.rs:228`:

```
228 |                 from_index: s.from_index,
    |                             ^^^^^^^^^^^^^ expected `u32`, found `u16`
```

`neat-core`'s `SynapseData.from_index` is `u16` (`≤ u16::MAX`, see `MAX_NODE_COUNT`), but the GPU mirror `SynapseGpu` and the WGSL shaders (`forward_mse_batched.wgsl`, `forward_mse_scratch.wgsl`) use `u32` — WGSL has no `u16` type. The direct field assignment no longer compiles.

Fix: widen explicitly with `u32::from(s.from_index)`, matching the existing `num_synapses: u32::from(n.num_synapses)` conversion a few lines above. No behavioural change — `from_index` values are bounded by `u16::MAX` so the widening is lossless.

## How it was found

Surfaced by the failing **Unit tests + coverage** check on `stSoftwareAU/NEAT-AI-Examples` PR #606, whose CI checks out and builds `rust_scorer` with `RUSTFLAGS="-D warnings"`.

## Verification

```
$ RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer
    Finished `release` profile

$ cargo test --release -p rust_scorer
    test result: ok. 20 passed; 0 failed
```