### PR TITLE
Early-exit / partial-score API for directory-mode batch scoring (Issue #308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ section to the released version with its date.
 
 ## [Unreleased]
 
+### Added
+
+- **Early-exit / partial-score API for directory-mode batch scoring
+  (Issue #308).** New library entrypoint
+  `multi_score::score_from_creature_dir_with_early_exit` mirrors
+  `score_from_creature_dir` but invokes a caller-supplied callback after each
+  scored chunk with a `PartialScore` snapshot (running mean error + records
+  scored) per still-active creature. The callback returns an `EarlyExit`
+  directive — `Continue`, `AbortCreatures(indices)` (freeze those creatures at
+  their partial score for the rest of the corpus), or `AbortAll` (stop the
+  sweep). Aborted creatures skip all remaining activation work, which is the
+  wall-clock saving. This unblocks NEAT-AI#3264's cascading / early-abort
+  fitness ranking without reimplementing the fused scoring loop in TypeScript.
+  **Full-score parity:** with no callback (or a callback that always returns
+  `Continue`) scores are bit-identical to the old path — verified by
+  `tests/early_exit_tdd.rs`. **Benchmark (Issue #308 gate,
+  `BENCH_SCORING_BYTES=32 MiB`, synthetic 8→8→2 population, aborting 50 % of
+  creatures after the first chunk):** directory-mode median wall-clock drops
+  **40.4 %** at N=50 (2.02 s → 1.20 s) and **45.1 %** at N=200 (4.77 s →
+  2.62 s) — far above the ≥5 % merge gate. Single-creature path unchanged.
+
 ### Changed
 
 - **Document the recommended `NEAT_SCORER_READ_BYTES` for large-record GRQ

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -325,6 +325,67 @@ This mode uses one shared training-data scan and parallelises scoring across cre
 
 Per-chunk activation runs through a single flat Rayon layer (Issue #41): a worker network pool sized to `activation_threads` is built up-front, and every chunk dispatches one `par_iter_mut` over that pool. When the population meets or exceeds `activation_threads` each creature owns one worker; below that, the thread budget is spread across creatures so a small population still saturates the CPU. The JSON output keeps the same shape — `parallelActivationBatches` and `maxActivationBatchRecords` are not emitted in directory mode.
 
+#### Early-exit / partial-score API (Issue #308)
+
+The directory-mode batch path is also exposed as a library entrypoint with a
+per-chunk early-exit hook, so a caller (e.g. NEAT-AI#3264's cascading fitness
+ranking) can abort creatures mid-corpus without reimplementing the fused
+scoring loop:
+
+```rust
+use rust_scorer::multi_score::{score_from_creature_dir_with_early_exit, EarlyExit};
+use rust_scorer::{cost::CostKind, gpu::GpuBackendLabel};
+use std::path::Path;
+
+let scores = score_from_creature_dir_with_early_exit(
+    Path::new("creatures/"),
+    Path::new("training_data/"),
+    GpuBackendLabel::CpuFallback,
+    CostKind::Mse,
+    |partials| {
+        // Abort any creature whose running error is already 10x the best so far.
+        let best = partials.iter().map(|p| p.partial_error).fold(f64::INFINITY, f64::min);
+        let losers: Vec<usize> = partials
+            .iter()
+            .filter(|p| p.partial_error > best * 10.0)
+            .map(|p| p.creature_index)
+            .collect();
+        if losers.is_empty() { EarlyExit::Continue } else { EarlyExit::AbortCreatures(losers) }
+    },
+).unwrap();
+```
+
+After each scored chunk the callback receives one `PartialScore` per
+still-active creature (`creature_index`, `key`, running `partial_error`,
+`records_scored`) and returns an `EarlyExit`:
+
+- `Continue` — keep scoring every active creature.
+- `AbortCreatures(indices)` — stop scoring those creatures; each freezes at its
+  current partial score (its final `error` over a partial `record_count`).
+  Skipping them removes their activation cost from every remaining chunk.
+- `AbortAll` — stop the sweep entirely; every active creature freezes.
+
+**Full-score parity is guaranteed:** the plain `score_from_creature_dir` (no
+callback), and a callback that always returns `Continue`, produce
+**bit-identical** scores (`tests/early_exit_tdd.rs`). Aborting ~50 % of the
+population after the first chunk cuts directory-mode median wall-clock by
+**40–45 %** on the synthetic bench (`early_exit_directory` in
+`benches/scoring.rs`).
+
+```mermaid
+flowchart TD
+    A[Read chunk] --> B[Score chunk: active creatures only]
+    B --> C{Callback registered?}
+    C -- No --> A
+    C -- Yes --> D[Build PartialScore per active creature]
+    D --> E{EarlyExit?}
+    E -- Continue --> A
+    E -- AbortCreatures --> F[Mark listed creatures inactive] --> A
+    E -- AbortAll --> G[Stop sweep]
+    A -- corpus exhausted --> H[Finalise: error = sum / records_scored]
+    G --> H
+```
+
 For forward-only single-creature fused scoring, activation parallelism also
 defaults to all available CPU cores. Set `NEAT_SCORER_ACTIVATION_THREADS` only
 when you want to tune down/up manually.

--- a/docs/archive/pr-summaries/pr-summary-308.md
+++ b/docs/archive/pr-summaries/pr-summary-308.md
@@ -1,0 +1,111 @@
+## Summary
+
+Adds an **early-exit / partial-score API** to the directory-mode batch scoring
+path — the path production already uses 100 % of the time. A new library
+entrypoint `multi_score::score_from_creature_dir_with_early_exit` mirrors
+`score_from_creature_dir` but invokes a caller-supplied callback after each
+scored chunk. This unblocks [NEAT-AI#3264](https://github.com/stSoftwareAU/NEAT-AI/issues/3264)
+(cascading / early-abort fitness ranking) by letting a caller abort creatures
+mid-corpus **without reimplementing the fused `mse_sum_batch_packed` loop in
+TypeScript**. Closes #308.
+
+The callback receives one `PartialScore` per still-active creature
+(`creature_index`, `key`, running `partial_error`, `records_scored`) and returns
+an `EarlyExit`:
+
+- `Continue` — keep scoring every active creature.
+- `AbortCreatures(indices)` — stop scoring those creatures; each freezes at its
+  current partial score (its final `error` over a partial `record_count`).
+  Skipping them removes their activation cost from every remaining chunk — the
+  wall-clock saving.
+- `AbortAll` — stop the sweep immediately; every active creature freezes.
+
+**Full-score path unchanged:** `score_from_creature_dir` (no callback) delegates
+to the shared internal `score_from_creature_dir_cpu` with `None`, so its
+behaviour and scores are bit-identical to before. A callback that always returns
+`Continue` is likewise bit-identical (verified in tests). Per-creature
+`record_count` now reflects the records each creature was actually scored
+against, which equals the full corpus on the full-score path and the partial
+count for an aborted creature.
+
+### API shape chosen
+
+Of the candidate APIs in the issue, this PR takes the **chunk callback on the
+directory batch entrypoint** — the least invasive: it reuses the existing
+single-pass I/O envelope and flat Rayon worker pool, and adds only a per-chunk
+`active`/`records_scored` bookkeeping layer that collapses to a no-op when no
+callback is registered.
+
+## Evidence
+
+Backend/CLI change — no web UI to screenshot. Evidence is the benchmark A/B and
+the parity/behaviour tests.
+
+### Benchmark gate (merge on ≥5 % directory-mode wall-clock)
+
+`early_exit_directory` group in `rust_scorer/benches/scoring.rs`,
+`BENCH_SCORING_BYTES=33554432` (32 MiB corpus), synthetic 8→8→2 population,
+callback aborts ~50 % of the population (even indices) after the first scored
+chunk. Criterion median wall-clock:
+
+| Population | Full-score (baseline) | Early-exit (abort 50 %) | Δ wall-clock |
+|-----------:|----------------------:|------------------------:|-------------:|
+| N = 50     | 2.0183 s              | 1.2027 s                | **−40.4 %**  |
+| N = 200    | 4.7739 s              | 2.6207 s                | **−45.1 %**  |
+
+Both far exceed the **≥5 %** merge gate. The saving comes from aborted creatures
+skipping activation over the remaining chunks; because fitness/activation is
+~93.6 % of production wall-clock, removing half the population early recovers
+close to half the run.
+
+**Full-score parity (mandatory):** `always_continue_matches_full_score_baseline`
+asserts `error`/`score`/`record_count` are **bit-identical** (`to_bits()`)
+between `score_from_creature_dir` and the always-`Continue` early-exit path.
+
+### Per-chunk flow
+
+```mermaid
+flowchart TD
+    A[Read chunk] --> B[Score chunk: active creatures only]
+    B --> C{Callback registered?}
+    C -- No --> A
+    C -- Yes --> D[Build PartialScore per active creature]
+    D --> E{EarlyExit?}
+    E -- Continue --> A
+    E -- AbortCreatures --> F[Mark listed creatures inactive] --> A
+    E -- AbortAll --> G[Stop sweep]
+    A -- corpus exhausted --> H[Finalise: error = sum / records_scored]
+    G --> H
+```
+
+## Test Plan
+
+New integration tests in `rust_scorer/tests/early_exit_tdd.rs` (all drive the
+real library entrypoints against a temp corpus, with a tiny
+`NEAT_SCORER_READ_BYTES` forcing many streamed chunks):
+
+- `always_continue_matches_full_score_baseline` — full-score parity: an
+  always-`Continue` callback returns bit-identical `error`/`score`/`record_count`
+  vs `score_from_creature_dir`, and the callback fires on every chunk.
+- `abort_creatures_freezes_partial_and_keeps_survivors_exact` — aborting a
+  subset freezes their `record_count` below the full corpus while survivors stay
+  bit-identical to the baseline.
+- `abort_all_stops_sweep_early_for_every_creature` — `AbortAll` on the first
+  chunk stops the sweep; every creature has a partial (non-zero, below-full)
+  `record_count` and a finite score.
+- `partial_score_snapshot_is_well_formed` — the `PartialScore` snapshot exposes
+  a finite non-negative running error, a correct `key`, and monotonic
+  `records_scored`.
+
+Full `./quality.sh` passes (shellcheck, cargo-deny, fmt, clippy, check, build,
+test, rustdoc with `-D warnings`, release build). Existing
+`single_pass_assertion` tests still pass, confirming the corpus is still swept
+exactly once.
+
+## Out of scope
+
+- **GPU path** (`score_from_creature_dir_gpu`) — early-exit is CPU-only for now;
+  production directory-mode uses the CPU pipeline (95.8 % of neurons are
+  GPU-unsupported, #299). The GPU batched kernel would need a per-dispatch
+  active-mask to benefit, which is a larger change.
+- **Single-creature path** — unchanged, per the issue.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/benches/scoring.rs
+++ b/rust_scorer/benches/scoring.rs
@@ -47,7 +47,10 @@ use std::sync::Arc;
 
 use rust_scorer::cost::CostKind;
 use rust_scorer::gpu::{GpuBackendLabel, GpuMode, resolve_backend, select_adapter};
-use rust_scorer::multi_score::{score_from_creature_dir, score_from_creature_dir_gpu};
+use rust_scorer::multi_score::{
+    EarlyExit, score_from_creature_dir, score_from_creature_dir_gpu,
+    score_from_creature_dir_with_early_exit,
+};
 use rust_scorer::prod_fixture::{
     PRODUCTION_CREATURE_URL, corpus_record_count, fetch_creature_to, load_production_creature,
     resolve_creature_path,
@@ -760,10 +763,85 @@ fn bench_production_multi(c: &mut Criterion) {
     group.finish();
 }
 
+/// Issue #308: directory-mode early-exit A/B. For each population `N` this
+/// benches the full-score baseline (`score_from_creature_dir`) against the
+/// early-exit path (`score_from_creature_dir_with_early_exit`) with a callback
+/// that aborts ~50 % of the population after the first scored chunk — the
+/// representative "early-exit fires on ≥30 % of the population" scenario from
+/// the issue. Criterion's report lets you read the wall-clock delta between the
+/// `full` and `abort50` rows; the merge gate is ≥5 % on `abort50`.
+fn bench_early_exit_directory(c: &mut Criterion) {
+    let fix = fixture();
+    let mut group = c.benchmark_group("early_exit_directory");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(15));
+    group.throughput(Throughput::Bytes(fix.total_bytes as u64));
+
+    for &n in &[50_usize, 200_usize] {
+        let sub_dir = fix
+            .creatures_root
+            .parent()
+            .unwrap()
+            .join(format!("ee-dir-{n}"));
+        if !sub_dir.exists() {
+            fs::create_dir_all(&sub_dir).unwrap();
+            for i in 0..n {
+                let src = fix.creatures_root.join(format!("creature-{i:03}.json"));
+                let dst = sub_dir.join(format!("creature-{i:03}.json"));
+                fs::copy(&src, &dst).expect("copy creature");
+            }
+        }
+
+        // Full-score baseline.
+        group.bench_with_input(BenchmarkId::new("full", n), &sub_dir, |b, dir| {
+            b.iter(|| {
+                let result = score_from_creature_dir(
+                    dir,
+                    &fix.data_dir,
+                    GpuBackendLabel::CpuFallback,
+                    CostKind::default(),
+                )
+                .expect("full-score");
+                black_box(result);
+            });
+        });
+
+        // Early-exit: abort ~50 % of the population (even indices) after the
+        // first callback fires, then let the rest run to completion.
+        group.bench_with_input(BenchmarkId::new("abort50", n), &sub_dir, |b, dir| {
+            b.iter(|| {
+                let mut aborted = false;
+                let result = score_from_creature_dir_with_early_exit(
+                    dir,
+                    &fix.data_dir,
+                    GpuBackendLabel::CpuFallback,
+                    CostKind::default(),
+                    |partials| {
+                        if !aborted {
+                            aborted = true;
+                            let losers: Vec<usize> = partials
+                                .iter()
+                                .map(|p| p.creature_index)
+                                .filter(|i| i % 2 == 0)
+                                .collect();
+                            return EarlyExit::AbortCreatures(losers);
+                        }
+                        EarlyExit::Continue
+                    },
+                )
+                .expect("early-exit score");
+                black_box(result);
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_score_from_json_fused,
     bench_score_from_creature_dir,
+    bench_early_exit_directory,
     bench_unpack_and_mse_inner,
     bench_gpu_score_from_creature_dir,
     bench_gpu_pipelining_toggle,

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -223,6 +223,70 @@ fn workers_per_creature(n_creatures: usize, activation_threads: usize) -> Vec<us
         .collect()
 }
 
+/// Running snapshot of one still-active creature's score, handed to the
+/// early-exit callback after each scored chunk (Issue #308).
+///
+/// The directory-mode batch path sweeps the training corpus exactly once and
+/// scores every creature in that single pass. After each scored chunk a
+/// registered callback receives one [`PartialScore`] per creature that is still
+/// active, so a caller (e.g. NEAT-AI#3264's cascading fitness ranking) can
+/// decide — without reimplementing the fused scoring loop — whether a creature
+/// is already so far behind that scoring it over the rest of the corpus is
+/// wasted work.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PartialScore {
+    /// Stable index of the creature within the loaded directory (sorted file
+    /// order). Use this value in [`EarlyExit::AbortCreatures`] to abort it.
+    pub creature_index: usize,
+    /// Creature id (the `.json` file stem), matching the key in the returned
+    /// [`ScoreResult`] map.
+    pub key: String,
+    /// Mean error over the records scored **so far** (running cost sum divided
+    /// by [`records_scored`](PartialScore::records_scored)). Converges to the
+    /// creature's final `error` as the sweep completes.
+    pub partial_error: f64,
+    /// How many training records this creature has been scored against so far.
+    pub records_scored: usize,
+}
+
+/// Directive the early-exit callback returns after each scored chunk
+/// (Issue #308).
+///
+/// The full-score path is preserved by returning [`EarlyExit::Continue`] every
+/// time: with only `Continue` decisions every creature is scored over the whole
+/// corpus and the results are bit-identical to [`score_from_creature_dir`].
+// `#[allow(dead_code)]`: the self-contained `main.rs` module tree recompiles
+// this file for the binary, where these variants are never constructed; they
+// are part of the library API consumed by benches/tests (same rationale as
+// `training_pass_probe`).
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EarlyExit {
+    /// Keep scoring every still-active creature.
+    Continue,
+    /// Stop scoring the listed creature indices for the remainder of the
+    /// corpus. Each aborted creature freezes at its current partial score,
+    /// which becomes its final reported `error` (over its partial
+    /// `record_count`). Unknown indices are ignored.
+    AbortCreatures(Vec<usize>),
+    /// Stop the corpus sweep entirely. Every still-active creature freezes at
+    /// its current partial score. Use when no remaining creature is worth
+    /// scoring further.
+    AbortAll,
+}
+
+/// Early-exit callback trait object: invoked after each scored chunk with the
+/// running per-creature [`PartialScore`]s, returning the [`EarlyExit`] directive
+/// (Issue #308). Aliased to keep the internal `score_from_creature_dir_cpu`
+/// signature readable (`clippy::type_complexity`).
+type EarlyExitCallback<'a> = dyn FnMut(&[PartialScore]) -> EarlyExit + 'a;
+
+// Internal sentinel error used to unwind cleanly out of `for_each_read_chunk`
+// on `EarlyExit::AbortAll`. It is caught immediately after the sweep and never
+// surfaced to callers — a distinct NUL-prefixed marker that no genuine I/O or
+// cost error can collide with.
+const EARLY_EXIT_ABORT_ALL_SENTINEL: &str = "\u{0}neat-scorer-early-exit-abort-all";
+
 /// Score every creature in `creatures_dir` against the `.bin` training records
 /// under `data_path`, returning per-creature [`ScoreResult`]s keyed by creature
 /// id.
@@ -231,6 +295,10 @@ fn workers_per_creature(n_creatures: usize, activation_threads: usize) -> Vec<us
 /// `cost` is the resolved loss function dispatched through
 /// [`accumulate_cost_sum`] inside the per-chunk hot loop. Returns `Err` with a
 /// human-readable message on I/O, shape, or cost-resolution failure.
+///
+/// This is the full-score path: every creature is scored over the entire
+/// corpus. For the early-exit variant see
+/// [`score_from_creature_dir_with_early_exit`].
 ///
 /// # Examples
 ///
@@ -258,6 +326,95 @@ pub fn score_from_creature_dir(
     // Issue #121 — resolved cost selector; dispatched through
     // [`accumulate_cost_sum`] inside the per-chunk hot loop.
     cost: CostKind,
+) -> Result<BTreeMap<String, ScoreResult>, String> {
+    // No callback registered → behaviour and scores are identical to before the
+    // early-exit surface landed (Issue #308).
+    score_from_creature_dir_cpu(creatures_dir, data_path, gpu_backend, cost, None)
+}
+
+/// Issue #308 — directory-mode batch scoring with a per-chunk early-exit hook.
+///
+/// Same single-pass I/O envelope and scores as [`score_from_creature_dir`], but
+/// after every scored chunk `on_chunk` is called with one [`PartialScore`] per
+/// still-active creature. Its [`EarlyExit`] return controls the rest of the
+/// sweep:
+///
+/// * [`EarlyExit::Continue`] — keep scoring every active creature.
+/// * [`EarlyExit::AbortCreatures`] — stop scoring the given creatures; each
+///   freezes at its current partial score (its final `error` over its partial
+///   `record_count`). Skipping them removes their activation cost from every
+///   remaining chunk — the source of the wall-clock saving.
+/// * [`EarlyExit::AbortAll`] — stop the sweep immediately; every active
+///   creature freezes at its current partial score.
+///
+/// Returning [`EarlyExit::Continue`] on every call yields results bit-identical
+/// to [`score_from_creature_dir`] (the full-score parity contract).
+///
+/// The callback fires once per scored chunk (a whole-record slice teased out of
+/// the streamed reads), not once per record, so its overhead is amortised over
+/// a large batch of records.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use rust_scorer::cost::CostKind;
+/// use rust_scorer::gpu::GpuBackendLabel;
+/// use rust_scorer::multi_score::{score_from_creature_dir_with_early_exit, EarlyExit};
+///
+/// let scores = score_from_creature_dir_with_early_exit(
+///     Path::new("creatures/"),
+///     Path::new("training_data/"),
+///     GpuBackendLabel::CpuFallback,
+///     CostKind::Mse,
+///     |partials| {
+///         // Abort any creature whose running error is already 10x the best.
+///         let best = partials.iter().map(|p| p.partial_error).fold(f64::INFINITY, f64::min);
+///         let losers: Vec<usize> = partials
+///             .iter()
+///             .filter(|p| p.partial_error > best * 10.0)
+///             .map(|p| p.creature_index)
+///             .collect();
+///         if losers.is_empty() { EarlyExit::Continue } else { EarlyExit::AbortCreatures(losers) }
+///     },
+/// )
+/// .unwrap();
+/// println!("scored {} creatures", scores.len());
+/// ```
+// `#[allow(dead_code)]`: library API used by benches/tests; the binary's
+// self-contained module tree recompiles this file and never calls it.
+#[allow(dead_code)]
+pub fn score_from_creature_dir_with_early_exit<F>(
+    creatures_dir: &Path,
+    data_path: &Path,
+    gpu_backend: GpuBackendLabel,
+    cost: CostKind,
+    mut on_chunk: F,
+) -> Result<BTreeMap<String, ScoreResult>, String>
+where
+    F: FnMut(&[PartialScore]) -> EarlyExit,
+{
+    score_from_creature_dir_cpu(
+        creatures_dir,
+        data_path,
+        gpu_backend,
+        cost,
+        Some(&mut on_chunk),
+    )
+}
+
+/// Shared CPU directory-mode implementation behind [`score_from_creature_dir`]
+/// (no callback) and [`score_from_creature_dir_with_early_exit`] (Issue #308).
+///
+/// When `on_chunk` is `None` the early-exit bookkeeping collapses to a no-op:
+/// every creature stays active for the whole corpus and the numeric result is
+/// identical to the pre-#308 full-score path.
+fn score_from_creature_dir_cpu(
+    creatures_dir: &Path,
+    data_path: &Path,
+    gpu_backend: GpuBackendLabel,
+    cost: CostKind,
+    mut on_chunk: Option<&mut EarlyExitCallback<'_>>,
 ) -> Result<BTreeMap<String, ScoreResult>, String> {
     let started = Instant::now();
     let loaded = load_creatures_from_dir(creatures_dir)?;
@@ -361,11 +518,20 @@ pub fn score_from_creature_dir(
         )?;
     }
 
+    let n_creatures = loaded.len();
     let mut pending: Vec<u8> = Vec::new();
     let mut head: usize = 0;
     let mut unpack_floats: Vec<f32> = Vec::new();
     let mut total_records = 0_usize;
-    let mut total_mse = vec![0.0_f64; loaded.len()];
+    let mut total_mse = vec![0.0_f64; n_creatures];
+    // Issue #308 — per-creature early-exit bookkeeping. `active[ci]` gates
+    // whether creature `ci` is still scored; `records_scored[ci]` is how many
+    // records it has been scored against (its final `record_count`). With no
+    // callback every creature stays active for the whole corpus, so
+    // `records_scored[ci] == total_records` and the result is unchanged.
+    let mut active = vec![true; n_creatures];
+    let mut records_scored = vec![0_usize; n_creatures];
+    let mut abort_all = false;
     // Reused per-chunk buffers — populated inside `score_chunk`.
     let mut work_ranges: Vec<Option<Range<usize>>> = vec![None; total_workers];
     let mut worker_sums: Vec<f64> = vec![0.0; total_workers];
@@ -384,8 +550,13 @@ pub fn score_from_creature_dir(
             *slot = None;
         }
 
-        // Fill work_ranges per creature.
+        // Fill work_ranges per creature. Issue #308: skip creatures the caller
+        // has aborted — their worker slots stay `None`, so no activation runs
+        // for them this chunk. That skipped activation is the wall-clock saving.
         for (ci, &nominal_w) in workers_per.iter().enumerate() {
+            if !active[ci] {
+                continue;
+            }
             let off = worker_offsets[ci];
             let actual_w = nominal_w.min(n_records).max(1);
             if actual_w == 1 {
@@ -427,9 +598,55 @@ pub fn score_from_creature_dir(
             })?;
 
         // Reduce per-worker sums into per-creature totals (sequential —
-        // total_workers ≤ activation_threads, so this is cheap).
+        // total_workers ≤ activation_threads, so this is cheap). Inactive
+        // creatures had `None` ranges → their worker sums are `0.0`, so this
+        // leaves their frozen totals untouched.
         for (worker_idx, &s) in worker_sums.iter().enumerate() {
             total_mse[worker_creature_idx[worker_idx]] += s;
+        }
+
+        // Issue #308: this chunk's records count only towards creatures that
+        // were actually scored (active) this chunk.
+        for (ci, scored) in records_scored.iter_mut().enumerate() {
+            if active[ci] {
+                *scored += n_records;
+            }
+        }
+
+        // Issue #308: hand the caller a running snapshot and apply its
+        // early-exit decision. Skipped entirely when no callback is registered,
+        // so the full-score path pays nothing.
+        if let Some(cb) = on_chunk.as_deref_mut() {
+            let partials: Vec<PartialScore> = (0..n_creatures)
+                .filter(|&ci| active[ci])
+                .map(|ci| PartialScore {
+                    creature_index: ci,
+                    key: loaded[ci].key.clone(),
+                    // `records_scored[ci] >= n_records >= 1` here: the callback
+                    // only ever sees a creature after it has scored ≥1 record.
+                    partial_error: total_mse[ci] / records_scored[ci] as f64,
+                    records_scored: records_scored[ci],
+                })
+                .collect();
+            match cb(&partials) {
+                EarlyExit::Continue => {}
+                EarlyExit::AbortCreatures(indices) => {
+                    for i in indices {
+                        if i < n_creatures {
+                            active[i] = false;
+                        }
+                    }
+                }
+                EarlyExit::AbortAll => {
+                    for a in active.iter_mut() {
+                        *a = false;
+                    }
+                    abort_all = true;
+                    // Unwind out of `for_each_read_chunk` so the sweep stops
+                    // reading immediately; caught right after the sweep.
+                    return Err(EARLY_EXIT_ABORT_ALL_SENTINEL.to_string());
+                }
+            }
         }
 
         Ok(())
@@ -439,7 +656,7 @@ pub fn score_from_creature_dir(
     // creature in the batch. Record it so `single_pass_assertion` fails loudly
     // if a future change reintroduces per-creature re-reads.
     training_pass_probe::record_sweep();
-    for_each_read_chunk(&bin_files, fused_read_buf_len, |chunk| {
+    let sweep = for_each_read_chunk(&bin_files, fused_read_buf_len, |chunk| {
         run_io_loop(
             chunk,
             &mut pending,
@@ -448,9 +665,21 @@ pub fn score_from_creature_dir(
             record_bytes,
             &mut score_chunk,
         )
-    })?;
+    });
+    // Issue #308: `EarlyExit::AbortAll` unwinds via a private sentinel error —
+    // a clean early stop, not a failure. `for_each_read_chunk` wraps the inner
+    // message with file/offset context, so match by substring (the NUL-prefixed
+    // marker cannot collide with a genuine I/O or cost error). Any other error
+    // is a real fault and propagates.
+    match sweep {
+        Ok(()) => {}
+        Err(e) if abort_all && e.contains(EARLY_EXIT_ABORT_ALL_SENTINEL) => {}
+        Err(e) => return Err(e),
+    }
 
-    if head != pending.len() {
+    // A mid-corpus abort legitimately leaves an unread trailing fragment, so
+    // only enforce whole-record consumption when the sweep ran to completion.
+    if !abort_all && head != pending.len() {
         return Err(format!(
             "Trailing {} bytes (incomplete record) after reading all training files",
             pending.len() - head
@@ -462,8 +691,18 @@ pub fn score_from_creature_dir(
 
     let elapsed = started.elapsed().as_secs_f64();
     let mut results = BTreeMap::new();
-    for (loaded_creature, mse_sum) in loaded.iter().zip(total_mse.iter()) {
-        let avg_error = *mse_sum / total_records as f64;
+    for (ci, loaded_creature) in loaded.iter().enumerate() {
+        let scored = records_scored[ci];
+        if scored == 0 {
+            // Defensive: the callback only ever sees a creature after ≥1 record,
+            // so a zero here would mean an internal accounting bug — fail loud
+            // rather than divide by zero (Issue #3234).
+            return Err(format!(
+                "Creature '{}' was scored against zero records",
+                loaded_creature.path.display()
+            ));
+        }
+        let avg_error = total_mse[ci] / scored as f64;
         // Issue #289: the scoring API now returns the typed `ScoringError`;
         // flatten to this module's `String` error contract at the boundary.
         let components =
@@ -488,7 +727,7 @@ pub fn score_from_creature_dir(
                 score,
                 error: avg_error,
                 complexity_penalty,
-                record_count: total_records,
+                record_count: scored,
                 hidden_neurons,
                 synapse_count,
                 forward_only: true,

--- a/rust_scorer/tests/early_exit_tdd.rs
+++ b/rust_scorer/tests/early_exit_tdd.rs
@@ -1,0 +1,272 @@
+//! Issue #308 — early-exit / partial-score API for directory-mode batch scoring.
+//!
+//! These integration tests drive the real library entrypoints
+//! ([`score_from_creature_dir`] and
+//! [`score_from_creature_dir_with_early_exit`]) against a temp corpus and
+//! assert on the returned [`ScoreResult`]s — the full-score parity contract,
+//! per-creature abort freezing its partial score, and `AbortAll` stopping the
+//! sweep early.
+//!
+//! A tiny `NEAT_SCORER_READ_BYTES` forces many streamed chunks so the callback
+//! fires repeatedly and an abort genuinely removes work from later chunks
+//! (rather than the whole corpus arriving in a single chunk).
+
+use std::cell::RefCell;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::gpu::GpuBackendLabel;
+use rust_scorer::multi_score::{
+    EarlyExit, PartialScore, score_from_creature_dir, score_from_creature_dir_with_early_exit,
+};
+
+const INPUTS: usize = 2;
+const OUTPUTS: usize = 1;
+const RECORD_BYTES: usize = (INPUTS + OUTPUTS) * 4;
+
+/// Forward-only creature mapping `w0*x0 + w1*x1` onto a single IDENTITY output.
+/// Distinct weights give each creature a distinct error so abort selection is
+/// meaningful.
+fn linear_creature(w0: f32, w1: f32) -> String {
+    format!(
+        r#"{{"input":{INPUTS},"output":{OUTPUTS},"forwardOnly":true,"neurons":[{{"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}}],"synapses":[{{"fromUUID":"input-0","toUUID":"output-0","weight":{w0}}},{{"fromUUID":"input-1","toUUID":"output-0","weight":{w1}}}]}}"#
+    )
+}
+
+/// Materialise `n` creatures with linearly-varying weights into `dir`.
+fn write_creatures(dir: &Path, n: usize) {
+    std::fs::create_dir_all(dir).expect("create creatures dir");
+    for i in 0..n {
+        let w0 = 0.3 + 0.15 * i as f32;
+        let w1 = 0.5;
+        std::fs::write(
+            dir.join(format!("creature-{i:03}.json")),
+            linear_creature(w0, w1),
+        )
+        .expect("write creature");
+    }
+}
+
+/// Write `n_records` deterministic records to a single `.bin` file.
+fn write_training_data(dir: &Path, n_records: usize) {
+    std::fs::create_dir_all(dir).expect("create data dir");
+    let mut file = std::fs::File::create(dir.join("0.bin")).expect("create data file");
+    for r in 0..n_records {
+        let x0 = (r as f32 * 0.01).sin();
+        let x1 = (r as f32 * 0.017).cos();
+        let target = 0.4 * x0 + 0.5 * x1; // ground truth close to, but not, any creature
+        for v in [x0, x1, target] {
+            file.write_all(&v.to_le_bytes()).expect("write f32");
+        }
+    }
+}
+
+/// Force many small streamed chunks so the early-exit callback fires often.
+fn force_small_reads() {
+    // SAFETY: set before the scorer spawns any worker threads; every test in
+    // this binary sets the same value, so concurrent tests do not observe a
+    // conflicting size.
+    unsafe {
+        std::env::set_var("NEAT_SCORER_READ_BYTES", RECORD_BYTES.to_string());
+    }
+}
+
+fn fixture(tag: &str, n_creatures: usize, n_records: usize) -> (PathBuf, PathBuf) {
+    let root = std::env::temp_dir().join(format!("early_exit_tdd_{tag}"));
+    let _ = std::fs::remove_dir_all(&root);
+    let creatures = root.join("creatures");
+    let data = root.join("data");
+    write_creatures(&creatures, n_creatures);
+    write_training_data(&data, n_records);
+    (creatures, data)
+}
+
+/// Full-score parity: a callback that always returns `Continue` must produce
+/// results bit-identical to the plain `score_from_creature_dir`.
+#[test]
+fn always_continue_matches_full_score_baseline() {
+    force_small_reads();
+    let (creatures, data) = fixture("parity", 6, 400);
+
+    let baseline = score_from_creature_dir(
+        &creatures,
+        &data,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+    )
+    .expect("baseline score");
+
+    let calls = RefCell::new(0usize);
+    let early = score_from_creature_dir_with_early_exit(
+        &creatures,
+        &data,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+        |partials| {
+            *calls.borrow_mut() += 1;
+            // Every creature stays active for the whole corpus.
+            assert_eq!(partials.len(), 6);
+            EarlyExit::Continue
+        },
+    )
+    .expect("early-exit score");
+
+    assert!(
+        *calls.borrow() > 1,
+        "callback should fire once per chunk (many chunks)"
+    );
+    assert_eq!(baseline.len(), early.len());
+    for (key, base) in &baseline {
+        let got = early.get(key).expect("same keys");
+        assert_eq!(
+            base.error.to_bits(),
+            got.error.to_bits(),
+            "error for {key} must be bit-identical on the full-score path"
+        );
+        assert_eq!(base.score.to_bits(), got.score.to_bits(), "score for {key}");
+        assert_eq!(
+            base.record_count, got.record_count,
+            "record_count for {key}"
+        );
+    }
+}
+
+/// Aborting a subset of creatures freezes their partial score (record_count <
+/// full) while the survivors match the full-score baseline exactly.
+#[test]
+fn abort_creatures_freezes_partial_and_keeps_survivors_exact() {
+    force_small_reads();
+    let (creatures, data) = fixture("abort_subset", 6, 400);
+
+    let baseline = score_from_creature_dir(
+        &creatures,
+        &data,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+    )
+    .expect("baseline score");
+    let full_records = baseline.values().next().unwrap().record_count;
+
+    // Abort creatures 0, 2, 4 on the first callback; survivors 1, 3, 5.
+    let aborted_once = RefCell::new(false);
+    let early = score_from_creature_dir_with_early_exit(
+        &creatures,
+        &data,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+        |partials| {
+            if !*aborted_once.borrow() {
+                *aborted_once.borrow_mut() = true;
+                let losers: Vec<usize> = partials
+                    .iter()
+                    .map(|p| p.creature_index)
+                    .filter(|i| i % 2 == 0)
+                    .collect();
+                return EarlyExit::AbortCreatures(losers);
+            }
+            // After the first abort, only survivors remain active.
+            assert!(partials.iter().all(|p| p.creature_index % 2 == 1));
+            EarlyExit::Continue
+        },
+    )
+    .expect("early-exit score");
+
+    for (key, res) in &early {
+        let idx: usize = key.trim_start_matches("creature-").parse().unwrap();
+        if idx % 2 == 0 {
+            // Aborted: scored fewer records than the full corpus.
+            assert!(
+                res.record_count < full_records && res.record_count > 0,
+                "aborted {key} record_count {} should be in (0, {full_records})",
+                res.record_count
+            );
+        } else {
+            // Survivor: identical to the full-score baseline.
+            let base = &baseline[key];
+            assert_eq!(res.record_count, full_records, "survivor {key} full corpus");
+            assert_eq!(
+                base.error.to_bits(),
+                res.error.to_bits(),
+                "survivor {key} error must match baseline exactly"
+            );
+        }
+    }
+}
+
+/// `AbortAll` stops the sweep immediately: every creature freezes with a
+/// partial (non-zero, below-full) record count and still produces a valid score.
+#[test]
+fn abort_all_stops_sweep_early_for_every_creature() {
+    force_small_reads();
+    let (creatures, data) = fixture("abort_all", 4, 400);
+
+    let baseline = score_from_creature_dir(
+        &creatures,
+        &data,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+    )
+    .expect("baseline score");
+    let full_records = baseline.values().next().unwrap().record_count;
+
+    let seen = RefCell::new(0usize);
+    let early = score_from_creature_dir_with_early_exit(
+        &creatures,
+        &data,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+        |_partials| {
+            *seen.borrow_mut() += 1;
+            EarlyExit::AbortAll
+        },
+    )
+    .expect("early-exit score");
+
+    // AbortAll on the very first chunk ⇒ callback fires exactly once.
+    assert_eq!(*seen.borrow(), 1);
+    assert_eq!(early.len(), 4);
+    for (key, res) in &early {
+        assert!(
+            res.record_count > 0 && res.record_count < full_records,
+            "{key} should have a partial record_count, got {}",
+            res.record_count
+        );
+        assert!(res.score.is_finite(), "{key} score must be finite");
+    }
+}
+
+/// The partial-score snapshot exposes the running mean error and a
+/// monotonically-growing `records_scored` per creature.
+#[test]
+fn partial_score_snapshot_is_well_formed() {
+    force_small_reads();
+    let (creatures, data) = fixture("snapshot", 3, 300);
+
+    let last_records: RefCell<Vec<usize>> = RefCell::new(vec![0; 3]);
+    let observed: RefCell<Vec<PartialScore>> = RefCell::new(Vec::new());
+    let _ = score_from_creature_dir_with_early_exit(
+        &creatures,
+        &data,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+        |partials| {
+            for p in partials {
+                assert!(p.records_scored >= 1);
+                assert!(p.partial_error.is_finite() && p.partial_error >= 0.0);
+                assert_eq!(p.key, format!("creature-{:03}", p.creature_index));
+                let mut last = last_records.borrow_mut();
+                assert!(
+                    p.records_scored >= last[p.creature_index],
+                    "records_scored must be monotonic"
+                );
+                last[p.creature_index] = p.records_scored;
+            }
+            observed.borrow_mut().extend(partials.iter().cloned());
+            EarlyExit::Continue
+        },
+    )
+    .expect("early-exit score");
+
+    assert!(!observed.borrow().is_empty(), "callback must have fired");
+}


### PR DESCRIPTION
## Summary

Adds an **early-exit / partial-score API** to the directory-mode batch scoring
path — the path production already uses 100 % of the time. A new library
entrypoint `multi_score::score_from_creature_dir_with_early_exit` mirrors
`score_from_creature_dir` but invokes a caller-supplied callback after each
scored chunk. This unblocks [NEAT-AI#3264](https://github.com/stSoftwareAU/NEAT-AI/issues/3264)
(cascading / early-abort fitness ranking) by letting a caller abort creatures
mid-corpus **without reimplementing the fused `mse_sum_batch_packed` loop in
TypeScript**. Closes #308.

The callback receives one `PartialScore` per still-active creature
(`creature_index`, `key`, running `partial_error`, `records_scored`) and returns
an `EarlyExit`:

- `Continue` — keep scoring every active creature.
- `AbortCreatures(indices)` — stop scoring those creatures; each freezes at its
  current partial score (its final `error` over a partial `record_count`).
  Skipping them removes their activation cost from every remaining chunk — the
  wall-clock saving.
- `AbortAll` — stop the sweep immediately; every active creature freezes.

**Full-score path unchanged:** `score_from_creature_dir` (no callback) delegates
to the shared internal `score_from_creature_dir_cpu` with `None`, so its
behaviour and scores are bit-identical to before. A callback that always returns
`Continue` is likewise bit-identical (verified in tests). Per-creature
`record_count` now reflects the records each creature was actually scored
against, which equals the full corpus on the full-score path and the partial
count for an aborted creature.

### API shape chosen

Of the candidate APIs in the issue, this PR takes the **chunk callback on the
directory batch entrypoint** — the least invasive: it reuses the existing
single-pass I/O envelope and flat Rayon worker pool, and adds only a per-chunk
`active`/`records_scored` bookkeeping layer that collapses to a no-op when no
callback is registered.

## Evidence

Backend/CLI change — no web UI to screenshot. Evidence is the benchmark A/B and
the parity/behaviour tests.

### Benchmark gate (merge on ≥5 % directory-mode wall-clock)

`early_exit_directory` group in `rust_scorer/benches/scoring.rs`,
`BENCH_SCORING_BYTES=33554432` (32 MiB corpus), synthetic 8→8→2 population,
callback aborts ~50 % of the population (even indices) after the first scored
chunk. Criterion median wall-clock:

| Population | Full-score (baseline) | Early-exit (abort 50 %) | Δ wall-clock |
|-----------:|----------------------:|------------------------:|-------------:|
| N = 50     | 2.0183 s              | 1.2027 s                | **−40.4 %**  |
| N = 200    | 4.7739 s              | 2.6207 s                | **−45.1 %**  |

Both far exceed the **≥5 %** merge gate. The saving comes from aborted creatures
skipping activation over the remaining chunks; because fitness/activation is
~93.6 % of production wall-clock, removing half the population early recovers
close to half the run.

**Full-score parity (mandatory):** `always_continue_matches_full_score_baseline`
asserts `error`/`score`/`record_count` are **bit-identical** (`to_bits()`)
between `score_from_creature_dir` and the always-`Continue` early-exit path.

### Per-chunk flow

```mermaid
flowchart TD
    A[Read chunk] --> B[Score chunk: active creatures only]
    B --> C{Callback registered?}
    C -- No --> A
    C -- Yes --> D[Build PartialScore per active creature]
    D --> E{EarlyExit?}
    E -- Continue --> A
    E -- AbortCreatures --> F[Mark listed creatures inactive] --> A
    E -- AbortAll --> G[Stop sweep]
    A -- corpus exhausted --> H[Finalise: error = sum / records_scored]
    G --> H
```

## Test Plan

New integration tests in `rust_scorer/tests/early_exit_tdd.rs` (all drive the
real library entrypoints against a temp corpus, with a tiny
`NEAT_SCORER_READ_BYTES` forcing many streamed chunks):

- `always_continue_matches_full_score_baseline` — full-score parity: an
  always-`Continue` callback returns bit-identical `error`/`score`/`record_count`
  vs `score_from_creature_dir`, and the callback fires on every chunk.
- `abort_creatures_freezes_partial_and_keeps_survivors_exact` — aborting a
  subset freezes their `record_count` below the full corpus while survivors stay
  bit-identical to the baseline.
- `abort_all_stops_sweep_early_for_every_creature` — `AbortAll` on the first
  chunk stops the sweep; every creature has a partial (non-zero, below-full)
  `record_count` and a finite score.
- `partial_score_snapshot_is_well_formed` — the `PartialScore` snapshot exposes
  a finite non-negative running error, a correct `key`, and monotonic
  `records_scored`.

Full `./quality.sh` passes (shellcheck, cargo-deny, fmt, clippy, check, build,
test, rustdoc with `-D warnings`, release build). Existing
`single_pass_assertion` tests still pass, confirming the corpus is still swept
exactly once.

## Out of scope

- **GPU path** (`score_from_creature_dir_gpu`) — early-exit is CPU-only for now;
  production directory-mode uses the CPU pipeline (95.8 % of neurons are
  GPU-unsupported, #299). The GPU batched kernel would need a per-dispatch
  active-mask to benefit, which is a larger change.
- **Single-creature path** — unchanged, per the issue.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrdev9of-d89287`<!-- vibe-worker-issue-308 -->