### PR TITLE
Add # Examples doctest blocks to public API (Issue #275)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-275.md
+++ b/docs/archive/pr-summaries/pr-summary-275.md
@@ -60,7 +60,7 @@ Backend/CLI change with no web interface to screenshot. The evidence is the
 doctest run: `cargo test --doc -p rust_scorer` reports **17 passed; 0 failed**
 (13 executed with assertions, 4 `no_run` compile-checked):
 
-```
+```text
 running 17 tests
 test rust_scorer/src/cost.rs - cost::CostKind::from_cli ... ok
 test rust_scorer/src/cost.rs - cost::accumulate_cost_sum ... ok
@@ -74,7 +74,7 @@ test result: ok. 17 passed; 0 failed; 0 ignored
 `./quality.sh` passes cleanly (fmt, cargo-deny, clippy, check, build, test,
 rustdoc with `RUSTDOCFLAGS=-D warnings`, release build):
 
-```
+```text
 ✅ All quality checks passed!
 ```
 

--- a/docs/archive/pr-summaries/pr-summary-275.md
+++ b/docs/archive/pr-summaries/pr-summary-275.md
@@ -1,0 +1,101 @@
+# Add `# Examples` doctest blocks to the public API (Issue #275)
+
+## Summary
+
+The crate root (`rust_scorer/src/lib.rs`) re-exports 17 public functions for
+external targets (Criterion benches, integration tests). Each carried a `///`
+summary but **none** had a Rust API Guidelines **C-EXAMPLE** `# Examples`
+block. This PR adds a `# Examples` section to all 17, turning them into
+compile-checked, always-current usage samples that `cargo test` runs.
+
+Beyond documentation, doctests are compiled and executed by `cargo test`, so
+they catch signature drift that prose comments silently miss — exactly the
+value C-EXAMPLE is after. Where a function's `Err` conditions were not already
+spelled out (C-FAILURE), a short sentence was added alongside the example.
+
+Closes #275.
+
+## What changed
+
+Thirteen functions got **runnable** doctests with real `assert_*` checks; the
+four I/O- and GPU-bound entry points got `no_run` doctests that still
+type-check the call shape (they cannot execute without training files or a GPU
+device):
+
+| Module | Function | Kind |
+| --- | --- | --- |
+| `cost` | `CostKind::as_str` | runnable |
+| `cost` | `CostKind::from_cli` | runnable |
+| `cost` | `CostKind::gpu_supported` | runnable |
+| `cost` | `accumulate_cost_sum` | runnable |
+| `scoring` | `value_penalty` | runnable |
+| `scoring` | `compute_score_components` | runnable |
+| `scoring` | `complexity_penalty` | runnable |
+| `scoring` | `calculate_score` | runnable |
+| `env_tuning` | `parse_tuning_var` | runnable |
+| `read_tuning` | `training_read_target_bytes_from_env` | runnable |
+| `read_tuning` | `training_read_backend_label` | runnable |
+| `stream_score` | `activation_worker_count_for_scorer` | runnable |
+| `stream_score` | `effective_fused_read_buf_len` | runnable |
+| `stream_score` | `accumulate_cost_sum_forward_only_fused` | `no_run` |
+| `multi_score` | `score_from_creature_dir` | `no_run` |
+| `multi_score` | `gpu_directory_compatible` | `no_run` |
+| `multi_score` | `score_from_creature_dir_gpu` | `no_run` |
+
+The priority entry points called out in the issue —
+`scoring::calculate_score`, `scoring::compute_score_components`,
+`multi_score::score_from_creature_dir`, and `cost::accumulate_cost_sum` — are
+all covered.
+
+`Cargo.lock` was also synced to the committed `1.0.3` crate version (it lagged
+at `1.0.2`).
+
+## Deno regression avoided
+
+N/A — this is a Rust-only repository; no Node or Deno tooling is involved.
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. The evidence is the
+doctest run: `cargo test --doc -p rust_scorer` reports **17 passed; 0 failed**
+(13 executed with assertions, 4 `no_run` compile-checked):
+
+```
+running 17 tests
+test rust_scorer/src/cost.rs - cost::CostKind::from_cli ... ok
+test rust_scorer/src/cost.rs - cost::accumulate_cost_sum ... ok
+test rust_scorer/src/scoring.rs - scoring::calculate_score ... ok
+test rust_scorer/src/scoring.rs - scoring::compute_score_components ... ok
+test rust_scorer/src/multi_score.rs - multi_score::score_from_creature_dir - compile ... ok
+... (17 total)
+test result: ok. 17 passed; 0 failed; 0 ignored
+```
+
+`./quality.sh` passes cleanly (fmt, cargo-deny, clippy, check, build, test,
+rustdoc with `RUSTDOCFLAGS=-D warnings`, release build):
+
+```
+✅ All quality checks passed!
+```
+
+```mermaid
+flowchart LR
+    A["Public fn with /// summary"] --> B["Add # Examples doctest"]
+    B --> C["cargo test --doc compiles & runs it"]
+    C --> D["Signature drift caught early"]
+```
+
+## Test Plan
+
+- The added doctests **are** the new tests — each runnable example calls the
+  real function with test data and asserts on the result (e.g.
+  `cost::CostKind::from_cli` asserts the accept and reject paths; the malformed
+  chunk in `cost::accumulate_cost_sum` asserts `is_err()`).
+- Verified with `cargo test --doc -p rust_scorer` → 17 passed, 0 failed.
+- Full gate `./quality.sh < /dev/null` → all checks passed.
+- No existing tests were modified or removed.
+
+## Security self-check
+
+Documentation-only change (doc comments + lockfile version sync). No new input
+handling, no new SQL/shell/HTTP calls, no secrets staged.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -50,6 +50,14 @@ impl CostKind {
     /// Stable serialised label as a `&'static str`. Matches the TypeScript
     /// `BUILT_IN_COST_NAMES` strings exactly. Used both by tests/benches and
     /// by Issue #121's `costName` JSON field on `ScoreResult`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_scorer::cost::CostKind;
+    /// assert_eq!(CostKind::Mse.as_str(), "MSE");
+    /// assert_eq!(CostKind::CrossEntropy.as_str(), "CROSS_ENTROPY");
+    /// ```
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Mse => "MSE",
@@ -68,6 +76,17 @@ impl CostKind {
     /// logic without going through clap's argv parser. The error message
     /// lists every supported name in the TypeScript order to match the
     /// `--help` output.
+    ///
+    /// Returns `Err` (with a message listing the supported names) when `raw`
+    /// does not exactly match one of the `BUILT_IN_COST_NAMES` strings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_scorer::cost::CostKind;
+    /// assert_eq!(CostKind::from_cli("MSE").unwrap(), CostKind::Mse);
+    /// assert!(CostKind::from_cli("FOO").is_err());
+    /// ```
     // Consumed by unit tests and downstream callers (`NeatOptions.costName`
     // pass-through, dispatch landing in #119-3); the bin target itself
     // relies on clap, not this helper.
@@ -92,6 +111,14 @@ impl CostKind {
     /// Issue #121: which costs the GPU `forward_mse_batched` kernel can
     /// service. Only [`CostKind::Mse`] today — every other cost forces a
     /// CPU fallback (or a hard error under `--gpu on`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_scorer::cost::CostKind;
+    /// assert!(CostKind::Mse.gpu_supported());
+    /// assert!(!CostKind::Mae.gpu_supported());
+    /// ```
     pub const fn gpu_supported(self) -> bool {
         matches!(self, Self::Mse)
     }
@@ -109,6 +136,44 @@ impl CostKind {
 /// `Result` return type is retained so future costs that need to surface
 /// a setup error (e.g. a kernel-only cost on the CPU path) can do so
 /// without churning every call site.
+///
+/// Returns `Err` when `chunk`'s float length is not a whole multiple of the
+/// `input_size + num_outputs` record stride (a malformed packed chunk).
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::cost::{CostKind, accumulate_cost_sum};
+/// use neat_core::creature::{CreatureExport, NeuronExport, SynapseExport, compile_creature};
+///
+/// // A trivial forward-only creature: one input wired straight to one output.
+/// let creature = CreatureExport {
+///     input: 1,
+///     output: 1,
+///     neurons: vec![NeuronExport {
+///         neuron_type: "output".to_string(),
+///         uuid: "output-0".to_string(),
+///         bias: 0.0,
+///         squash: Some("IDENTITY".to_string()),
+///     }],
+///     synapses: vec![SynapseExport {
+///         from_uuid: "input-0".to_string(),
+///         to_uuid: "output-0".to_string(),
+///         weight: 1.0,
+///         synapse_type: None,
+///     }],
+///     semantic_version: Some("4.0.0".to_string()),
+///     forward_only: true,
+/// };
+/// let mut network = compile_creature(&creature).unwrap();
+///
+/// // One packed record `[input, target]`; MSE sum is finite and non-negative.
+/// let sum = accumulate_cost_sum(CostKind::Mse, &mut network, &[0.5, 0.5], 1, 1, true).unwrap();
+/// assert!(sum.is_finite() && sum >= 0.0);
+///
+/// // A chunk length that is not a whole multiple of the 2-value stride errors.
+/// assert!(accumulate_cost_sum(CostKind::Mse, &mut network, &[0.5], 1, 1, true).is_err());
+/// ```
 pub fn accumulate_cost_sum(
     kind: CostKind,
     network: &mut CompiledNetwork,

--- a/rust_scorer/src/env_tuning.rs
+++ b/rust_scorer/src/env_tuning.rs
@@ -17,6 +17,22 @@
 ///
 /// The caller is responsible for emitting the warning (so this stays pure and
 /// unit-testable without touching process state or capturing stderr).
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::env_tuning::parse_tuning_var;
+///
+/// let parse = |s: &str| s.parse::<usize>().ok();
+/// // An unset knob falls back to the default silently.
+/// let (value, warning) = parse_tuning_var("NEAT_SCORER_READ_BYTES", None, 42, parse);
+/// assert_eq!(value, 42);
+/// assert!(warning.is_none());
+/// // A set-but-malformed value returns the default plus a diagnostic.
+/// let (value, warning) = parse_tuning_var("NEAT_SCORER_READ_BYTES", Some("2MB"), 42, parse);
+/// assert_eq!(value, 42);
+/// assert!(warning.is_some());
+/// ```
 pub fn parse_tuning_var<T, F>(
     name: &str,
     raw: Option<&str>,

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -189,6 +189,26 @@ fn workers_per_creature(n_creatures: usize, activation_threads: usize) -> Vec<us
 /// `cost` is the resolved loss function dispatched through
 /// [`accumulate_cost_sum`] inside the per-chunk hot loop. Returns `Err` with a
 /// human-readable message on I/O, shape, or cost-resolution failure.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use rust_scorer::cost::CostKind;
+/// use rust_scorer::gpu::GpuBackendLabel;
+/// use rust_scorer::multi_score::score_from_creature_dir;
+///
+/// let scores = score_from_creature_dir(
+///     Path::new("creatures/"),
+///     Path::new("training_data/"),
+///     GpuBackendLabel::CpuFallback,
+///     CostKind::Mse,
+/// )
+/// .unwrap();
+/// for (id, result) in &scores {
+///     println!("{id}: score = {}", result.score);
+/// }
+/// ```
 pub fn score_from_creature_dir(
     creatures_dir: &Path,
     data_path: &Path,
@@ -464,6 +484,18 @@ pub fn score_from_creature_dir(
 ///   GPU-incompatibility: they are left for the normal scoring path to surface
 ///   with its existing, precise error message (e.g. shape mismatch,
 ///   `forwardOnly=false`).
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use rust_scorer::multi_score::gpu_directory_compatible;
+///
+/// match gpu_directory_compatible(Path::new("creatures/")) {
+///     Ok(()) => println!("set is GPU-hostable (or deferred to the scoring path)"),
+///     Err(reason) => println!("must fall back to CPU: {reason}"),
+/// }
+/// ```
 pub fn gpu_directory_compatible(creatures_dir: &Path) -> Result<(), String> {
     // A load failure here (missing dir, shape mismatch, forwardOnly=false, …)
     // is not a GPU-hostability question — return Ok so the real scoring path
@@ -511,6 +543,29 @@ pub fn gpu_directory_compatible(creatures_dir: &Path) -> Result<(), String> {
 /// path, with `gpuKernel` (`forward_mse_batched` for creatures within the 256
 /// cap, `forward_mse_scratch` above it — Issue #182), `gpuInflightChunks`, and
 /// `gpuDispatchCount` populated for every entry.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use std::sync::Arc;
+/// use rust_scorer::cost::CostKind;
+/// use rust_scorer::gpu::{GpuBackendLabel, select_adapter};
+/// use rust_scorer::multi_score::score_from_creature_dir_gpu;
+///
+/// // A real adapter is required — this only runs on a GPU-capable host.
+/// let ctx = Arc::new(select_adapter().unwrap().expect("a compatible GPU adapter"));
+/// let scores = score_from_creature_dir_gpu(
+///     Path::new("creatures/"),
+///     Path::new("training_data/"),
+///     GpuBackendLabel::Metal,
+///     ctx,
+///     2, // pipelined dispatches
+///     CostKind::Mse,
+/// )
+/// .unwrap();
+/// println!("scored {} creatures on the GPU", scores.len());
+/// ```
 pub fn score_from_creature_dir_gpu(
     creatures_dir: &Path,
     data_path: &Path,

--- a/rust_scorer/src/read_tuning.rs
+++ b/rust_scorer/src/read_tuning.rs
@@ -11,6 +11,19 @@ const DEFAULT_READ_BYTES: usize = 2 * 1024 * 1024;
 pub const MAX_READ_BYTES: usize = 64 * 1024 * 1024;
 
 /// Target bytes per `read` (rounded down to a multiple of `record_bytes`).
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::read_tuning::training_read_target_bytes_from_env;
+///
+/// // Whatever `NEAT_SCORER_READ_BYTES` is set to, the result is always a whole
+/// // number of records and at least one record wide.
+/// let record_bytes = 256;
+/// let target = training_read_target_bytes_from_env(record_bytes);
+/// assert_eq!(target % record_bytes, 0);
+/// assert!(target >= record_bytes);
+/// ```
 pub fn training_read_target_bytes_from_env(record_bytes: usize) -> usize {
     let rb = record_bytes.max(1);
     let env = std::env::var("NEAT_SCORER_READ_BYTES").ok();
@@ -28,6 +41,16 @@ pub fn training_read_target_bytes_from_env(record_bytes: usize) -> usize {
 }
 
 /// Stable label for the active training-read implementation (for JSON diagnostics).
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::read_tuning::training_read_backend_label;
+///
+/// // `native_pipelined` on native targets, `wasm_chunked` under wasm32.
+/// let label = training_read_backend_label();
+/// assert!(label == "native_pipelined" || label == "wasm_chunked");
+/// ```
 pub fn training_read_backend_label() -> &'static str {
     #[cfg(target_arch = "wasm32")]
     {

--- a/rust_scorer/src/scoring.rs
+++ b/rust_scorer/src/scoring.rs
@@ -24,6 +24,19 @@ pub const SEMANTIC_MAJOR_VERSION: u32 = 4;
 /// arbitrary creature JSON — so malformed input yields a structured error
 /// rather than a release-build panic (Issue #201). The remaining bounds are
 /// pure internal-math invariants and stay as `debug_assert!`.
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::scoring::value_penalty;
+/// // Magnitudes at or below 1.0 carry no penalty.
+/// assert_eq!(value_penalty(1.0).unwrap(), 0.0);
+/// // Larger magnitudes approach — but never reach — 1.0.
+/// let p = value_penalty(10.0).unwrap();
+/// assert!(p > 0.0 && p < 1.0);
+/// // Negative input is rejected.
+/// assert!(value_penalty(-1.0).is_err());
+/// ```
 pub fn value_penalty(value: f64) -> Result<f64, String> {
     if value < 0.0 {
         return Err(format!("value_penalty: value {value} is negative"));
@@ -99,6 +112,38 @@ pub struct ScoreComponents {
 /// values come straight from user-supplied creature JSON, so a NaN/inf weight
 /// or bias yields a structured error instead of a release-build panic
 /// (Issue #201).
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::scoring::compute_score_components;
+/// use neat_core::creature::{CreatureExport, NeuronExport, SynapseExport};
+///
+/// let creature = CreatureExport {
+///     input: 1,
+///     output: 1,
+///     neurons: vec![NeuronExport {
+///         neuron_type: "output".to_string(),
+///         uuid: "output-0".to_string(),
+///         bias: -0.3,
+///         squash: Some("IDENTITY".to_string()),
+///     }],
+///     synapses: vec![SynapseExport {
+///         from_uuid: "input-0".to_string(),
+///         to_uuid: "output-0".to_string(),
+///         weight: 2.0,
+///         synapse_type: None,
+///     }],
+///     semantic_version: Some("4.0.0".to_string()),
+///     forward_only: true,
+/// };
+///
+/// let components = compute_score_components(&creature).unwrap();
+/// assert_eq!(components.synapse_count, 1);
+/// assert_eq!(components.hidden_neuron_count, 0);
+/// // Max absolute weight/bias across `{2.0, 0.3}` is `2.0`.
+/// assert!((components.max_weight_bias - 2.0).abs() < 1e-12);
+/// ```
 pub fn compute_score_components(creature: &CreatureExport) -> Result<ScoreComponents, String> {
     let mut max_weight_bias: f64 = 0.0;
     let mut total_weight_bias: f64 = 0.0;
@@ -189,6 +234,22 @@ pub fn compute_score_components(creature: &CreatureExport) -> Result<ScoreCompon
 /// The weight/bias term routes through `calculate_penalty` (which validates
 /// finiteness), so every call site shares the same numerical behaviour and the
 /// same structured-error propagation (Issue #201).
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::scoring::{ScoreComponents, complexity_penalty};
+///
+/// let components = ScoreComponents {
+///     hidden_neuron_count: 2,
+///     synapse_count: 4,
+///     max_weight_bias: 1.5,
+///     avg_weight_bias: 0.75,
+///     squash_complexity_penalty: 0.0,
+/// };
+/// let penalty = complexity_penalty(&components, 0.01).unwrap();
+/// assert!(penalty > 0.0);
+/// ```
 pub fn complexity_penalty(components: &ScoreComponents, growth_cost: f64) -> Result<f64, String> {
     let weight_bias_penalty =
         calculate_penalty(components.max_weight_bias, components.avg_weight_bias)?;
@@ -213,6 +274,27 @@ pub fn complexity_penalty(components: &ScoreComponents, growth_cost: f64) -> Res
 /// rather than a release-build panic (Issue #201). The `score <= 1.0` bound is
 /// a pure internal-math invariant (guaranteed once `error >= 0` and the
 /// penalties are non-negative) and stays as `debug_assert!`.
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::scoring::{ScoreComponents, calculate_score};
+///
+/// let components = ScoreComponents {
+///     hidden_neuron_count: 0,
+///     synapse_count: 0,
+///     max_weight_bias: 0.0,
+///     avg_weight_bias: 0.0,
+///     squash_complexity_penalty: 0.0,
+/// };
+/// // Zero error, no complexity, current major version → a perfect score of 1.0.
+/// let score = calculate_score(0.0, &components, 0.01, Some("4.1.0")).unwrap();
+/// assert!((score - 1.0).abs() < 1e-12);
+/// // An off-version creature pays a tiny version penalty.
+/// assert!(calculate_score(0.0, &components, 0.01, Some("3.0.0")).unwrap() < 1.0);
+/// // A negative average error is rejected.
+/// assert!(calculate_score(-0.1, &components, 0.01, None).is_err());
+/// ```
 pub fn calculate_score(
     error: f64,
     components: &ScoreComponents,

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -28,6 +28,16 @@ const MAX_ACTIVATION_WORKERS: usize = 64;
 
 /// Parsed `NEAT_SCORER_ACTIVATION_THREADS`: missing defaults to all available CPUs.
 /// Clamped to `[1, MAX_ACTIVATION_WORKERS]`.
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::stream_score::activation_worker_count_for_scorer;
+///
+/// // Always at least one worker and never above the internal cap of 64.
+/// let workers = activation_worker_count_for_scorer();
+/// assert!((1..=64).contains(&workers));
+/// ```
 pub fn activation_worker_count_for_scorer() -> usize {
     // Unset/blank/malformed all resolve to "all available CPUs"; a malformed
     // value additionally warns instead of falling back silently (Issue #204).
@@ -53,6 +63,18 @@ pub fn activation_worker_count_for_scorer() -> usize {
 /// (capped like the core I/O tuner) so `pending` can hold two whole records per activation batch.
 /// Otherwise each read often yields only one complete record when `record_bytes` is large, and
 /// parallel activation never runs (`parallelActivationBatches: 0`).
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::stream_score::effective_fused_read_buf_len;
+///
+/// // The buffer is always a whole number of records and holds at least one.
+/// let record_bytes = 256;
+/// let len = effective_fused_read_buf_len(record_bytes, 4096);
+/// assert_eq!(len % record_bytes, 0);
+/// assert!(len >= record_bytes);
+/// ```
 pub fn effective_fused_read_buf_len(record_bytes: usize, target_read_bytes: usize) -> usize {
     let rb = record_bytes.max(1);
     let worker_count = activation_worker_count_for_scorer();
@@ -99,6 +121,36 @@ fn partition_packed_records(
 /// seen in one activation call (diagnostic: if it stays `1` while `parallel_activation_batches`
 /// is `0`, each read chunk holds at most one full record — raise **`NEAT_SCORER_READ_BYTES`**
 /// so multiple records fit in `pending` at once).
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::PathBuf;
+/// use rust_scorer::cost::CostKind;
+/// use rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused;
+/// use neat_core::creature::{compile_creature, parse_creature_json};
+/// use neat_core::training_data::TrainingDataConfig;
+///
+/// let creature = parse_creature_json(&std::fs::read_to_string("creature.json").unwrap()).unwrap();
+/// let mut network = compile_creature(&creature).unwrap();
+/// let config = TrainingDataConfig {
+///     num_inputs: creature.input,
+///     num_outputs: creature.output,
+/// };
+/// let bin_files = vec![PathBuf::from("data/train.bin")];
+///
+/// let (loss_sum, records, _batches, _max_batch, _clone_secs) =
+///     accumulate_cost_sum_forward_only_fused(
+///         CostKind::Mse,
+///         &bin_files,
+///         &config,
+///         &creature,
+///         &mut network,
+///     )
+///     .unwrap();
+/// let mean_error = loss_sum / records as f64;
+/// println!("mean error = {mean_error}");
+/// ```
 pub fn accumulate_cost_sum_forward_only_fused(
     cost: CostKind,
     bin_files: &[std::path::PathBuf],


### PR DESCRIPTION
# Add `# Examples` doctest blocks to the public API (Issue #275)

## Summary

The crate root (`rust_scorer/src/lib.rs`) re-exports 17 public functions for
external targets (Criterion benches, integration tests). Each carried a `///`
summary but **none** had a Rust API Guidelines **C-EXAMPLE** `# Examples`
block. This PR adds a `# Examples` section to all 17, turning them into
compile-checked, always-current usage samples that `cargo test` runs.

Beyond documentation, doctests are compiled and executed by `cargo test`, so
they catch signature drift that prose comments silently miss — exactly the
value C-EXAMPLE is after. Where a function's `Err` conditions were not already
spelled out (C-FAILURE), a short sentence was added alongside the example.

Closes #275.

## What changed

Thirteen functions got **runnable** doctests with real `assert_*` checks; the
four I/O- and GPU-bound entry points got `no_run` doctests that still
type-check the call shape (they cannot execute without training files or a GPU
device):

| Module | Function | Kind |
| --- | --- | --- |
| `cost` | `CostKind::as_str` | runnable |
| `cost` | `CostKind::from_cli` | runnable |
| `cost` | `CostKind::gpu_supported` | runnable |
| `cost` | `accumulate_cost_sum` | runnable |
| `scoring` | `value_penalty` | runnable |
| `scoring` | `compute_score_components` | runnable |
| `scoring` | `complexity_penalty` | runnable |
| `scoring` | `calculate_score` | runnable |
| `env_tuning` | `parse_tuning_var` | runnable |
| `read_tuning` | `training_read_target_bytes_from_env` | runnable |
| `read_tuning` | `training_read_backend_label` | runnable |
| `stream_score` | `activation_worker_count_for_scorer` | runnable |
| `stream_score` | `effective_fused_read_buf_len` | runnable |
| `stream_score` | `accumulate_cost_sum_forward_only_fused` | `no_run` |
| `multi_score` | `score_from_creature_dir` | `no_run` |
| `multi_score` | `gpu_directory_compatible` | `no_run` |
| `multi_score` | `score_from_creature_dir_gpu` | `no_run` |

The priority entry points called out in the issue —
`scoring::calculate_score`, `scoring::compute_score_components`,
`multi_score::score_from_creature_dir`, and `cost::accumulate_cost_sum` — are
all covered.

`Cargo.lock` was also synced to the committed `1.0.3` crate version (it lagged
at `1.0.2`).

## Deno regression avoided

N/A — this is a Rust-only repository; no Node or Deno tooling is involved.

## Evidence

Backend/CLI change with no web interface to screenshot. The evidence is the
doctest run: `cargo test --doc -p rust_scorer` reports **17 passed; 0 failed**
(13 executed with assertions, 4 `no_run` compile-checked):

```
running 17 tests
test rust_scorer/src/cost.rs - cost::CostKind::from_cli ... ok
test rust_scorer/src/cost.rs - cost::accumulate_cost_sum ... ok
test rust_scorer/src/scoring.rs - scoring::calculate_score ... ok
test rust_scorer/src/scoring.rs - scoring::compute_score_components ... ok
test rust_scorer/src/multi_score.rs - multi_score::score_from_creature_dir - compile ... ok
... (17 total)
test result: ok. 17 passed; 0 failed; 0 ignored
```

`./quality.sh` passes cleanly (fmt, cargo-deny, clippy, check, build, test,
rustdoc with `RUSTDOCFLAGS=-D warnings`, release build):

```
✅ All quality checks passed!
```

```mermaid
flowchart LR
    A["Public fn with /// summary"] --> B["Add # Examples doctest"]
    B --> C["cargo test --doc compiles & runs it"]
    C --> D["Signature drift caught early"]
```

## Test Plan

- The added doctests **are** the new tests — each runnable example calls the
  real function with test data and asserts on the result (e.g.
  `cost::CostKind::from_cli` asserts the accept and reject paths; the malformed
  chunk in `cost::accumulate_cost_sum` asserts `is_err()`).
- Verified with `cargo test --doc -p rust_scorer` → 17 passed, 0 failed.
- Full gate `./quality.sh < /dev/null` → all checks passed.
- No existing tests were modified or removed.

## Security self-check

Documentation-only change (doc comments + lockfile version sync). No new input
handling, no new SQL/shell/HTTP calls, no secrets staged.
