### PR TITLE
Fix rust_scorer build: widen synapse from_index u16→u32 for GPU

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core narrowed `from_index` to u16 (neat-core #177); the
+                // GPU SSBO layout and WGSL shaders require u32, so widen here.
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Problem

`rust_scorer` fails to compile against the current `neat-core` `Develop`:

```
error[E0308]: mismatched types
  --> rust_scorer/src/gpu/forward_mse_batched.rs:228:29
228 |                 from_index: s.from_index,
    |                             ^^^^^^^^^^^^ expected `u32`, found `u16`
```

neat-core narrowed `Synapse::from_index` from `u32` to `u16` (neat-core #177). The GPU SSBO mirror `SynapseGpu.from_index` and both WGSL shaders (`forward_mse_batched.wgsl`, `forward_mse_scratch.wgsl`) still declare `from_index: u32` — which is correct for the GPU layout — so the struct construction no longer type-checks.

## Fix

Widen at the construction site with `u32::from(s.from_index)`, matching the existing `u32::from(...)` conversions for `num_synapses` and `squash_type` a few lines above. The GPU layout is unchanged; this is a pure widening of the host-side copy.

## Verification

`cargo build --release -p rust_scorer` (with `RUSTFLAGS="-D warnings"`) against `neat-core` `Develop` now succeeds.

## Context

Surfaced by `stSoftwareAU/NEAT-AI-Examples#606` CI, whose unit-tests job builds `rust_scorer` from this repo's `Develop`. That PR is blocked until this fix is released on `Develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)