### PR TITLE
fix(gpu): widen synapse from_index u16->u32 for neat-core #177 (Issue #250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,16 +92,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "ash"
@@ -182,9 +176,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -452,15 +446,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -580,12 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,8 +579,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -675,12 +659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -772,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.43"
+version = "0.1.45"
 dependencies = [
  "serde",
  "serde_json",
@@ -979,16 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,9 +973,9 @@ checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1108,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 dependencies = [
  "bytemuck",
  "clap",
@@ -1161,12 +1129,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1261,9 +1223,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1335,12 +1297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,24 +1316,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1433,40 +1371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1807,100 +1711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/docs/archive/pr-summaries/pr-summary-250.md
+++ b/docs/archive/pr-summaries/pr-summary-250.md
@@ -1,0 +1,60 @@
+# PR Summary — Issue #250
+
+## Summary
+
+neat-core #177 (landed via neat-core #186) narrowed `SynapseData::from_index`
+from `u32` to `u16` for perf/SIMD. Because `rust_scorer` consumes `neat-core`
+via an unpinned `path` dependency that tracks head, the scorer build broke with
+`E0308` at the `SynapseGpu { … }` construction in
+`rust_scorer/src/gpu/forward_mse_batched.rs` — the GPU/WGSL layout has no 16-bit
+integer type, so `SynapseGpu.from_index` stays `u32`.
+
+This change widens losslessly at the GPU upload boundary with
+`from_index: u32::from(s.from_index)`, matching the existing `squash_type` /
+`num_synapses` conversions a few lines above. The u16 narrowing in neat-core is
+intentional and permanent — only the boundary conversion is added here.
+
+This is the same one-line fix as the recommended candidate **PR #242**, applied
+to the milestone branch `milestone/248-bug-neat-core-breaking-type-change-broke-score`
+so it stays buildable against neat-core ≥0.1.46 alongside the merge on `Develop`.
+
+As part of resolving this issue, the seven near-identical automation PRs were
+consolidated: one was merged to the default branch and the other six were closed
+with comments pointing at the merged PR.
+
+```mermaid
+flowchart LR
+    A["neat-core #177: from_index u32→u16"] --> B["scorer build E0308"]
+    B --> C["7 duplicate widen PRs"]
+    C --> D["Merge #242 → Develop"]
+    C --> E["Close #240/#241/#243/#244/#246/#249"]
+    D --> F["Examples #604 green"]
+    A --> G["This PR: widen on milestone branch"]
+```
+
+Closes #250.
+
+## Evidence
+
+Backend/CLI change with no web interface — no screenshot applicable.
+
+Reproduced the failure, then verified the fix against the sibling neat-core
+clone (which carries the `u16` narrowing):
+
+- Before: `cargo check -p rust_scorer` failed with
+  `error[E0308]: mismatched types … expected u32, found u16` at
+  `forward_mse_batched.rs:228`.
+- After: `./quality.sh` passes cleanly (`✅ All quality checks passed!`),
+  including `fmt --check`, clippy, check, build, test, rustdoc and release build.
+- New regression test passes:
+  `gpu::forward_mse_batched::tests::build_batched_network_data_widens_from_index_to_u32 ... ok`.
+
+## Test Plan
+
+- Added `rust_scorer/src/gpu/forward_mse_batched.rs::tests::build_batched_network_data_widens_from_index_to_u32`
+  — builds a creature, runs `build_batched_network_data`, and asserts every
+  `SynapseGpu.from_index` equals `u32::from` of the source network's `u16`
+  `from_index`. Fails to compile against the unfixed code (E0308); passes after
+  the widening.
+- Ran the full `./quality.sh` gate to confirm no regressions across the existing
+  `forward_mse_batched` tests.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core #177 narrowed `SynapseData::from_index` to `u16`;
+                // the GPU/WGSL layout keeps `from_index` as `u32`, so widen here.
+                from_index: u32::from(s.from_index),
             });
         }
 
