### PR TITLE
Fix E0308: widen synapse from_index to u32 for GPU struct

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,7 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Summary

`neat-core` (NEAT-AI-core) declares `SynapseData.from_index` as `u16`, but
the GPU-side `SynapseGpu.from_index` must be `u32` (WGSL has no `u16` type).
The direct assignment `from_index: s.from_index` therefore fails to compile
with `error[E0308]: mismatched types — expected u32, found u16` at
`rust_scorer/src/gpu/forward_mse_batched.rs:228`.

This widens the value explicitly with `u32::from(s.from_index)`, mirroring
the existing `u32::from(n.num_synapses)` conversion a few lines above. The
widening is lossless (`u16` → `u32`).

## Impact

This build break surfaced in the downstream consumer
`stSoftwareAU/NEAT-AI-Examples` PR #604, whose "Unit tests + coverage" job
builds `rust_scorer` against `neat-core@Develop`.

## Verification

`RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer` succeeds
against `NEAT-AI-core@Develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)