### PR TITLE
fix: widen synapse from_index to u32 for neat-core 0.1.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.43"
+version = "0.1.46"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core Issue #177 narrowed SynapseData::from_index to u16;
+                // the GPU mirror (and its WGSL shaders) keep it as u32, so widen.
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Problem

neat-core Issue #177 narrowed `SynapseData::from_index` from `u32` to `u16`. The `rust_scorer` GPU mirror `SynapseGpu` (and its WGSL shaders `forward_mse_batched.wgsl` / `forward_mse_scratch.wgsl`) keep `from_index` as `u32`, so the direct field assignment in `forward_mse_batched.rs:228` no longer type checks:

```
error[E0308]: mismatched types
  --> rust_scorer/src/gpu/forward_mse_batched.rs:228:29
   |  expected `u32`, found `u16`
```

This breaks `RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer`, which is run by the **Unit tests + coverage** check in `stSoftwareAU/NEAT-AI-Examples` (PR #606) against the latest neat-core `Develop`.

## Fix

Widen with `u32::from(s.from_index)`, matching the existing `u32::from(...)` conversions for `squash_type` and `num_synapses` on adjacent lines. The GPU/WGSL layout is unchanged (still `u32`).

## Verification

- `RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer` — passes.
- `cargo test --release -p rust_scorer --no-run` — all test binaries compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)