### PR TITLE
docs(release): track neat-core semver breaking-change signalling (Issue #251)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-251.md
+++ b/docs/archive/pr-summaries/pr-summary-251.md
@@ -1,0 +1,78 @@
+## Summary
+
+Make **neat-core** signal breaking changes through semantic versioning so the
+scorer (which tracks the `neat-core` path dependency at head) is no longer broken
+silently. neat-core #177 (`SynapseData::from_index` `u32 → u16`) was breaking but
+shipped as `0.1.43 → 0.1.46` with no signal — neat-core had no semver tags (only
+`wasm-bundle-<sha>`) and its CI auto-bumped only the patch.
+
+Issue #251 is the **scorer-side tracking** issue of epic #248; the substantive
+work lands in the **NEAT-AI-core** repo (an internal `stSoftwareAU/*` dependency)
+via companion PR
+**[stSoftwareAU/NEAT-AI-core#190](https://github.com/stSoftwareAU/NEAT-AI-core/pull/190)**.
+This PR records the cross-repo decision on the scorer side.
+
+Closes #251.
+
+### NEAT-AI-core#190 (the fix)
+
+- `RELEASING.md` policy: breaking ⇒ major-equivalent bump (pre-1.0: **minor**,
+  `0.1.x → 0.2.0`); non-breaking ⇒ **patch**.
+- `version-gate` CI job + `check-version-bump.sh` — a breaking change **cannot**
+  ship on a patch-only bump.
+- `version-increment` CI job now bumps the minor on a breaking signal
+  (`breaking-change` label or Conventional Commit `type!:` / `BREAKING CHANGE:`).
+- `release.yml` cuts `v<version>` git tag + GitHub release on `Develop`,
+  decoupled from `wasm-bundle-<sha>`.
+- Retro-bump `0.1.46 → 0.2.0` to reflect the #177 break (not reverted).
+
+### This (scorer) PR
+
+- `docs/release-process/neat-core-semver-signalling.md` — tracking record of the
+  decision and the scorer-side implication (the sibling CI gate can key off the
+  signalled semver). No scorer code change is needed: the scorer uses a **path**
+  dependency, so there is no version pin to bump.
+
+Per the release-gating policy (#2944), the neat-core PR is **not** auto-merged and
+the `v0.2.0` release is **human-gated** — neat-core's `release` workflow cuts it on
+merge of PR #190.
+
+## Evidence
+
+Backend/cross-repo + documentation change — no scorer web UI to screenshot.
+
+Validation of the neat-core companion PR (#190), run locally:
+
+- `bats tests/scripts/next_version.bats`, `check_version_bump.bats`,
+  `detect_breaking.bats` — policy logic, all green.
+- Full `bats tests/scripts` — **146 tests** green, including the SHA-pinning,
+  actionlint, and script-injection workflow gates over the two new/edited
+  workflows.
+- `actionlint`, `shellcheck`, `markdownlint-cli2`, `codespell` clean;
+  `cargo check --workspace --locked` passes at `v0.2.0`.
+
+```mermaid
+flowchart TD
+    A[PR against neat-core Develop] --> B{Breaking signal?}
+    B -- "yes" --> C[version-increment:<br/>bump minor pre-1.0]
+    B -- "no" --> D[version-increment:<br/>bump patch]
+    C --> E[version-gate:<br/>breaking must not be patch-only]
+    D --> E
+    E -- "ok, merged" --> F[release.yml:<br/>cut v&lt;version&gt; tag + release]
+    F --> G[scorer CI gate keys off<br/>signalled semver]
+```
+
+## Test Plan
+
+The enforcement logic is covered by bats unit tests in the neat-core companion
+PR (#190), which run real scripts with test data and assert on exit codes /
+output (not source greps):
+
+- `tests/scripts/next_version.bats` — patch vs minor/major bump selection.
+- `tests/scripts/check_version_bump.bats` — gate rejects breaking-on-patch-only
+  and downgrades; allows over-bumping.
+- `tests/scripts/detect_breaking.bats` — Conventional Commit marker detection
+  over a throwaway git history.
+
+This scorer PR is documentation-only (tracking record); the scorer's own
+`./quality.sh` gate covers it.

--- a/docs/release-process/neat-core-semver-signalling.md
+++ b/docs/release-process/neat-core-semver-signalling.md
@@ -1,0 +1,48 @@
+# neat-core semver signalling (Issue #251)
+
+Tracking record for **Issue #251** — *"neat-core: signal breaking changes via a
+semver (major-equivalent) bump + git tags/releases"* — part of the
+release-process redesign epic **#248**.
+
+## Context
+
+`rust_scorer` depends on **`neat-core`** as a **path dependency** at head
+(`../../NEAT-AI-core/neat-core`). When neat-core
+[#177](https://github.com/stSoftwareAU/NEAT-AI-core/issues/177) narrowed
+`SynapseData::from_index` from `u32` to `u16` — a **breaking** type change — it
+shipped with **no signal**:
+
+- neat-core had **no semver tags** (only `wasm-bundle-<sha>` artifacts), and
+- its CI auto-bumped only the **patch** (`0.1.43 → 0.1.46`).
+
+So the scorer, tracking the path dep at head, **broke silently**.
+
+## Resolution (lands in NEAT-AI-core)
+
+The fix lives in the neat-core repository — companion PR
+**[stSoftwareAU/NEAT-AI-core#190](https://github.com/stSoftwareAU/NEAT-AI-core/pull/190)**:
+
+- **Policy** (`RELEASING.md`): a **breaking** change is a **major-equivalent**
+  bump — pre-1.0 that is the **minor** (`0.1.x → 0.2.0`); non-breaking changes
+  bump the **patch**.
+- **Enforcement**: a `version-gate` CI job fails any PR whose breaking change
+  ships on a patch-only bump; the `version-increment` job bumps the minor when a
+  break is signalled (the `breaking-change` label or a Conventional Commit
+  `type!:` / `BREAKING CHANGE:` marker).
+- **Discoverability**: a `release` workflow cuts a **`v<version>`** git tag +
+  GitHub release on every version bump, **decoupled** from the existing
+  `wasm-bundle-<sha>` artifacts.
+- **Retro decision**: the #177 break is retro-bumped `0.1.46 → 0.2.0` (the `u16`
+  narrowing is **not** reverted).
+
+## Scorer-side implication
+
+This unblocks the **scorer CI gate** (sibling sub-issue of #248): that gate can
+key off neat-core's now-signalled semver — comparing the pinned/observed
+neat-core version and reacting to a major-equivalent (minor pre-1.0) bump as a
+breaking change — instead of discovering breaks at compile/runtime.
+
+No scorer code change is required for #251 itself: the scorer consumes neat-core
+via a **path** dependency, so there is no version pin to bump here. Per the
+release-gating policy, cutting the `v0.2.0` release is a **human-gated** step
+performed by neat-core's `release` workflow on merge of PR #190.


### PR DESCRIPTION
## Summary

Make **neat-core** signal breaking changes through semantic versioning so the
scorer (which tracks the `neat-core` path dependency at head) is no longer broken
silently. neat-core #177 (`SynapseData::from_index` `u32 → u16`) was breaking but
shipped as `0.1.43 → 0.1.46` with no signal — neat-core had no semver tags (only
`wasm-bundle-<sha>`) and its CI auto-bumped only the patch.

Issue #251 is the **scorer-side tracking** issue of epic #248; the substantive
work lands in the **NEAT-AI-core** repo (an internal `stSoftwareAU/*` dependency)
via companion PR
**[stSoftwareAU/NEAT-AI-core#190](https://github.com/stSoftwareAU/NEAT-AI-core/pull/190)**.
This PR records the cross-repo decision on the scorer side.

Closes #251.

### NEAT-AI-core#190 (the fix)

- `RELEASING.md` policy: breaking ⇒ major-equivalent bump (pre-1.0: **minor**,
  `0.1.x → 0.2.0`); non-breaking ⇒ **patch**.
- `version-gate` CI job + `check-version-bump.sh` — a breaking change **cannot**
  ship on a patch-only bump.
- `version-increment` CI job now bumps the minor on a breaking signal
  (`breaking-change` label or Conventional Commit `type!:` / `BREAKING CHANGE:`).
- `release.yml` cuts `v<version>` git tag + GitHub release on `Develop`,
  decoupled from `wasm-bundle-<sha>`.
- Retro-bump `0.1.46 → 0.2.0` to reflect the #177 break (not reverted).

### This (scorer) PR

- `docs/release-process/neat-core-semver-signalling.md` — tracking record of the
  decision and the scorer-side implication (the sibling CI gate can key off the
  signalled semver). No scorer code change is needed: the scorer uses a **path**
  dependency, so there is no version pin to bump.

Per the release-gating policy (#2944), the neat-core PR is **not** auto-merged and
the `v0.2.0` release is **human-gated** — neat-core's `release` workflow cuts it on
merge of PR #190.

## Evidence

Backend/cross-repo + documentation change — no scorer web UI to screenshot.

Validation of the neat-core companion PR (#190), run locally:

- `bats tests/scripts/next_version.bats`, `check_version_bump.bats`,
  `detect_breaking.bats` — policy logic, all green.
- Full `bats tests/scripts` — **146 tests** green, including the SHA-pinning,
  actionlint, and script-injection workflow gates over the two new/edited
  workflows.
- `actionlint`, `shellcheck`, `markdownlint-cli2`, `codespell` clean;
  `cargo check --workspace --locked` passes at `v0.2.0`.

```mermaid
flowchart TD
    A[PR against neat-core Develop] --> B{Breaking signal?}
    B -- "yes" --> C[version-increment:<br/>bump minor pre-1.0]
    B -- "no" --> D[version-increment:<br/>bump patch]
    C --> E[version-gate:<br/>breaking must not be patch-only]
    D --> E
    E -- "ok, merged" --> F[release.yml:<br/>cut v&lt;version&gt; tag + release]
    F --> G[scorer CI gate keys off<br/>signalled semver]
```

## Test Plan

The enforcement logic is covered by bats unit tests in the neat-core companion
PR (#190), which run real scripts with test data and assert on exit codes /
output (not source greps):

- `tests/scripts/next_version.bats` — patch vs minor/major bump selection.
- `tests/scripts/check_version_bump.bats` — gate rejects breaking-on-patch-only
  and downgrades; allows over-bumping.
- `tests/scripts/detect_breaking.bats` — Conventional Commit marker detection
  over a throwaway git history.

This scorer PR is documentation-only (tracking record); the scorer's own
`./quality.sh` gate covers it.



## Milestone
This PR is part of the **#248 bug: neat-core breaking type change broke scorer build via unpinned path dep** milestone and targets the `milestone/248-bug-neat-core-breaking-type-change-broke-score` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqr6mkq4-07ce21`<!-- vibe-worker-issue-251 -->