### PR TITLE
Widen u16 from_index for u32 GPU synapse buffer

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core narrowed SynapseData::from_index to u16 (Issue #177);
+                // widen for the u32 GPU buffer (WGSL has no 16-bit integer type).
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Problem

`RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer` fails:

```
error[E0308]: mismatched types
  --> rust_scorer/src/gpu/forward_mse_batched.rs:228:29
228 |  from_index: s.from_index,
    |              ^^^^^^^^^^^^^ expected `u32`, found `u16`
```

## Root cause

neat-core narrowed `SynapseData::from_index` from `u32` to `u16` (neat-core Issue #177). The GPU mirror `SynapseGpu.from_index` remains `u32` — correct, since WGSL has no 16-bit integer type — so the upload site must widen explicitly.

## Fix

Widen with `u32::from(s.from_index)` at the upload in `forward_mse_batched`, matching the existing `u32::from(n.num_synapses)` conversion. The GPU buffer layout and shaders are unchanged.

Verified locally: `RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer` and `cargo test --release -p rust_scorer` pass.

This break is consumed by `stSoftwareAU/NEAT-AI-Examples` PR #604, whose unit-tests job builds this repo's `Develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)