@@ -908,6 +910,29 @@ mod tests {
 
         assert_eq!(data.num_inputs, 1);
         assert_eq!(data.num_outputs, 1);
+    }
+
+    #[test]
+    fn build_batched_network_data_widens_from_index_to_u32() {
+        // Regression for #250: neat-core #177 narrowed `SynapseData::from_index`
+        // to `u16`, while the GPU/WGSL `SynapseGpu` layout keeps it as `u32`.
+        // `build_batched_network_data` must widen losslessly at the upload
+        // boundary, so every `SynapseGpu.from_index` equals the `u32` widening
+        // of the source network's `u16` `from_index`.
+        let net = synthetic_creature(2, 1, 2);
+        let expected: Vec<u32> = net
+            .synapses
+            .iter()
+            .map(|s| u32::from(s.from_index))
+            .collect();
+
+        let data = build_batched_network_data(&[net], 2, 1).expect("supported squash types");
+
+        let actual: Vec<u32> = data.synapses.iter().map(|s| s.from_index).collect();
+        assert_eq!(
+            actual, expected,
+            "from_index must be widened u16 -> u32 unchanged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# PR Summary — Issue #250

## Summary

neat-core #177 (landed via neat-core #186) narrowed `SynapseData::from_index`
from `u32` to `u16` for perf/SIMD. Because `rust_scorer` consumes `neat-core`
via an unpinned `path` dependency that tracks head, the scorer build broke with
`E0308` at the `SynapseGpu { … }` construction in
`rust_scorer/src/gpu/forward_mse_batched.rs` — the GPU/WGSL layout has no 16-bit
integer type, so `SynapseGpu.from_index` stays `u32`.

This change widens losslessly at the GPU upload boundary with
`from_index: u32::from(s.from_index)`, matching the existing `squash_type` /
`num_synapses` conversions a few lines above. The u16 narrowing in neat-core is
intentional and permanent — only the boundary conversion is added here.

This is the same one-line fix as the recommended candidate **PR #242**, applied
to the milestone branch `milestone/248-bug-neat-core-breaking-type-change-broke-score`
so it stays buildable against neat-core ≥0.1.46 alongside the merge on `Develop`.

As part of resolving this issue, the seven near-identical automation PRs were
consolidated: one was merged to the default branch and the other six were closed
with comments pointing at the merged PR.

```mermaid
flowchart LR
    A["neat-core #177: from_index u32→u16"] --> B["scorer build E0308"]
    B --> C["7 duplicate widen PRs"]
    C --> D["Merge #242 → Develop"]
    C --> E["Close #240/#241/#243/#244/#246/#249"]
    D --> F["Examples #604 green"]
    A --> G["This PR: widen on milestone branch"]
```

Closes #250.

## Evidence

Backend/CLI change with no web interface — no screenshot applicable.

Reproduced the failure, then verified the fix against the sibling neat-core
clone (which carries the `u16` narrowing):

- Before: `cargo check -p rust_scorer` failed with
  `error[E0308]: mismatched types … expected u32, found u16` at
  `forward_mse_batched.rs:228`.
- After: `./quality.sh` passes cleanly (`✅ All quality checks passed!`),
  including `fmt --check`, clippy, check, build, test, rustdoc and release build.
- New regression test passes:
  `gpu::forward_mse_batched::tests::build_batched_network_data_widens_from_index_to_u32 ... ok`.

## Test Plan

- Added `rust_scorer/src/gpu/forward_mse_batched.rs::tests::build_batched_network_data_widens_from_index_to_u32`
  — builds a creature, runs `build_batched_network_data`, and asserts every
  `SynapseGpu.from_index` equals `u32::from` of the source network's `u16`
  `from_index`. Fails to compile against the unfixed code (E0308); passes after
  the widening.
- Ran the full `./quality.sh` gate to confirm no regressions across the existing
  `forward_mse_batched` tests.



## Milestone
This PR is part of the **#248 bug: neat-core breaking type change broke scorer build via unpinned path dep** milestone and targets the `milestone/248-bug-neat-core-breaking-type-change-broke-score` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqr6mkq4-07ce21`<!-- vibe-worker-issue-250 -->