### PR TITLE
Widen synapse from_index to u32 for SynapseGpu (neat-core #177)

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,7 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                from_index: u32::from(s.from_index),
             });
         }
 


### PR DESCRIPTION
## Summary

`neat-core` Issue #177 narrowed `CompiledNetwork` synapse `from_index` from `u32` to `u16`. `SynapseGpu.from_index` (the GPU/wire layout, `#[repr(C)]`, also mirrored in the WGSL shaders) remains `u32`, so the assignment at `rust_scorer/src/gpu/forward_mse_batched.rs:228` no longer compiled:

```
error[E0308]: mismatched types
   --> rust_scorer/src/gpu/forward_mse_batched.rs:228:29
228 |                 from_index: s.from_index,
    |                             ^^^^^^^^^^^^ expected `u32`, found `u16`
```

The fix widens explicitly via `u32::from(s.from_index)` — an infallible widening that matches the neighbouring `num_synapses: u32::from(...)` conversion and the `from_index as u32` widening neat-core itself already uses in `topology_export.rs`.

## Why this matters

`NEAT-AI-Examples` CI builds `rust_scorer` from `Develop` in its unit-test job, so this breakage failed every PR there (surfaced on `stSoftwareAU/NEAT-AI-Examples#604`).

## Verification

- `RUSTFLAGS="-D warnings" cargo build --release -p rust_scorer` — passes
- `cargo test --release -p rust_scorer --lib gpu::forward_mse_batched` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)