### PR TITLE
Milestone: #248 bug: neat-core breaking type change broke scorer build via unpinned path dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
             "rust_scorer/src/main.rs"
             ".github/CODEOWNERS"
             "SECURITY.md"
+            "neat-core.expected-version"
           )
           missing_files=()
           for file in "${required_files[@]}"; do
@@ -237,6 +238,16 @@ jobs:
 
       - name: Validate Cargo workspace
         run: cargo metadata --no-deps --format-version 1 > /dev/null
+
+      # Gate against an unhandled breaking neat-core bump (Issue #252). scorer
+      # keeps the unpinned `path` dependency that tracks head, so this step
+      # fails the build when the sibling neat-core's breaking component (major
+      # for >= 1.0, minor for pre-1.0) climbs above the recorded baseline in
+      # neat-core.expected-version — forcing a deliberate upgrade rather than
+      # tracking head blindly. Reuses the neat-core checkout + sibling symlink
+      # above; the default manifest path resolves via that symlink.
+      - name: Gate on unhandled breaking neat-core bump
+        run: ./scripts/check-neat-core-version.sh
 
   shell-checks:
     name: Shell Script Quality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ section to the released version with its date.
 
 ### Added
 
+- **CI gate against an unhandled breaking neat-core bump (Issue #252).** The
+  `neat-core` dependency stays an unpinned `path` dependency that tracks head
+  (kept by design), so a new version-baseline gate now guards against silently
+  consuming a breaking change. Scorer records the last-handled neat-core
+  version in the checked-in `neat-core.expected-version` file;
+  `scripts/check-neat-core-version.sh` (run in the CI `validation` job and
+  locally via `./quality.sh`) reads the sibling
+  `../NEAT-AI-core/Cargo.toml` `[workspace.package] version` and **fails**
+  when neat-core's breaking component (major for `>= 1.0`, minor for pre-1.0)
+  exceeds the baseline — forcing a deliberate upgrade. Documented in the
+  README and CONTRIBUTING; covered by `tests/scripts/neat_core_version_gate.bats`.
+
 - **stderr note when a non-MSE `--cost` forces CPU fallback in directory
   mode (Issue #205).** Under the default `--gpu auto`, selecting a non-MSE
   `--cost` makes `auto_should_use_gpu` return false, so the directory path

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,16 @@ parent/
   NEAT-AI-scorer/    # this repository
 ```
 
+The `neat-core` path dependency is **unpinned** and tracks head, so a
+**breaking** neat-core change can reach scorer silently. CI guards against
+this with the **neat-core breaking-bump gate** (`scripts/check-neat-core-version.sh`):
+it fails when neat-core's breaking component (major for `>= 1.0`, minor for
+pre-1.0) climbs above the version recorded in
+[`neat-core.expected-version`](./neat-core.expected-version). When the gate
+fails, update `rust_scorer` for the breaking change and bump that baseline
+file in the same PR. See the README "neat-core breaking-bump gate" section
+for the full rationale.
+
 ## Prerequisites
 
 The local gate and CI expect the following tools on your `PATH`:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.45"
+version = "0.1.46"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.65"
+version = "1.0.1"
 dependencies = [
  "bytemuck",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,16 +92,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "ash"
@@ -182,9 +176,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -452,15 +446,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -580,12 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,8 +579,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -675,12 +659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -772,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.1.43"
+version = "0.1.45"
 dependencies = [
  "serde",
  "serde_json",
@@ -979,16 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,9 +973,9 @@ checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1108,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 dependencies = [
  "bytemuck",
  "clap",
@@ -1161,12 +1129,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1261,9 +1223,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1335,12 +1297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,24 +1316,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1433,40 +1371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1807,100 +1711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -331,6 +331,46 @@ warning.
 
 Place **NEAT-AI-core** and **NEAT-AI-scorer** as **siblings** (e.g. `…/src/NEAT-AI-core` and `…/src/NEAT-AI-scorer`). The path in `rust_scorer/Cargo.toml` is `../../NEAT-AI-core/neat-core` so `cargo build` resolves `neat-core` from your local **NEAT-AI-core** tree. CI does the same via a second checkout (`../NEAT-AI-core`).
 
+### neat-core breaking-bump gate (Issue #252)
+
+The `neat-core` dependency is an **unpinned `path` dependency that always
+tracks head** — there is no version to pin (kept by design). To stop scorer
+from silently tracking a **breaking** neat-core change, CI runs a
+version-baseline gate:
+
+- Scorer records the **last-handled** neat-core version in the checked-in
+  [`neat-core.expected-version`](./neat-core.expected-version) file.
+- CI reads neat-core's actual version from the cloned sibling
+  `../NEAT-AI-core/Cargo.toml` (`[workspace.package] version`).
+- The **breaking component** follows SemVer: the **major** for `>= 1.0`
+  releases, the **minor** for pre-1.0 (`0.x`) releases. The gate **fails**
+  when neat-core's breaking component is **greater** than the recorded
+  baseline, and **passes** on patch-level drift or an exact match.
+
+This is what would have caught the neat-core breaking type change
+(NEAT-AI-core #177) before the build broke.
+
+**How to clear the gate** when it fails — in a single deliberate PR:
+
+1. Update `rust_scorer` for the breaking neat-core change.
+2. Bump the recorded version in
+   [`neat-core.expected-version`](./neat-core.expected-version) to match the
+   new neat-core version.
+
+The gate runs as a step in the CI `validation` job and locally via
+`./quality.sh` (the script is `scripts/check-neat-core-version.sh`; it skips
+locally when no sibling `../NEAT-AI-core` clone is present).
+
+```mermaid
+flowchart TD
+    A[CI: read neat-core Cargo.toml version] --> B[read neat-core.expected-version baseline]
+    B --> C{breaking component<br/>greater than baseline?}
+    C -->|"yes (major ↑, or pre-1.0 minor ↑)"| D[FAIL: deliberate upgrade required]
+    C -->|"no (match / patch drift)"| E[PASS]
+    D --> F[update rust_scorer + bump baseline]
+    F --> E
+```
+
 ## Relationship to NEAT-AI
 
 Scorer-specific Rust stays here; **`neat-core`** tracks **NEAT-AI-core**.

--- a/docs/archive/pr-summaries/pr-summary-250.md
+++ b/docs/archive/pr-summaries/pr-summary-250.md
@@ -1,0 +1,60 @@
+# PR Summary — Issue #250
+
+## Summary
+
+neat-core #177 (landed via neat-core #186) narrowed `SynapseData::from_index`
+from `u32` to `u16` for perf/SIMD. Because `rust_scorer` consumes `neat-core`
+via an unpinned `path` dependency that tracks head, the scorer build broke with
+`E0308` at the `SynapseGpu { … }` construction in
+`rust_scorer/src/gpu/forward_mse_batched.rs` — the GPU/WGSL layout has no 16-bit
+integer type, so `SynapseGpu.from_index` stays `u32`.
+
+This change widens losslessly at the GPU upload boundary with
+`from_index: u32::from(s.from_index)`, matching the existing `squash_type` /
+`num_synapses` conversions a few lines above. The u16 narrowing in neat-core is
+intentional and permanent — only the boundary conversion is added here.
+
+This is the same one-line fix as the recommended candidate **PR #242**, applied
+to the milestone branch `milestone/248-bug-neat-core-breaking-type-change-broke-score`
+so it stays buildable against neat-core ≥0.1.46 alongside the merge on `Develop`.
+
+As part of resolving this issue, the seven near-identical automation PRs were
+consolidated: one was merged to the default branch and the other six were closed
+with comments pointing at the merged PR.
+
+```mermaid
+flowchart LR
+    A["neat-core #177: from_index u32→u16"] --> B["scorer build E0308"]
+    B --> C["7 duplicate widen PRs"]
+    C --> D["Merge #242 → Develop"]
+    C --> E["Close #240/#241/#243/#244/#246/#249"]
+    D --> F["Examples #604 green"]
+    A --> G["This PR: widen on milestone branch"]
+```
+
+Closes #250.
+
+## Evidence
+
+Backend/CLI change with no web interface — no screenshot applicable.
+
+Reproduced the failure, then verified the fix against the sibling neat-core
+clone (which carries the `u16` narrowing):
+
+- Before: `cargo check -p rust_scorer` failed with
+  `error[E0308]: mismatched types … expected u32, found u16` at
+  `forward_mse_batched.rs:228`.
+- After: `./quality.sh` passes cleanly (`✅ All quality checks passed!`),
+  including `fmt --check`, clippy, check, build, test, rustdoc and release build.
+- New regression test passes:
+  `gpu::forward_mse_batched::tests::build_batched_network_data_widens_from_index_to_u32 ... ok`.
+
+## Test Plan
+
+- Added `rust_scorer/src/gpu/forward_mse_batched.rs::tests::build_batched_network_data_widens_from_index_to_u32`
+  — builds a creature, runs `build_batched_network_data`, and asserts every
+  `SynapseGpu.from_index` equals `u32::from` of the source network's `u16`
+  `from_index`. Fails to compile against the unfixed code (E0308); passes after
+  the widening.
+- Ran the full `./quality.sh` gate to confirm no regressions across the existing
+  `forward_mse_batched` tests.

--- a/docs/archive/pr-summaries/pr-summary-251.md
+++ b/docs/archive/pr-summaries/pr-summary-251.md
@@ -1,0 +1,78 @@
+## Summary
+
+Make **neat-core** signal breaking changes through semantic versioning so the
+scorer (which tracks the `neat-core` path dependency at head) is no longer broken
+silently. neat-core #177 (`SynapseData::from_index` `u32 → u16`) was breaking but
+shipped as `0.1.43 → 0.1.46` with no signal — neat-core had no semver tags (only
+`wasm-bundle-<sha>`) and its CI auto-bumped only the patch.
+
+Issue #251 is the **scorer-side tracking** issue of epic #248; the substantive
+work lands in the **NEAT-AI-core** repo (an internal `stSoftwareAU/*` dependency)
+via companion PR
+**[stSoftwareAU/NEAT-AI-core#190](https://github.com/stSoftwareAU/NEAT-AI-core/pull/190)**.
+This PR records the cross-repo decision on the scorer side.
+
+Closes #251.
+
+### NEAT-AI-core#190 (the fix)
+
+- `RELEASING.md` policy: breaking ⇒ major-equivalent bump (pre-1.0: **minor**,
+  `0.1.x → 0.2.0`); non-breaking ⇒ **patch**.
+- `version-gate` CI job + `check-version-bump.sh` — a breaking change **cannot**
+  ship on a patch-only bump.
+- `version-increment` CI job now bumps the minor on a breaking signal
+  (`breaking-change` label or Conventional Commit `type!:` / `BREAKING CHANGE:`).
+- `release.yml` cuts `v<version>` git tag + GitHub release on `Develop`,
+  decoupled from `wasm-bundle-<sha>`.
+- Retro-bump `0.1.46 → 0.2.0` to reflect the #177 break (not reverted).
+
+### This (scorer) PR
+
+- `docs/release-process/neat-core-semver-signalling.md` — tracking record of the
+  decision and the scorer-side implication (the sibling CI gate can key off the
+  signalled semver). No scorer code change is needed: the scorer uses a **path**
+  dependency, so there is no version pin to bump.
+
+Per the release-gating policy (#2944), the neat-core PR is **not** auto-merged and
+the `v0.2.0` release is **human-gated** — neat-core's `release` workflow cuts it on
+merge of PR #190.
+
+## Evidence
+
+Backend/cross-repo + documentation change — no scorer web UI to screenshot.
+
+Validation of the neat-core companion PR (#190), run locally:
+
+- `bats tests/scripts/next_version.bats`, `check_version_bump.bats`,
+  `detect_breaking.bats` — policy logic, all green.
+- Full `bats tests/scripts` — **146 tests** green, including the SHA-pinning,
+  actionlint, and script-injection workflow gates over the two new/edited
+  workflows.
+- `actionlint`, `shellcheck`, `markdownlint-cli2`, `codespell` clean;
+  `cargo check --workspace --locked` passes at `v0.2.0`.
+
+```mermaid
+flowchart TD
+    A[PR against neat-core Develop] --> B{Breaking signal?}
+    B -- "yes" --> C[version-increment:<br/>bump minor pre-1.0]
+    B -- "no" --> D[version-increment:<br/>bump patch]
+    C --> E[version-gate:<br/>breaking must not be patch-only]
+    D --> E
+    E -- "ok, merged" --> F[release.yml:<br/>cut v&lt;version&gt; tag + release]
+    F --> G[scorer CI gate keys off<br/>signalled semver]
+```
+
+## Test Plan
+
+The enforcement logic is covered by bats unit tests in the neat-core companion
+PR (#190), which run real scripts with test data and assert on exit codes /
+output (not source greps):
+
+- `tests/scripts/next_version.bats` — patch vs minor/major bump selection.
+- `tests/scripts/check_version_bump.bats` — gate rejects breaking-on-patch-only
+  and downgrades; allows over-bumping.
+- `tests/scripts/detect_breaking.bats` — Conventional Commit marker detection
+  over a throwaway git history.
+
+This scorer PR is documentation-only (tracking record); the scorer's own
+`./quality.sh` gate covers it.

--- a/docs/archive/pr-summaries/pr-summary-252.md
+++ b/docs/archive/pr-summaries/pr-summary-252.md
@@ -1,0 +1,94 @@
+# PR Summary — Issue #252
+
+## Summary
+
+Adds a scorer CI gate that **fails on an unhandled breaking neat-core bump**,
+while **keeping the unpinned `path` dependency** (Round 2 decision). scorer
+consumes `neat-core` via `neat-core = { path = "../../NEAT-AI-core/neat-core" }`,
+which always tracks head — so a breaking neat-core change could reach scorer
+silently (this is what broke the build in the NEAT-AI-core #177 scenario).
+
+The safeguard is a **version-baseline check**:
+
+- Scorer records the last-handled neat-core version in a new checked-in
+  `neat-core.expected-version` file (currently `0.1.46`).
+- `scripts/check-neat-core-version.sh` reads neat-core's actual version from
+  the sibling `../NEAT-AI-core/Cargo.toml` (`[workspace.package] version`).
+- The **breaking component** follows SemVer — major for `>= 1.0`, minor for
+  pre-1.0 (`0.x`). The gate **fails** when neat-core's breaking component is
+  greater than the baseline, and **passes** on patch-level drift or an exact
+  match.
+
+The gate runs as a step in the CI `validation` job (which already checks out
+and symlinks the sibling neat-core) and locally via `./quality.sh`. The path
+dependency in `rust_scorer/Cargo.toml` is **unchanged**.
+
+Closes #252.
+
+## Acceptance criteria
+
+- [x] Path dep `neat-core = { path = … }` **unchanged** (kept per Round 2).
+- [x] CI **fails** on a breaking bump above the baseline; the failure message
+      points at the deliberate-upgrade step (update `rust_scorer` + bump
+      `neat-core.expected-version`).
+- [x] CI **passes** after scorer records handling (baseline bumped to match).
+- [x] Demonstrated against the #177 scenario (see Evidence).
+- [x] Gate documented in README ("neat-core breaking-bump gate" section) and
+      CONTRIBUTING.
+
+## Evidence
+
+Backend/CLI/CI change — no web UI to screenshot. The `#177` scenario is
+demonstrated directly against the real script:
+
+```text
+-- baseline 0.1.46 (pre-fix) vs neat-core 0.2.0:
+FAIL: breaking neat-core bump: 0.2.0 exceeds handled baseline 0.1.46 (pre-1.0 minor increased)
+       To clear this gate, in a single deliberate PR:
+         1. Update rust_scorer for the breaking neat-core change.
+         2. Bump the recorded baseline in neat-core.expected-version to 0.2.0.
+exit=1
+
+-- baseline 0.2.0 (handled) vs neat-core 0.2.0:
+OK   neat-core 0.2.0 matches handled baseline 0.2.0 (patch-level drift allowed)
+exit=0
+```
+
+Against the real sibling clone the gate is green
+(`OK   neat-core 0.1.46 matches handled baseline 0.1.46`).
+
+### Gate flow
+
+```mermaid
+flowchart TD
+    A[CI validation job: read neat-core Cargo.toml version] --> B[read neat-core.expected-version baseline]
+    B --> C{breaking component<br/>greater than baseline?}
+    C -->|"yes (major up, or pre-1.0 minor up)"| D[FAIL: deliberate upgrade required]
+    C -->|"no (match / patch drift)"| E[PASS]
+    D --> F[update rust_scorer + bump baseline]
+    F --> E
+```
+
+## Test Plan
+
+- New `tests/scripts/neat_core_version_gate.bats` (15 cases) drives the real
+  script against synthetic fixtures: exact match, patch drift, the pre-1.0
+  breaking bump (#177), handled baseline, the `1.0` boundary crossing, post-1.0
+  major bump (fails) vs minor bump (passes), core-behind-baseline, comment
+  handling, and parse/usage errors. A final case runs against the real sibling
+  when present.
+- Full `bats tests/scripts` suite passes (308 tests).
+- `shellcheck`, `codespell`, `markdownlint-cli2`, and the workflow meta-checks
+  (`check-ci-job-graph.sh`, `check-workflow-paths.sh`, `check-workflow-timeouts.sh`,
+  `check-ci-permissions.sh`, `check-readme-ci-alignment.sh`, `actionlint`) all
+  pass with the CI edits.
+
+## Files changed
+
+- `scripts/check-neat-core-version.sh` — new gate script.
+- `neat-core.expected-version` — new checked-in baseline (`0.1.46`).
+- `.github/workflows/ci.yml` — new `validation` step + baseline added to the
+  required-files list.
+- `quality.sh` — local mirror of the gate (skips when no sibling clone).
+- `tests/scripts/neat_core_version_gate.bats` — new tests.
+- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md` — documentation.

--- a/docs/release-process/neat-core-semver-signalling.md
+++ b/docs/release-process/neat-core-semver-signalling.md
@@ -1,0 +1,48 @@
+# neat-core semver signalling (Issue #251)
+
+Tracking record for **Issue #251** — *"neat-core: signal breaking changes via a
+semver (major-equivalent) bump + git tags/releases"* — part of the
+release-process redesign epic **#248**.
+
+## Context
+
+`rust_scorer` depends on **`neat-core`** as a **path dependency** at head
+(`../../NEAT-AI-core/neat-core`). When neat-core
+[#177](https://github.com/stSoftwareAU/NEAT-AI-core/issues/177) narrowed
+`SynapseData::from_index` from `u32` to `u16` — a **breaking** type change — it
+shipped with **no signal**:
+
+- neat-core had **no semver tags** (only `wasm-bundle-<sha>` artifacts), and
+- its CI auto-bumped only the **patch** (`0.1.43 → 0.1.46`).
+
+So the scorer, tracking the path dep at head, **broke silently**.
+
+## Resolution (lands in NEAT-AI-core)
+
+The fix lives in the neat-core repository — companion PR
+**[stSoftwareAU/NEAT-AI-core#190](https://github.com/stSoftwareAU/NEAT-AI-core/pull/190)**:
+
+- **Policy** (`RELEASING.md`): a **breaking** change is a **major-equivalent**
+  bump — pre-1.0 that is the **minor** (`0.1.x → 0.2.0`); non-breaking changes
+  bump the **patch**.
+- **Enforcement**: a `version-gate` CI job fails any PR whose breaking change
+  ships on a patch-only bump; the `version-increment` job bumps the minor when a
+  break is signalled (the `breaking-change` label or a Conventional Commit
+  `type!:` / `BREAKING CHANGE:` marker).
+- **Discoverability**: a `release` workflow cuts a **`v<version>`** git tag +
+  GitHub release on every version bump, **decoupled** from the existing
+  `wasm-bundle-<sha>` artifacts.
+- **Retro decision**: the #177 break is retro-bumped `0.1.46 → 0.2.0` (the `u16`
+  narrowing is **not** reverted).
+
+## Scorer-side implication
+
+This unblocks the **scorer CI gate** (sibling sub-issue of #248): that gate can
+key off neat-core's now-signalled semver — comparing the pinned/observed
+neat-core version and reacting to a major-equivalent (minor pre-1.0) bump as a
+breaking change — instead of discovering breaks at compile/runtime.
+
+No scorer code change is required for #251 itself: the scorer consumes neat-core
+via a **path** dependency, so there is no version pin to bump here. Per the
+release-gating policy, cutting the `v0.2.0` release is a **human-gated** step
+performed by neat-core's `release` workflow on merge of PR #190.

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -1,0 +1,8 @@
+# Last-handled neat-core version (Issue #252).
+#
+# scorer consumes neat-core via an unpinned `path` dependency that tracks head.
+# CI (scripts/check-neat-core-version.sh) fails when the sibling neat-core
+# presents a breaking bump above this baseline — pre-1.0 a higher minor, or any
+# higher major — forcing a deliberate upgrade. Clear the gate by updating
+# rust_scorer for the change and bumping this version to match neat-core.
+0.1.46

--- a/quality.sh
+++ b/quality.sh
@@ -38,6 +38,16 @@ echo "🦀 Validating pinned rust-toolchain.toml (Issue #209)..."
 echo "🔗 Validating NEAT-AI-core checkout path strategy in workflows..."
 ./scripts/check-workflow-paths.sh
 
+echo "🚧 Gating on unhandled breaking neat-core bump (Issue #252)..."
+# Mirrors the CI `validation` job step. Runs only when the sibling neat-core
+# clone is present (CI always has it; local checkouts may not), so a missing
+# sibling does not block an otherwise valid local gate run.
+if [ -f "./../NEAT-AI-core/Cargo.toml" ]; then
+  ./scripts/check-neat-core-version.sh
+else
+  echo "   ⚠️  sibling ../NEAT-AI-core not found — skipping (CI runs this for real)"
+fi
+
 echo "🔐 Validating Gitleaks workflow hardening (Issue #21)..."
 ./scripts/check-gitleaks-workflow.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -225,7 +225,9 @@ pub fn build_batched_network_data(
         for s in &net.synapses {
             synapses.push(SynapseGpu {
                 weight: s.weight,
-                from_index: s.from_index,
+                // neat-core #177 narrowed `SynapseData::from_index` to `u16`;
+                // the GPU/WGSL layout keeps `from_index` as `u32`, so widen here.
+                from_index: u32::from(s.from_index),
             });
         }
 
@@ -908,6 +910,29 @@ mod tests {
 
         assert_eq!(data.num_inputs, 1);
         assert_eq!(data.num_outputs, 1);
+    }
+
+    #[test]
+    fn build_batched_network_data_widens_from_index_to_u32() {
+        // Regression for #250: neat-core #177 narrowed `SynapseData::from_index`
+        // to `u16`, while the GPU/WGSL `SynapseGpu` layout keeps it as `u32`.
+        // `build_batched_network_data` must widen losslessly at the upload
+        // boundary, so every `SynapseGpu.from_index` equals the `u32` widening
+        // of the source network's `u16` `from_index`.
+        let net = synthetic_creature(2, 1, 2);
+        let expected: Vec<u32> = net
+            .synapses
+            .iter()
+            .map(|s| u32::from(s.from_index))
+            .collect();
+
+        let data = build_batched_network_data(&[net], 2, 1).expect("supported squash types");
+
+        let actual: Vec<u32> = data.synapses.iter().map(|s| s.from_index).collect();
+        assert_eq!(
+            actual, expected,
+            "from_index must be widened u16 -> u32 unchanged"
+        );
     }
 
     #[test]

--- a/scripts/check-neat-core-version.sh
+++ b/scripts/check-neat-core-version.sh
@@ -132,10 +132,10 @@ parse_semver() {
   if [[ ! "$core" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     return 1
   fi
-  local IFS='.'
-  # shellcheck disable=SC2086
-  set -- $core
-  echo "$1 $2 $3"
+  local major minor patch
+  # Scope IFS to this single read rather than tampering with it globally.
+  IFS='.' read -r major minor patch <<<"$core"
+  echo "$major $minor $patch"
 }
 
 baseline_raw="$(read_baseline_version)"

--- a/scripts/check-neat-core-version.sh
+++ b/scripts/check-neat-core-version.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Gate against an unhandled breaking neat-core bump (Issue #252).
+#
+# scorer consumes neat-core through an UNPINNED `path` dependency that always
+# tracks head (see `rust_scorer/Cargo.toml`). The path dep is kept by design
+# (Round 2 decision), so the safeguard is this CI gate: it fails when the
+# sibling neat-core presents a breaking bump scorer has not yet acknowledged,
+# forcing a deliberate upgrade instead of tracking head blindly. This is what
+# would have caught the neat-core #177 breaking type change before the build
+# broke.
+#
+# Mechanism — version-baseline check:
+#   * scorer records the last-handled neat-core version in the checked-in
+#     `neat-core.expected-version` file.
+#   * CI reads neat-core's actual version from the cloned sibling
+#     `../NEAT-AI-core/Cargo.toml` ([workspace.package] version).
+#   * The "breaking component" is the major for >= 1.0 releases and the minor
+#     for pre-1.0 (0.x) releases, per SemVer. The gate FAILS when neat-core's
+#     breaking component is greater than the recorded baseline; it PASSES on
+#     patch-level drift (policy) and when the two match.
+#
+# "Handling" a breaking bump = a deliberate scorer PR that makes the
+# corresponding code change AND bumps the recorded baseline to the new
+# neat-core version.
+#
+# Usage:
+#   check-neat-core-version.sh [--baseline PATH] [--core-manifest PATH]
+#
+# Defaults resolve the same paths Cargo uses: the baseline at the repo root and
+# the neat-core workspace manifest at the sibling `../NEAT-AI-core/Cargo.toml`
+# (the symlink CI creates makes this resolve on the runner too — see
+# `.github/workflows/ci.yml`).
+#
+# Exit codes:
+#   0  versions are compatible (match, patch drift, or core behind baseline)
+#   1  breaking neat-core bump above the recorded baseline — gate fails
+#   2  usage / parse error (missing file, malformed version)
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-neat-core-version.sh [--baseline PATH] [--core-manifest PATH]
+
+Options:
+  --baseline PATH        File recording the last-handled neat-core version
+                         (default: neat-core.expected-version at the repo root).
+  --core-manifest PATH   neat-core workspace Cargo.toml carrying
+                         [workspace.package] version (default: the sibling
+                         ../NEAT-AI-core/Cargo.toml).
+  -h, --help             Show this message.
+
+Exits 0 when compatible, 1 on an unhandled breaking bump, 2 on a usage error.
+EOF
+}
+
+BASELINE=""
+CORE_MANIFEST=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline)
+      [[ $# -ge 2 ]] || { echo "Missing value for --baseline" >&2; usage >&2; exit 2; }
+      BASELINE="$2"
+      shift 2
+      ;;
+    --core-manifest)
+      [[ $# -ge 2 ]] || { echo "Missing value for --core-manifest" >&2; usage >&2; exit 2; }
+      CORE_MANIFEST="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ -z "$BASELINE" ]]; then
+  BASELINE="$REPO_ROOT/neat-core.expected-version"
+fi
+if [[ -z "$CORE_MANIFEST" ]]; then
+  CORE_MANIFEST="$REPO_ROOT/../NEAT-AI-core/Cargo.toml"
+fi
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "FAIL: baseline file not found: $BASELINE" >&2
+  exit 2
+fi
+if [[ ! -f "$CORE_MANIFEST" ]]; then
+  echo "FAIL: neat-core manifest not found: $CORE_MANIFEST" >&2
+  echo "      Is the sibling NEAT-AI-core clone present? CI clones + symlinks it." >&2
+  exit 2
+fi
+
+# First non-comment, non-blank line of the baseline file is the version.
+read_baseline_version() {
+  awk '
+    { sub(/#.*/, "") }            # strip inline comments
+    { gsub(/[[:space:]]+/, "") }  # trim all whitespace
+    NF { print; exit }            # first non-empty line wins
+  ' "$BASELINE"
+}
+
+# Extract [workspace.package] version from the neat-core manifest. Only the
+# version key that lives under the [workspace.package] table counts — a bare
+# scan would also match dependency versions.
+read_core_version() {
+  awk '
+    /^\[/ { in_wp = ($0 ~ /^\[workspace\.package\]/) }
+    in_wp && /^[[:space:]]*version[[:space:]]*=/ {
+      if (match($0, /"[^"]*"/)) {
+        v = substr($0, RSTART + 1, RLENGTH - 2)
+        print v
+        exit
+      }
+    }
+  ' "$CORE_MANIFEST"
+}
+
+# Validate X.Y.Z (optionally with a -prerelease/+build suffix we ignore) and
+# echo the bare "major minor patch" triple. Returns non-zero when malformed.
+parse_semver() {
+  local raw="$1" core
+  core="${raw%%[-+]*}"   # drop pre-release / build metadata
+  if [[ ! "$core" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    return 1
+  fi
+  local IFS='.'
+  # shellcheck disable=SC2086
+  set -- $core
+  echo "$1 $2 $3"
+}
+
+baseline_raw="$(read_baseline_version)"
+if [[ -z "$baseline_raw" ]]; then
+  echo "FAIL: baseline file is empty: $BASELINE" >&2
+  exit 2
+fi
+
+core_raw="$(read_core_version)"
+if [[ -z "$core_raw" ]]; then
+  echo "FAIL: no [workspace.package] version found in $CORE_MANIFEST" >&2
+  exit 2
+fi
+
+if ! baseline_parts="$(parse_semver "$baseline_raw")"; then
+  echo "FAIL: malformed baseline version '$baseline_raw' in $BASELINE (expected X.Y.Z)" >&2
+  exit 2
+fi
+if ! core_parts="$(parse_semver "$core_raw")"; then
+  echo "FAIL: malformed neat-core version '$core_raw' in $CORE_MANIFEST (expected X.Y.Z)" >&2
+  exit 2
+fi
+
+read -r b_major b_minor b_patch <<<"$baseline_parts"
+read -r c_major c_minor c_patch <<<"$core_parts"
+: "$b_patch" "$c_patch"  # patch components are informational only
+
+remediation() {
+  cat >&2 <<EOF
+       neat-core has presented a breaking bump scorer has not handled.
+       To clear this gate, in a single deliberate PR:
+         1. Update rust_scorer for the breaking neat-core change.
+         2. Bump the recorded baseline in neat-core.expected-version to $core_raw.
+       See the README "neat-core breaking-bump gate" section.
+EOF
+}
+
+# Breaking-bump decision (SemVer): the major signals breaking changes once a
+# crate reaches 1.0; before that, the minor carries that role.
+if (( c_major > b_major )); then
+  echo "FAIL: breaking neat-core bump: $core_raw exceeds handled baseline $baseline_raw (major increased)" >&2
+  remediation
+  exit 1
+fi
+
+if (( c_major == b_major )); then
+  if (( b_major == 0 )); then
+    # Pre-1.0: the minor is the breaking component.
+    if (( c_minor > b_minor )); then
+      echo "FAIL: breaking neat-core bump: $core_raw exceeds handled baseline $baseline_raw (pre-1.0 minor increased)" >&2
+      remediation
+      exit 1
+    fi
+    if (( c_minor < b_minor )); then
+      echo "OK   neat-core $core_raw is behind handled baseline $baseline_raw (no breaking bump)"
+      exit 0
+    fi
+    echo "OK   neat-core $core_raw matches handled baseline $baseline_raw (patch-level drift allowed)"
+    exit 0
+  fi
+  # >= 1.0: same major — minor/patch drift is additive, never breaking.
+  echo "OK   neat-core $core_raw within handled baseline $baseline_raw major line (patch-level drift allowed)"
+  exit 0
+fi
+
+# c_major < b_major: neat-core sits below the baseline major — not a breaking
+# bump scorer needs to act on.
+echo "OK   neat-core $core_raw is behind handled baseline $baseline_raw (no breaking bump)"
+exit 0

--- a/tests/scripts/neat_core_version_gate.bats
+++ b/tests/scripts/neat_core_version_gate.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-neat-core-version.sh — Issue #252.
+#
+# The gate fails CI when the sibling neat-core presents a breaking bump above
+# scorer's recorded baseline (neat-core.expected-version), forcing a deliberate
+# upgrade instead of tracking head blindly. Pre-1.0 the breaking component is
+# the minor; >= 1.0 it is the major. Patch-level drift is allowed.
+#
+# Every case drives the real script against synthetic fixtures in a temporary
+# directory so behaviour (exit codes, messages) is verified end-to-end without
+# touching the real baseline file or the sibling clone.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-neat-core-version.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+  BASELINE="$TMP_DIR/neat-core.expected-version"
+  CORE_MANIFEST="$TMP_DIR/Cargo.toml"
+  export BASELINE CORE_MANIFEST
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Write a baseline file containing a single version string.
+write_baseline() {
+  printf '%s\n' "$1" >"$BASELINE"
+}
+
+# Write a neat-core workspace manifest carrying [workspace.package] version.
+write_core_manifest() {
+  cat >"$CORE_MANIFEST" <<EOF
+[workspace]
+members = ["neat-core"]
+resolver = "2"
+
+[workspace.package]
+version = "$1"
+edition = "2024"
+EOF
+}
+
+run_gate() {
+  run "$SCRIPT_UNDER_TEST" --baseline "$BASELINE" --core-manifest "$CORE_MANIFEST"
+}
+
+@test "passes when neat-core version exactly matches the baseline" {
+  write_baseline "0.1.46"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "passes on patch-level drift above the baseline" {
+  write_baseline "0.1.40"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"patch-level drift"* ]]
+}
+
+@test "fails on a pre-1.0 breaking bump (minor increased) — the #177 scenario" {
+  write_baseline "0.1.46"
+  write_core_manifest "0.2.0"
+  run_gate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"breaking"* ]]
+  # Failure must point at the deliberate-upgrade step.
+  [[ "$output" == *"neat-core.expected-version"* ]]
+}
+
+@test "passes after the baseline acknowledges the breaking bump (#177 handled)" {
+  write_baseline "0.2.0"
+  write_core_manifest "0.2.0"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "fails when neat-core crosses the 1.0 boundary above a 0.x baseline" {
+  write_baseline "0.5.0"
+  write_core_manifest "1.0.0"
+  run_gate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"breaking"* ]]
+}
+
+@test "fails on a post-1.0 major bump" {
+  write_baseline "1.4.2"
+  write_core_manifest "2.0.0"
+  run_gate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"breaking"* ]]
+}
+
+@test "passes on a post-1.0 minor bump (additive, non-breaking)" {
+  write_baseline "1.4.2"
+  write_core_manifest "1.7.0"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "passes (with a note) when neat-core is behind the baseline" {
+  write_baseline "0.2.0"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"behind"* ]]
+}
+
+@test "ignores comments and blank lines in the baseline file" {
+  cat >"$BASELINE" <<'EOF'
+# Last-handled neat-core version (Issue #252).
+
+0.1.46
+EOF
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 0 ]
+}
+
+@test "errors when the baseline file is missing" {
+  write_core_manifest "0.1.46"
+  run "$SCRIPT_UNDER_TEST" --baseline "$TMP_DIR/nope.version" --core-manifest "$CORE_MANIFEST"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "errors when the neat-core manifest is missing" {
+  write_baseline "0.1.46"
+  run "$SCRIPT_UNDER_TEST" --baseline "$BASELINE" --core-manifest "$TMP_DIR/nope.toml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "errors when the baseline version is malformed" {
+  write_baseline "not-a-version"
+  write_core_manifest "0.1.46"
+  run_gate
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"malformed"* ]]
+}
+
+@test "errors when the manifest has no [workspace.package] version" {
+  write_baseline "0.1.46"
+  cat >"$CORE_MANIFEST" <<'EOF'
+[workspace]
+members = ["neat-core"]
+EOF
+  run_gate
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"version"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository baseline matches the sibling neat-core when present" {
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  SIBLING_MANIFEST="$REPO_ROOT/../NEAT-AI-core/Cargo.toml"
+  if [ ! -f "$SIBLING_MANIFEST" ]; then
+    skip "sibling NEAT-AI-core clone not present"
+  fi
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Milestone: #248 bug: neat-core breaking type change broke scorer build via unpinned path dep

This PR merges the completed milestone branch into Develop.
Closes #256

### Issues addressed
- #252: ci(scorer): gate that fails on an unhandled breaking neat-core bump (keep path dep)
- #251: neat-core: signal breaking changes via a semver (major-equivalent) bump + git tags/releases
- #250: fix(gpu): merge one from_index u16→u32 widen PR, close the other six (unblock build + Examples #604)

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.