### PR TITLE
fix(gpu): widen synapse from_index u16->u32 for neat-core #177

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.65"
+version = "1.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core #177 narrowed `SynapseData::from_index` to `u16`;
+                // the GPU/WGSL layout keeps `from_index` as `u32`, so widen here.
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Problem

`neat-core` narrowed `SynapseData::from_index` from `u32` to `u16` (neat-core Issue #177). `rust_scorer`'s GPU/WGSL `SynapseGpu` layout keeps `from_index` as `u32` (required by the `forward_mse_batched.wgsl` / `forward_mse_scratch.wgsl` shaders), so the direct field assignment in `build_batched_network_data` no longer compiles:

```
error[E0308]: mismatched types
  --> rust_scorer/src/gpu/forward_mse_batched.rs:228:29
   |                             ^^^^^^^^^^^^ expected `u32`, found `u16`
```

This breaks every consumer that builds `rust_scorer` against `NEAT-AI-core@Develop` under `RUSTFLAGS="-D warnings"` — including the downstream CI for `stSoftwareAU/NEAT-AI-Examples` PR #606 (its `Unit tests + coverage` job builds `rust_scorer` at `NEAT-AI-scorer@Develop`).

## Fix

Widen losslessly with `u32::from(s.from_index)`, matching the existing `squash_type` and `num_synapses` conversions a few lines above in the same function. The GPU struct and WGSL shaders intentionally keep `from_index` as `u32`, so widening at upload time is the correct boundary.

## Verification

```
RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer
# Finished `release` profile [optimized] target(s)
```

built clean against `neat-core v0.1.46`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)