### PR TITLE
ci(scorer): gate on unhandled breaking neat-core bump (Issue #252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
             "rust_scorer/src/main.rs"
             ".github/CODEOWNERS"
             "SECURITY.md"
+            "neat-core.expected-version"
           )
           missing_files=()
           for file in "${required_files[@]}"; do
@@ -237,6 +238,16 @@ jobs:
 
       - name: Validate Cargo workspace
         run: cargo metadata --no-deps --format-version 1 > /dev/null
+
+      # Gate against an unhandled breaking neat-core bump (Issue #252). scorer
+      # keeps the unpinned `path` dependency that tracks head, so this step
+      # fails the build when the sibling neat-core's breaking component (major
+      # for >= 1.0, minor for pre-1.0) climbs above the recorded baseline in
+      # neat-core.expected-version — forcing a deliberate upgrade rather than
+      # tracking head blindly. Reuses the neat-core checkout + sibling symlink
+      # above; the default manifest path resolves via that symlink.
+      - name: Gate on unhandled breaking neat-core bump
+        run: ./scripts/check-neat-core-version.sh
 
   shell-checks:
     name: Shell Script Quality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ section to the released version with its date.
 
 ### Added
 
+- **CI gate against an unhandled breaking neat-core bump (Issue #252).** The
+  `neat-core` dependency stays an unpinned `path` dependency that tracks head
+  (kept by design), so a new version-baseline gate now guards against silently
+  consuming a breaking change. Scorer records the last-handled neat-core
+  version in the checked-in `neat-core.expected-version` file;
+  `scripts/check-neat-core-version.sh` (run in the CI `validation` job and
+  locally via `./quality.sh`) reads the sibling
+  `../NEAT-AI-core/Cargo.toml` `[workspace.package] version` and **fails**
+  when neat-core's breaking component (major for `>= 1.0`, minor for pre-1.0)
+  exceeds the baseline — forcing a deliberate upgrade. Documented in the
+  README and CONTRIBUTING; covered by `tests/scripts/neat_core_version_gate.bats`.
+
 - **stderr note when a non-MSE `--cost` forces CPU fallback in directory
   mode (Issue #205).** Under the default `--gpu auto`, selecting a non-MSE
   `--cost` makes `auto_should_use_gpu` return false, so the directory path

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,16 @@ parent/
   NEAT-AI-scorer/    # this repository
 ```
 
+The `neat-core` path dependency is **unpinned** and tracks head, so a
+**breaking** neat-core change can reach scorer silently. CI guards against
+this with the **neat-core breaking-bump gate** (`scripts/check-neat-core-version.sh`):
+it fails when neat-core's breaking component (major for `>= 1.0`, minor for
+pre-1.0) climbs above the version recorded in
+[`neat-core.expected-version`](./neat-core.expected-version). When the gate
+fails, update `rust_scorer` for the breaking change and bump that baseline
+file in the same PR. See the README "neat-core breaking-bump gate" section
+for the full rationale.
+
 ## Prerequisites
 
 The local gate and CI expect the following tools on your `PATH`:

--- a/README.md
+++ b/README.md
@@ -331,6 +331,46 @@ warning.
 
 Place **NEAT-AI-core** and **NEAT-AI-scorer** as **siblings** (e.g. `…/src/NEAT-AI-core` and `…/src/NEAT-AI-scorer`). The path in `rust_scorer/Cargo.toml` is `../../NEAT-AI-core/neat-core` so `cargo build` resolves `neat-core` from your local **NEAT-AI-core** tree. CI does the same via a second checkout (`../NEAT-AI-core`).
 
+### neat-core breaking-bump gate (Issue #252)
+
+The `neat-core` dependency is an **unpinned `path` dependency that always
+tracks head** — there is no version to pin (kept by design). To stop scorer
+from silently tracking a **breaking** neat-core change, CI runs a
+version-baseline gate:
+
+- Scorer records the **last-handled** neat-core version in the checked-in
+  [`neat-core.expected-version`](./neat-core.expected-version) file.
+- CI reads neat-core's actual version from the cloned sibling
+  `../NEAT-AI-core/Cargo.toml` (`[workspace.package] version`).
+- The **breaking component** follows SemVer: the **major** for `>= 1.0`
+  releases, the **minor** for pre-1.0 (`0.x`) releases. The gate **fails**
+  when neat-core's breaking component is **greater** than the recorded
+  baseline, and **passes** on patch-level drift or an exact match.
+
+This is what would have caught the neat-core breaking type change
+(NEAT-AI-core #177) before the build broke.
+
+**How to clear the gate** when it fails — in a single deliberate PR:
+
+1. Update `rust_scorer` for the breaking neat-core change.
+2. Bump the recorded version in
+   [`neat-core.expected-version`](./neat-core.expected-version) to match the
+   new neat-core version.
+
+The gate runs as a step in the CI `validation` job and locally via
+`./quality.sh` (the script is `scripts/check-neat-core-version.sh`; it skips
+locally when no sibling `../NEAT-AI-core` clone is present).
+
+```mermaid
+flowchart TD
+    A[CI: read neat-core Cargo.toml version] --> B[read neat-core.expected-version baseline]
+    B --> C{breaking component<br/>greater than baseline?}
+    C -->|"yes (major ↑, or pre-1.0 minor ↑)"| D[FAIL: deliberate upgrade required]
+    C -->|"no (match / patch drift)"| E[PASS]
+    D --> F[update rust_scorer + bump baseline]
+    F --> E
+```
+
 ## Relationship to NEAT-AI
 
 Scorer-specific Rust stays here; **`neat-core`** tracks **NEAT-AI-core**.

--- a/docs/archive/pr-summaries/pr-summary-252.md
+++ b/docs/archive/pr-summaries/pr-summary-252.md
@@ -1,0 +1,94 @@
+# PR Summary — Issue #252
+
+## Summary
+
+Adds a scorer CI gate that **fails on an unhandled breaking neat-core bump**,
+while **keeping the unpinned `path` dependency** (Round 2 decision). scorer
+consumes `neat-core` via `neat-core = { path = "../../NEAT-AI-core/neat-core" }`,
+which always tracks head — so a breaking neat-core change could reach scorer
+silently (this is what broke the build in the NEAT-AI-core #177 scenario).
+
+The safeguard is a **version-baseline check**:
+
+- Scorer records the last-handled neat-core version in a new checked-in
+  `neat-core.expected-version` file (currently `0.1.46`).
+- `scripts/check-neat-core-version.sh` reads neat-core's actual version from
+  the sibling `../NEAT-AI-core/Cargo.toml` (`[workspace.package] version`).
+- The **breaking component** follows SemVer — major for `>= 1.0`, minor for
+  pre-1.0 (`0.x`). The gate **fails** when neat-core's breaking component is
+  greater than the baseline, and **passes** on patch-level drift or an exact
+  match.
+
+The gate runs as a step in the CI `validation` job (which already checks out
+and symlinks the sibling neat-core) and locally via `./quality.sh`. The path
+dependency in `rust_scorer/Cargo.toml` is **unchanged**.
+
+Closes #252.
+
+## Acceptance criteria
+
+- [x] Path dep `neat-core = { path = … }` **unchanged** (kept per Round 2).
+- [x] CI **fails** on a breaking bump above the baseline; the failure message
+      points at the deliberate-upgrade step (update `rust_scorer` + bump
+      `neat-core.expected-version`).
+- [x] CI **passes** after scorer records handling (baseline bumped to match).
+- [x] Demonstrated against the #177 scenario (see Evidence).
+- [x] Gate documented in README ("neat-core breaking-bump gate" section) and
+      CONTRIBUTING.
+
+## Evidence
+
+Backend/CLI/CI change — no web UI to screenshot. The `#177` scenario is
+demonstrated directly against the real script:
+
+```text
+-- baseline 0.1.46 (pre-fix) vs neat-core 0.2.0:
+FAIL: breaking neat-core bump: 0.2.0 exceeds handled baseline 0.1.46 (pre-1.0 minor increased)
+       To clear this gate, in a single deliberate PR:
+         1. Update rust_scorer for the breaking neat-core change.
+         2. Bump the recorded baseline in neat-core.expected-version to 0.2.0.
+exit=1
+
+-- baseline 0.2.0 (handled) vs neat-core 0.2.0:
+OK   neat-core 0.2.0 matches handled baseline 0.2.0 (patch-level drift allowed)
+exit=0
+```
+
+Against the real sibling clone the gate is green
+(`OK   neat-core 0.1.46 matches handled baseline 0.1.46`).
+
+### Gate flow
+
+```mermaid
+flowchart TD
+    A[CI validation job: read neat-core Cargo.toml version] --> B[read neat-core.expected-version baseline]
+    B --> C{breaking component<br/>greater than baseline?}
+    C -->|"yes (major up, or pre-1.0 minor up)"| D[FAIL: deliberate upgrade required]
+    C -->|"no (match / patch drift)"| E[PASS]
+    D --> F[update rust_scorer + bump baseline]
+    F --> E
+```
+
+## Test Plan
+
+- New `tests/scripts/neat_core_version_gate.bats` (15 cases) drives the real
+  script against synthetic fixtures: exact match, patch drift, the pre-1.0
+  breaking bump (#177), handled baseline, the `1.0` boundary crossing, post-1.0
+  major bump (fails) vs minor bump (passes), core-behind-baseline, comment
+  handling, and parse/usage errors. A final case runs against the real sibling
+  when present.
+- Full `bats tests/scripts` suite passes (308 tests).
+- `shellcheck`, `codespell`, `markdownlint-cli2`, and the workflow meta-checks
+  (`check-ci-job-graph.sh`, `check-workflow-paths.sh`, `check-workflow-timeouts.sh`,
+  `check-ci-permissions.sh`, `check-readme-ci-alignment.sh`, `actionlint`) all
+  pass with the CI edits.
+
+## Files changed
+
+- `scripts/check-neat-core-version.sh` — new gate script.
+- `neat-core.expected-version` — new checked-in baseline (`0.1.46`).
+- `.github/workflows/ci.yml` — new `validation` step + baseline added to the
+  required-files list.
+- `quality.sh` — local mirror of the gate (skips when no sibling clone).
+- `tests/scripts/neat_core_version_gate.bats` — new tests.
+- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md` — documentation.

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -1,0 +1,8 @@
+# Last-handled neat-core version (Issue #252).
+#
+# scorer consumes neat-core via an unpinned `path` dependency that tracks head.
+# CI (scripts/check-neat-core-version.sh) fails when the sibling neat-core
+# presents a breaking bump above this baseline — pre-1.0 a higher minor, or any
+# higher major — forcing a deliberate upgrade. Clear the gate by updating
+# rust_scorer for the change and bumping this version to match neat-core.
+0.1.46

--- a/quality.sh
+++ b/quality.sh
@@ -38,6 +38,16 @@ echo "🦀 Validating pinned rust-toolchain.toml (Issue #209)..."
 echo "🔗 Validating NEAT-AI-core checkout path strategy in workflows..."
 ./scripts/check-workflow-paths.sh
 
+echo "🚧 Gating on unhandled breaking neat-core bump (Issue #252)..."
+# Mirrors the CI `validation` job step. Runs only when the sibling neat-core
+# clone is present (CI always has it; local checkouts may not), so a missing
+# sibling does not block an otherwise valid local gate run.
+if [ -f "./../NEAT-AI-core/Cargo.toml" ]; then
+  ./scripts/check-neat-core-version.sh
+else
+  echo "   ⚠️  sibling ../NEAT-AI-core not found — skipping (CI runs this for real)"
+fi
+
 echo "🔐 Validating Gitleaks workflow hardening (Issue #21)..."
 ./scripts/check-gitleaks-workflow.sh
 

--- a/scripts/check-neat-core-version.sh
+++ b/scripts/check-neat-core-version.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Gate against an unhandled breaking neat-core bump (Issue #252).
+#
+# scorer consumes neat-core through an UNPINNED `path` dependency that always
+# tracks head (see `rust_scorer/Cargo.toml`). The path dep is kept by design
+# (Round 2 decision), so the safeguard is this CI gate: it fails when the
+# sibling neat-core presents a breaking bump scorer has not yet acknowledged,
+# forcing a deliberate upgrade instead of tracking head blindly. This is what
+# would have caught the neat-core #177 breaking type change before the build
+# broke.
+#
+# Mechanism — version-baseline check:
+#   * scorer records the last-handled neat-core version in the checked-in
+#     `neat-core.expected-version` file.
+#   * CI reads neat-core's actual version from the cloned sibling
+#     `../NEAT-AI-core/Cargo.toml` ([workspace.package] version).
+#   * The "breaking component" is the major for >= 1.0 releases and the minor
+#     for pre-1.0 (0.x) releases, per SemVer. The gate FAILS when neat-core's
+#     breaking component is greater than the recorded baseline; it PASSES on
+#     patch-level drift (policy) and when the two match.
+#
+# "Handling" a breaking bump = a deliberate scorer PR that makes the
+# corresponding code change AND bumps the recorded baseline to the new
+# neat-core version.
+#
+# Usage:
+#   check-neat-core-version.sh [--baseline PATH] [--core-manifest PATH]
+#
+# Defaults resolve the same paths Cargo uses: the baseline at the repo root and
+# the neat-core workspace manifest at the sibling `../NEAT-AI-core/Cargo.toml`
+# (the symlink CI creates makes this resolve on the runner too — see
+# `.github/workflows/ci.yml`).
+#
+# Exit codes:
+#   0  versions are compatible (match, patch drift, or core behind baseline)
+#   1  breaking neat-core bump above the recorded baseline — gate fails
+#   2  usage / parse error (missing file, malformed version)
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-neat-core-version.sh [--baseline PATH] [--core-manifest PATH]
+
+Options:
+  --baseline PATH        File recording the last-handled neat-core version
+                         (default: neat-core.expected-version at the repo root).
+  --core-manifest PATH   neat-core workspace Cargo.toml carrying
+                         [workspace.package] version (default: the sibling
+                         ../NEAT-AI-core/Cargo.toml).
+  -h, --help             Show this message.
+
+Exits 0 when compatible, 1 on an unhandled breaking bump, 2 on a usage error.
+EOF
+}
+
+BASELINE=""
+CORE_MANIFEST=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline)
+      [[ $# -ge 2 ]] || { echo "Missing value for --baseline" >&2; usage >&2; exit 2; }
+      BASELINE="$2"
+      shift 2
+      ;;
+    --core-manifest)
+      [[ $# -ge 2 ]] || { echo "Missing value for --core-manifest" >&2; usage >&2; exit 2; }
+      CORE_MANIFEST="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ -z "$BASELINE" ]]; then
+  BASELINE="$REPO_ROOT/neat-core.expected-version"
+fi
+if [[ -z "$CORE_MANIFEST" ]]; then
+  CORE_MANIFEST="$REPO_ROOT/../NEAT-AI-core/Cargo.toml"
+fi
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "FAIL: baseline file not found: $BASELINE" >&2
+  exit 2
+fi
+if [[ ! -f "$CORE_MANIFEST" ]]; then
+  echo "FAIL: neat-core manifest not found: $CORE_MANIFEST" >&2
+  echo "      Is the sibling NEAT-AI-core clone present? CI clones + symlinks it." >&2
+  exit 2
+fi
+
+# First non-comment, non-blank line of the baseline file is the version.
+read_baseline_version() {
+  awk '
+    { sub(/#.*/, "") }            # strip inline comments
+    { gsub(/[[:space:]]+/, "") }  # trim all whitespace
+    NF { print; exit }            # first non-empty line wins
+  ' "$BASELINE"
+}
+
+# Extract [workspace.package] version from the neat-core manifest. Only the
+# version key that lives under the [workspace.package] table counts — a bare
+# scan would also match dependency versions.
+read_core_version() {
+  awk '
+    /^\[/ { in_wp = ($0 ~ /^\[workspace\.package\]/) }
+    in_wp && /^[[:space:]]*version[[:space:]]*=/ {
+      if (match($0, /"[^"]*"/)) {
+        v = substr($0, RSTART + 1, RLENGTH - 2)
+        print v
+        exit
+      }
+    }
+  ' "$CORE_MANIFEST"
+}
+
+# Validate X.Y.Z (optionally with a -prerelease/+build suffix we ignore) and
+# echo the bare "major minor patch" triple. Returns non-zero when malformed.
+parse_semver() {
+  local raw="$1" core
+  core="${raw%%[-+]*}"   # drop pre-release / build metadata
+  if [[ ! "$core" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    return 1
+  fi
+  local IFS='.'
+  # shellcheck disable=SC2086
+  set -- $core
+  echo "$1 $2 $3"
+}
+
+baseline_raw="$(read_baseline_version)"
+if [[ -z "$baseline_raw" ]]; then
+  echo "FAIL: baseline file is empty: $BASELINE" >&2
+  exit 2
+fi
+
+core_raw="$(read_core_version)"
+if [[ -z "$core_raw" ]]; then
+  echo "FAIL: no [workspace.package] version found in $CORE_MANIFEST" >&2
+  exit 2
+fi
+
+if ! baseline_parts="$(parse_semver "$baseline_raw")"; then
+  echo "FAIL: malformed baseline version '$baseline_raw' in $BASELINE (expected X.Y.Z)" >&2
+  exit 2
+fi
+if ! core_parts="$(parse_semver "$core_raw")"; then
+  echo "FAIL: malformed neat-core version '$core_raw' in $CORE_MANIFEST (expected X.Y.Z)" >&2
+  exit 2
+fi
+
+read -r b_major b_minor b_patch <<<"$baseline_parts"
+read -r c_major c_minor c_patch <<<"$core_parts"
+: "$b_patch" "$c_patch"  # patch components are informational only
+
+remediation() {
+  cat >&2 <<EOF
+       neat-core has presented a breaking bump scorer has not handled.
+       To clear this gate, in a single deliberate PR:
+         1. Update rust_scorer for the breaking neat-core change.
+         2. Bump the recorded baseline in neat-core.expected-version to $core_raw.
+       See the README "neat-core breaking-bump gate" section.
+EOF
+}
+
+# Breaking-bump decision (SemVer): the major signals breaking changes once a
+# crate reaches 1.0; before that, the minor carries that role.
+if (( c_major > b_major )); then
+  echo "FAIL: breaking neat-core bump: $core_raw exceeds handled baseline $baseline_raw (major increased)" >&2
+  remediation
+  exit 1
+fi
+
+if (( c_major == b_major )); then
+  if (( b_major == 0 )); then
+    # Pre-1.0: the minor is the breaking component.
+    if (( c_minor > b_minor )); then
+      echo "FAIL: breaking neat-core bump: $core_raw exceeds handled baseline $baseline_raw (pre-1.0 minor increased)" >&2
+      remediation
+      exit 1
+    fi
+    if (( c_minor < b_minor )); then
+      echo "OK   neat-core $core_raw is behind handled baseline $baseline_raw (no breaking bump)"
+      exit 0
+    fi
+    echo "OK   neat-core $core_raw matches handled baseline $baseline_raw (patch-level drift allowed)"
+    exit 0
+  fi
+  # >= 1.0: same major — minor/patch drift is additive, never breaking.
+  echo "OK   neat-core $core_raw within handled baseline $baseline_raw major line (patch-level drift allowed)"
+  exit 0
+fi
+
+# c_major < b_major: neat-core sits below the baseline major — not a breaking
+# bump scorer needs to act on.
+echo "OK   neat-core $core_raw is behind handled baseline $baseline_raw (no breaking bump)"
+exit 0

--- a/tests/scripts/neat_core_version_gate.bats
+++ b/tests/scripts/neat_core_version_gate.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-neat-core-version.sh — Issue #252.
+#
+# The gate fails CI when the sibling neat-core presents a breaking bump above
+# scorer's recorded baseline (neat-core.expected-version), forcing a deliberate
+# upgrade instead of tracking head blindly. Pre-1.0 the breaking component is
+# the minor; >= 1.0 it is the major. Patch-level drift is allowed.
+#
+# Every case drives the real script against synthetic fixtures in a temporary
+# directory so behaviour (exit codes, messages) is verified end-to-end without
+# touching the real baseline file or the sibling clone.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-neat-core-version.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+  BASELINE="$TMP_DIR/neat-core.expected-version"
+  CORE_MANIFEST="$TMP_DIR/Cargo.toml"
+  export BASELINE CORE_MANIFEST
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Write a baseline file containing a single version string.
+write_baseline() {
+  printf '%s\n' "$1" >"$BASELINE"
+}
+
+# Write a neat-core workspace manifest carrying [workspace.package] version.
+write_core_manifest() {
+  cat >"$CORE_MANIFEST" <<EOF
+[workspace]
+members = ["neat-core"]
+resolver = "2"
+
+[workspace.package]
+version = "$1"
+edition = "2024"
+EOF
+}
+
+run_gate() {
+  run "$SCRIPT_UNDER_TEST" --baseline "$BASELINE" --core-manifest "$CORE_MANIFEST"
+}
+
+@test "passes when neat-core version exactly matches the baseline" {
+  write_baseline "0.1.46"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "passes on patch-level drift above the baseline" {
+  write_baseline "0.1.40"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"patch-level drift"* ]]
+}
+
+@test "fails on a pre-1.0 breaking bump (minor increased) — the #177 scenario" {
+  write_baseline "0.1.46"
+  write_core_manifest "0.2.0"
+  run_gate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"breaking"* ]]
+  # Failure must point at the deliberate-upgrade step.
+  [[ "$output" == *"neat-core.expected-version"* ]]
+}
+
+@test "passes after the baseline acknowledges the breaking bump (#177 handled)" {
+  write_baseline "0.2.0"
+  write_core_manifest "0.2.0"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "fails when neat-core crosses the 1.0 boundary above a 0.x baseline" {
+  write_baseline "0.5.0"
+  write_core_manifest "1.0.0"
+  run_gate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"breaking"* ]]
+}
+
+@test "fails on a post-1.0 major bump" {
+  write_baseline "1.4.2"
+  write_core_manifest "2.0.0"
+  run_gate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"breaking"* ]]
+}
+
+@test "passes on a post-1.0 minor bump (additive, non-breaking)" {
+  write_baseline "1.4.2"
+  write_core_manifest "1.7.0"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "passes (with a note) when neat-core is behind the baseline" {
+  write_baseline "0.2.0"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"behind"* ]]
+}
+
+@test "ignores comments and blank lines in the baseline file" {
+  cat >"$BASELINE" <<'EOF'
+# Last-handled neat-core version (Issue #252).
+
+0.1.46
+EOF
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+}
+
+@test "errors when the baseline file is missing" {
+  write_core_manifest "0.1.46"
+  run "$SCRIPT_UNDER_TEST" --baseline "$TMP_DIR/nope.version" --core-manifest "$CORE_MANIFEST"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "errors when the neat-core manifest is missing" {
+  write_baseline "0.1.46"
+  run "$SCRIPT_UNDER_TEST" --baseline "$BASELINE" --core-manifest "$TMP_DIR/nope.toml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "errors when the baseline version is malformed" {
+  write_baseline "not-a-version"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"malformed"* ]]
+}
+
+@test "errors when the manifest has no [workspace.package] version" {
+  write_baseline "0.1.46"
+  cat >"$CORE_MANIFEST" <<'EOF'
+[workspace]
+members = ["neat-core"]
+EOF
+  run_gate
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"version"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository baseline matches the sibling neat-core when present" {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SIBLING_MANIFEST="$REPO_ROOT/../NEAT-AI-core/Cargo.toml"
+  if [ ! -f "$SIBLING_MANIFEST" ]; then
+    skip "sibling NEAT-AI-core clone not present"
+  fi
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# PR Summary — Issue #252

## Summary

Adds a scorer CI gate that **fails on an unhandled breaking neat-core bump**,
while **keeping the unpinned `path` dependency** (Round 2 decision). scorer
consumes `neat-core` via `neat-core = { path = "../../NEAT-AI-core/neat-core" }`,
which always tracks head — so a breaking neat-core change could reach scorer
silently (this is what broke the build in the NEAT-AI-core #177 scenario).

The safeguard is a **version-baseline check**:

- Scorer records the last-handled neat-core version in a new checked-in
  `neat-core.expected-version` file (currently `0.1.46`).
- `scripts/check-neat-core-version.sh` reads neat-core's actual version from
  the sibling `../NEAT-AI-core/Cargo.toml` (`[workspace.package] version`).
- The **breaking component** follows SemVer — major for `>= 1.0`, minor for
  pre-1.0 (`0.x`). The gate **fails** when neat-core's breaking component is
  greater than the baseline, and **passes** on patch-level drift or an exact
  match.

The gate runs as a step in the CI `validation` job (which already checks out
and symlinks the sibling neat-core) and locally via `./quality.sh`. The path
dependency in `rust_scorer/Cargo.toml` is **unchanged**.

Closes #252.

## Acceptance criteria

- [x] Path dep `neat-core = { path = … }` **unchanged** (kept per Round 2).
- [x] CI **fails** on a breaking bump above the baseline; the failure message
      points at the deliberate-upgrade step (update `rust_scorer` + bump
      `neat-core.expected-version`).
- [x] CI **passes** after scorer records handling (baseline bumped to match).
- [x] Demonstrated against the #177 scenario (see Evidence).
- [x] Gate documented in README ("neat-core breaking-bump gate" section) and
      CONTRIBUTING.

## Evidence

Backend/CLI/CI change — no web UI to screenshot. The `#177` scenario is
demonstrated directly against the real script:

```text
-- baseline 0.1.46 (pre-fix) vs neat-core 0.2.0:
FAIL: breaking neat-core bump: 0.2.0 exceeds handled baseline 0.1.46 (pre-1.0 minor increased)
       To clear this gate, in a single deliberate PR:
         1. Update rust_scorer for the breaking neat-core change.
         2. Bump the recorded baseline in neat-core.expected-version to 0.2.0.
exit=1

-- baseline 0.2.0 (handled) vs neat-core 0.2.0:
OK   neat-core 0.2.0 matches handled baseline 0.2.0 (patch-level drift allowed)
exit=0
```

Against the real sibling clone the gate is green
(`OK   neat-core 0.1.46 matches handled baseline 0.1.46`).

### Gate flow

```mermaid
flowchart TD
    A[CI validation job: read neat-core Cargo.toml version] --> B[read neat-core.expected-version baseline]
    B --> C{breaking component<br/>greater than baseline?}
    C -->|"yes (major up, or pre-1.0 minor up)"| D[FAIL: deliberate upgrade required]
    C -->|"no (match / patch drift)"| E[PASS]
    D --> F[update rust_scorer + bump baseline]
    F --> E
```

## Test Plan

- New `tests/scripts/neat_core_version_gate.bats` (15 cases) drives the real
  script against synthetic fixtures: exact match, patch drift, the pre-1.0
  breaking bump (#177), handled baseline, the `1.0` boundary crossing, post-1.0
  major bump (fails) vs minor bump (passes), core-behind-baseline, comment
  handling, and parse/usage errors. A final case runs against the real sibling
  when present.
- Full `bats tests/scripts` suite passes (308 tests).
- `shellcheck`, `codespell`, `markdownlint-cli2`, and the workflow meta-checks
  (`check-ci-job-graph.sh`, `check-workflow-paths.sh`, `check-workflow-timeouts.sh`,
  `check-ci-permissions.sh`, `check-readme-ci-alignment.sh`, `actionlint`) all
  pass with the CI edits.

## Files changed

- `scripts/check-neat-core-version.sh` — new gate script.
- `neat-core.expected-version` — new checked-in baseline (`0.1.46`).
- `.github/workflows/ci.yml` — new `validation` step + baseline added to the
  required-files list.
- `quality.sh` — local mirror of the gate (skips when no sibling clone).
- `tests/scripts/neat_core_version_gate.bats` — new tests.
- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md` — documentation.



## Milestone
This PR is part of the **#248 bug: neat-core breaking type change broke scorer build via unpinned path dep** milestone and targets the `milestone/248-bug-neat-core-breaking-type-change-broke-score` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqr94amz-60ea4f`<!-- vibe-worker-issue-252 -->