### PR TITLE
fix(rust_scorer): widen synapse from_index u16→u32 for GPU mirror

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core's SynapseExport.from_index is u16; the GPU/WGSL
+                // mirror is u32 (WGSL has no 16-bit int), so widen here.
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Problem

The `rust_scorer` release build fails on `Develop`:

```
error[E0308]: mismatched types
  --> rust_scorer/src/gpu/forward_mse_batched.rs:228:29
    |
228 |                 from_index: s.from_index,
    |                             ^^^^^^^^^^^^ expected `u32`, found `u16`
```

`neat-core`'s `SynapseExport.from_index` was changed from `u32` to `u16`
(`neat-core/src/network.rs:115`), but `rust_scorer` still assigns it
directly into the GPU mirror's `u32` `from_index` field.

## Fix

Widen with `u32::from(s.from_index)` when building `SynapseGpu`. The
GPU/WGSL `SynapseGpu` mirror must remain `u32` (WGSL has no 16-bit
integer type and the shaders index `act[syn.from_index]` as `u32`), so
the widening conversion is the correct adaptation — mirroring the
adjacent `num_synapses: u32::from(...)` handling.

## Verification

`RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer` now
succeeds against `neat-core` Develop (v0.1.46).

## Context

This regression breaks downstream CI in
`stSoftwareAU/NEAT-AI-Examples#606`, whose `unit-tests` job builds
`rust_scorer` from `NEAT-AI-scorer@Develop`. Fixed cross-repo per the
internal-dependency root-cause policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)