### PR TITLE
Assert multi-creature batch scoring makes exactly one pass over training data (stSoftwareAU/NEAT-AI#3236)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.0.5"
+version = "1.1.0"
 dependencies = [
  "bytemuck",
  "clap",

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.0.7"
+version = "1.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -58,8 +58,8 @@ const GROWTH_COST: f64 = 0.000_000_1;
 /// per-creature re-reads of the training data (which would make the sweep count
 /// scale with creature count instead of staying flat at `1`).
 ///
-/// Usage from a test: call [`reset`], run one scoring invocation, then assert
-/// [`count`] equals `1`.
+/// Usage from a test: call [`training_pass_probe::reset`], run one scoring
+/// invocation, then assert [`training_pass_probe::count`] equals `1`.
 ///
 /// Production overhead is a single atomic increment per whole scoring run —
 /// negligible against a full training-corpus sweep.

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -46,6 +46,48 @@ use crate::stream_score::{activation_worker_count_for_scorer, effective_fused_re
 /// Keep aligned with main scorer formula.
 const GROWTH_COST: f64 = 0.000_000_1;
 
+/// Instrumentation for the "single pass over training data" invariant
+/// (Issue #3236).
+///
+/// Every multi-creature batch scoring path in this module sweeps the training
+/// corpus **exactly once** via
+/// [`neat_core::training_bin_stream::for_each_read_chunk`], scoring the whole
+/// batch of creatures in that single pass. This process-global counter lets the
+/// `single_pass_assertion` integration test observe how many sweeps a scoring
+/// invocation performs and fail loudly if a future change reintroduces
+/// per-creature re-reads of the training data (which would make the sweep count
+/// scale with creature count instead of staying flat at `1`).
+///
+/// Usage from a test: call [`reset`], run one scoring invocation, then assert
+/// [`count`] equals `1`.
+///
+/// Production overhead is a single atomic increment per whole scoring run —
+/// negligible against a full training-corpus sweep.
+pub mod training_pass_probe {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TRAINING_DATA_SWEEPS: AtomicU64 = AtomicU64::new(0);
+
+    /// Reset the sweep counter to zero. Call immediately before a scoring
+    /// invocation whose sweep count you want to observe.
+    #[allow(dead_code)] // used by the `single_pass_assertion` integration test.
+    pub fn reset() {
+        TRAINING_DATA_SWEEPS.store(0, Ordering::SeqCst);
+    }
+
+    /// Number of full training-data sweeps recorded since the last [`reset`].
+    #[allow(dead_code)] // used by the `single_pass_assertion` integration test.
+    pub fn count() -> u64 {
+        TRAINING_DATA_SWEEPS.load(Ordering::SeqCst)
+    }
+
+    /// Record one full sweep over the training corpus. Called immediately
+    /// before each `for_each_read_chunk` invocation in the batch paths.
+    pub(crate) fn record_sweep() {
+        TRAINING_DATA_SWEEPS.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
 struct LoadedCreature {
     key: String,
     path: PathBuf,
@@ -393,6 +435,10 @@ pub fn score_from_creature_dir(
         Ok(())
     };
 
+    // Issue #3236: one sweep over the whole training corpus scores every
+    // creature in the batch. Record it so `single_pass_assertion` fails loudly
+    // if a future change reintroduces per-creature re-reads.
+    training_pass_probe::record_sweep();
     for_each_read_chunk(&bin_files, fused_read_buf_len, |chunk| {
         run_io_loop(
             chunk,
@@ -677,6 +723,8 @@ pub fn score_from_creature_dir_gpu(
             Ok(())
         };
 
+        // Issue #3236: single sweep over the corpus for the whole GPU batch.
+        training_pass_probe::record_sweep();
         for_each_read_chunk(&bin_files, fused_read_buf_len, |chunk| {
             run_io_loop(
                 chunk,
@@ -771,6 +819,9 @@ pub fn score_from_creature_dir_gpu(
             Ok(())
         };
 
+        // Issue #3236: single sweep over the corpus for the whole pipelined
+        // GPU batch.
+        training_pass_probe::record_sweep();
         for_each_read_chunk(&bin_files, fused_read_buf_len, |chunk| {
             run_io_loop(
                 chunk,

--- a/rust_scorer/tests/single_pass_assertion.rs
+++ b/rust_scorer/tests/single_pass_assertion.rs
@@ -1,0 +1,132 @@
+//! Issue #3236: permanent automated assertion that multi-creature
+//! (directory/batch) scoring makes **exactly one pass** over the training data,
+//! scoring the whole batch in that single sweep — independent of the number of
+//! creatures.
+//!
+//! The assertion is deterministic: `multi_score` records every sweep over the
+//! training corpus through
+//! [`rust_scorer::multi_score::training_pass_probe`], so these tests reset the
+//! probe, run one scoring invocation, then assert the observed sweep count is
+//! `1`. If a future change reintroduces per-creature re-reads of the training
+//! data (looping the `for_each_read_chunk` sweep once per creature), the sweep
+//! count would equal the creature count `N` and the `assert_eq!` below fails —
+//! breaking `cargo test` before the regression can land.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::gpu::GpuBackendLabel;
+use rust_scorer::multi_score::{score_from_creature_dir, training_pass_probe};
+
+/// The sweep probe is a process-global counter, so tests in this binary that
+/// touch it must not run concurrently. Serialise them through this lock; recover
+/// from poisoning so one failing test does not cascade into the others.
+static PROBE_LOCK: Mutex<()> = Mutex::new(());
+
+/// A minimal forward-only identity creature (1 input, 1 output). Every creature
+/// in a directory-mode batch must share the same input/output shape.
+fn minimal_creature() -> &'static str {
+    r#"{"input":1,"output":1,"forwardOnly":true,"neurons":[{"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}],"synapses":[{"fromUUID":"input-0","toUUID":"output-0","weight":1.0}]}"#
+}
+
+/// Write `n` distinct creature JSON files (identical shape, distinct filenames)
+/// into `creatures_dir`.
+fn write_creatures(creatures_dir: &Path, n: usize) {
+    for i in 0..n {
+        std::fs::write(
+            creatures_dir.join(format!("creature-{i}.json")),
+            minimal_creature(),
+        )
+        .expect("write creature json");
+    }
+}
+
+/// Write a training corpus of `records` (input, output) pairs across the given
+/// number of `.bin` files, round-robin, so multi-file traversal is exercised.
+fn write_training_data(data_dir: &Path, records: &[(f32, f32)], bin_files: usize) {
+    let files: Vec<std::fs::File> = (0..bin_files)
+        .map(|i| std::fs::File::create(data_dir.join(format!("{i}.bin"))).expect("create bin"))
+        .collect();
+    let mut files = files;
+    for (idx, (input, output)) in records.iter().enumerate() {
+        let f = &mut files[idx % bin_files];
+        f.write_all(&input.to_le_bytes()).expect("write input");
+        f.write_all(&output.to_le_bytes()).expect("write output");
+    }
+}
+
+/// Score `n_creatures` against a fixed corpus on the CPU path and return the
+/// number of training-data sweeps observed for that single invocation.
+fn sweeps_for_batch(n_creatures: usize, bin_files: usize) -> u64 {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let creatures_dir = tmp.path().join("creatures");
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir(&data_dir).expect("create data dir");
+
+    write_creatures(&creatures_dir, n_creatures);
+    let records: Vec<(f32, f32)> = (0..64).map(|i| (i as f32 * 0.1, i as f32 * 0.1)).collect();
+    write_training_data(&data_dir, &records, bin_files);
+
+    training_pass_probe::reset();
+    let scores = score_from_creature_dir(
+        &creatures_dir,
+        &data_dir,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+    )
+    .expect("scoring must succeed");
+
+    // Sanity: the single sweep really scored every creature in the batch.
+    assert_eq!(
+        scores.len(),
+        n_creatures,
+        "expected a score for each of the {n_creatures} creatures",
+    );
+
+    training_pass_probe::count()
+}
+
+/// Core assertion: scoring N > 1 creatures traverses the training data exactly
+/// once, regardless of N. A regression that re-reads per creature would report
+/// `N` sweeps instead of `1`.
+#[test]
+fn multi_creature_batch_makes_exactly_one_pass() {
+    let _guard = PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    for &n in &[2_usize, 5, 11] {
+        let sweeps = sweeps_for_batch(n, 1);
+        assert_eq!(
+            sweeps, 1,
+            "scoring {n} creatures must make exactly one pass over the training data, observed {sweeps}",
+        );
+    }
+}
+
+/// The one-pass property is independent of how many `.bin` files the corpus is
+/// split across: a single sweep still covers the whole multi-file corpus.
+#[test]
+fn multi_creature_batch_one_pass_across_multiple_bin_files() {
+    let _guard = PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let sweeps = sweeps_for_batch(4, 3);
+    assert_eq!(
+        sweeps, 1,
+        "one sweep must cover the whole multi-file corpus, observed {sweeps}",
+    );
+}
+
+/// Contrast case (Scope item 3): the single-creature path also makes exactly
+/// one pass, pinning that N == 1 and N > 1 share the same one-sweep contract.
+#[test]
+fn single_creature_makes_exactly_one_pass() {
+    let _guard = PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let sweeps = sweeps_for_batch(1, 1);
+    assert_eq!(
+        sweeps, 1,
+        "scoring a single creature must make exactly one pass, observed {sweeps}",
+    );
+}


### PR DESCRIPTION
## Summary

Adds a permanent, deterministic assertion that multi-creature (directory/batch) scoring reads the training corpus in **exactly one pass**, scoring the whole batch in that single sweep — so the "one pass over the training data" property is guaranteed by the test suite, not just by inspection.

Implements the "permanent automated assertion" half of stSoftwareAU/NEAT-AI#3236 (child of stSoftwareAU/NEAT-AI#3233).

## Changes

- **Instrumentation** — `rust_scorer/src/multi_score.rs` gains a process-global `training_pass_probe` sweep counter (`reset` / `count` / `record_sweep`). `record_sweep()` is called immediately before each `for_each_read_chunk` invocation in all three batch paths: CPU, GPU-synchronous, and GPU-pipelined. Overhead is one atomic increment per whole scoring run.
- **Test** — `rust_scorer/tests/single_pass_assertion.rs`:
  - `multi_creature_batch_makes_exactly_one_pass` — scoring N ∈ {2, 5, 11} creatures traverses the data **once**, independent of N.
  - `multi_creature_batch_one_pass_across_multiple_bin_files` — one sweep covers a multi-file corpus.
  - `single_creature_makes_exactly_one_pass` — contrast case pinning that N == 1 shares the one-sweep contract.

If a future change reintroduces per-creature re-reads (looping the sweep once per creature), the counter reports **N** and the `assert_eq!` fails — breaking `cargo test` before the regression can land.

## Regression detection verified

Temporarily wrapping the CPU-path sweep in `for _ in 0..loaded.len()` made the assertion fail loudly (`observed 2` / `observed 4`, `right: 1`); reverting restored green. This is the authoritative detection point — the existing `directory_mode_tdd.rs` / `scorer_smoke.rs` / `cost_parity.rs` tests do not cover pass count.

## Test plan

- `cargo test -p rust_scorer` — all suites pass (new `single_pass_assertion` 3/3; nothing else regressed).
- `cargo fmt --check` clean; `cargo clippy --all-targets` clean.

Tracked by stSoftwareAU/NEAT-AI#3236.