### PR TITLE
Widen GPU synapse from_index to u32 after neat-core u16 narrowing

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,10 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core narrowed `SynapseData::from_index` to `u16` (core
+                // Issue #177); widen losslessly to the `u32` the GPU SSBO and
+                // WGSL `SynapseGpu` expect, matching the conversions above.
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Problem

`neat-core` narrowed `SynapseData::from_index` from `u32` to `u16`
(NEAT-AI-core Issue #177). The batched GPU path in
`build_batched_network_data` (`rust_scorer/src/gpu/forward_mse_batched.rs`)
still assigned `s.from_index` directly into `SynapseGpu.from_index`
(`u32`), so `rust_scorer` now fails to compile:

```
error[E0308]: mismatched types
   --> rust_scorer/src/gpu/forward_mse_batched.rs:228:29
    |
228 |                 from_index: s.from_index,
    |                             ^^^^^^^^^^^^^ expected `u32`, found `u16`
```

Because downstream repos check out `NEAT-AI-scorer`'s default branch and
build it under `RUSTFLAGS="-D warnings"`, this breaks the
**Unit tests + coverage** job on every PR there — e.g.
stSoftwareAU/NEAT-AI-Examples#604.

## Fix

Widen losslessly with `u32::from(s.from_index)`, matching the existing
`squash_type` and `num_synapses` conversions a few lines above. The GPU
SSBO and the WGSL `SynapseGpu` struct keep their `u32` layout (WGSL has
no `u16`), so no shader change is needed.

## Verification

`RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer` against
the latest `neat-core` (0.1.46) now compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)