### PR TITLE
Reuse GPU bind group across dispatches (Issue #322)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,18 +150,18 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -176,9 +176,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "bytemuck",
  "clap",
@@ -1721,18 +1721,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.5"
+version = "1.1.7"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-322.md
+++ b/docs/archive/pr-summaries/pr-summary-322.md
@@ -1,0 +1,87 @@
+# PR summary — Issue #322
+
+## Summary
+
+Reduce GPU per-dispatch overhead by **reusing the batched runner's bind group
+across dispatches** — experiment 2 of #322 (parent #318). `Closes #322`.
+
+`BatchedRunner::score_chunk` previously called `device.create_bind_group` — plus
+allocating a fresh `bind_entries` `Vec` — on **every** dispatch. The immutable
+per-creature SSBOs (`header`, `neurons`, `synapses`, `creatures`) never change,
+so a bind group only goes stale when a growable buffer
+(`records`/`partials`/`scratch`) is reallocated or the scratch binding is
+resized. The runner now caches the bind group and rebuilds it **only** on that
+signature change, tracked by a monotonic reallocation-generation counter per
+growable buffer plus the bound scratch size.
+
+This is a correctness-preserving dispatch-overhead reduction. It does **not**
+flip `--gpu auto` routing — production GRQ topology is `ScratchOnly`, which still
+selects CPU per #317/#319 — it lowers the fixed cost of every GPU dispatch on the
+`--gpu on` and all-private `auto` paths.
+
+The three remaining #322 experiments (64 MiB read default; async readback beyond
+`inflight=2`, blocked by the #319 Metal SIGSEGV; Metal-native micro-benchmark)
+need the proprietary full 521-bin GRQ corpus or are non-shipping spikes, and are
+tracked in follow-up **#333**.
+
+### Reuse decision
+
+```mermaid
+flowchart TD
+    A[score_chunk] --> B[ensure records / partials / scratch buffers]
+    B --> C{buffer reallocated<br/>or scratch resized?}
+    C -->|signature changed| D[create_bind_group + cache signature<br/>bind_group_builds += 1]
+    C -->|signature unchanged| E[reuse cached bind group]
+    D --> F[dispatch]
+    E --> F[dispatch]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified with a
+before/after benchmark plus unit + GPU parity tests.
+
+**Benchmark** — [`gpu_pipeline_alloc_bench`](../../../rust_scorer/src/bin/gpu_pipeline_alloc_bench.rs)
+(8 creatures, 100 000 records, `READ_BYTES=2560` → deliberately dispatch-heavy so
+the per-dispatch fixed cost dominates). Host: **Apple M4 Pro** (Mac16,11), macOS,
+Metal backend. Median of 3 runs.
+
+| Metric | Baseline (create per dispatch) | Bind-group reuse | Δ |
+|---|---|---|---|
+| `gpu_dispatch_count` | 1563 | 1563 | — |
+| allocations (scored) | 117 277 | 86 037 | **−31 240 (−26.6 %)** |
+| `elapsed_secs` | 10.80 | 10.15 | **~−6.0 %** |
+
+~20 heap allocations removed per dispatch (the `bind_entries` `Vec` plus the
+wgpu-internal bind-group allocations). The saving is per-dispatch, so absolute
+wall-time impact scales with dispatch count. Recorded in
+[`docs/performance-baseline.md`](../../performance-baseline.md) under
+"Production GPU dispatch overhead — 12 July 2026".
+
+**Ship-gate note.** #322's full ship gate (≥3 % CPU win on the full 521-bin GRQ
+corpus, combined with #319 + kernel work) governs flipping the production default
+to GPU and needs proprietary data unavailable to the worker. This PR delivers the
+self-contained, measurable dispatch-overhead reduction and tracks the residual
+corpus/hardware-gated experiments in #333 rather than looping.
+
+## Test Plan
+
+CPU-only unit tests (run on CI) for the pure reuse decision, in
+`rust_scorer/src/gpu/forward_mse_batched.rs`:
+
+- `bind_group_rebuilds_when_no_group_cached_yet` — first dispatch always builds.
+- `bind_group_reused_when_signature_unchanged` — steady state reuses.
+- `bind_group_rebuilds_when_records_buffer_grows` — realloc invalidates.
+- `bind_group_rebuilds_when_scratch_binding_resized` — resized scratch invalidates.
+
+GPU-gated integration tests (run on the M4 Pro; skip cleanly with no adapter), in
+`rust_scorer/tests/gpu_bind_group_reuse.rs`:
+
+- `same_size_chunks_reuse_one_bind_group` — 5 identical dispatches build once.
+- `growing_chunk_forces_exactly_one_rebuild` — a larger chunk rebuilds once; a
+  return to a covered shape does not rebuild.
+- `reused_bind_group_preserves_cpu_parity` — GPU sums match the CPU
+  `mse_sum_batch_packed` baseline across three dispatches that reuse the group.
+
+Existing CPU↔GPU parity suite (`tests/gpu_multi_score_parity.rs`) and
+`./quality.sh` pass cleanly.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -884,6 +884,44 @@ for b in 2097152 8388608 16777216 33554432 67108864; do
 done
 ```
 
+## Production GPU dispatch overhead — 12 July 2026 (Issue #322)
+
+Experiment 2 of [#322](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/322)
+(parent [#318](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/318)):
+**bind-group reuse**. `BatchedRunner::score_chunk` previously called
+`device.create_bind_group` — plus a fresh `bind_entries` `Vec` — on *every*
+dispatch. The immutable per-creature SSBOs never change, so the bind group only
+goes stale when a growable buffer (`records`/`partials`/`scratch`) is reallocated
+or the scratch binding is resized. The runner now caches the bind group and
+rebuilds it only on that signature change.
+
+**Harness:** [`gpu_pipeline_alloc_bench`](../rust_scorer/src/bin/gpu_pipeline_alloc_bench.rs)
+(8 creatures, 100 000 records, `READ_BYTES=2560` → deliberately dispatch-heavy so
+the per-dispatch fixed cost dominates). Host: **Apple M4 Pro** (Mac16,11),
+macOS, Metal backend. Median of 3 runs.
+
+| Metric | Baseline (create per dispatch) | Bind-group reuse | Δ |
+|---|---|---|---|
+| `gpu_dispatch_count` | 1563 | 1563 | — |
+| allocations (scored) | 117 277 | 86 037 | **−31 240 (−26.6 %)** |
+| `elapsed_secs` | 10.80 | 10.15 | **~−6.0 %** |
+
+**Interpretation.** ~20 heap allocations per dispatch removed (one `bind_entries`
+`Vec` plus the wgpu-internal bind-group allocations), and ~6 % wall-clock on this
+dispatch-bound synthetic path. The saving is per-dispatch, so absolute wall-time
+impact scales with dispatch count — larger on many-chunk runs, smaller on the
+few-chunk full corpus. **Correctness is unchanged:** the reused bind group serves
+identical results (`gpu_bind_group_reuse::reused_bind_group_preserves_cpu_parity`
+plus the existing CPU↔GPU parity suite).
+
+**Scope note.** This does **not** flip `--gpu auto` routing — production GRQ
+topology is `ScratchOnly`, which still selects CPU per #317/#319. It reduces
+dispatch overhead on every GPU run (`--gpu on`, and the all-private `auto` path).
+The remaining #322 experiments (1: 64 MiB read default; 3: async readback beyond
+`inflight=2`, blocked by the #319 Metal SIGSEGV; 4: Metal-native micro-benchmark)
+need the full 521-bin GRQ corpus / are non-shipping spikes and are tracked in a
+follow-up.
+
 1. Run `./scripts/run-benches.sh` (default fixture) and record the median +
    std-dev proxy for each benchmark.
 2. For an issue-target run, set `BENCH_SCORING_BYTES=200000000` (200 MB) and

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.7"
+version = "1.1.8"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -307,6 +307,33 @@ pub enum KernelKind {
     Scratch,
 }
 
+/// Identity of the buffers a bind group references (Issue #322).
+///
+/// A `wgpu::BindGroup` stays valid for reuse across dispatches as long as every
+/// buffer it binds is the same allocation and any explicitly-sized binding keeps
+/// the same size. The immutable per-creature SSBOs (`header`, `neurons`,
+/// `synapses`, `creatures`) never change, so only three things can invalidate a
+/// cached bind group: the growable `records`/`partials`/`scratch` buffers being
+/// reallocated, or the scratch binding being resized. A monotonic generation
+/// counter per growable buffer (bumped on each reallocation) plus the bound
+/// scratch size captures exactly that — so a matching signature means the cached
+/// bind group is still correct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BindGroupSig {
+    records_gen: u64,
+    partials_gen: u64,
+    scratch_gen: u64,
+    scratch_bytes: u64,
+}
+
+/// Whether a cached bind group with signature `cached` must be rebuilt to serve
+/// a dispatch whose current buffer signature is `current` (Issue #322).
+///
+/// Pure so the reuse decision is unit-testable on CPU-only CI without a live GPU.
+fn bind_group_needs_rebuild(cached: Option<BindGroupSig>, current: BindGroupSig) -> bool {
+    cached != Some(current)
+}
+
 /// Reusable GPU pipeline + per-creature buffers for the batched kernel.
 ///
 /// One [`BatchedRunner`] is built once per scoring run. It owns the immutable
@@ -339,8 +366,23 @@ pub struct BatchedRunner {
     readback_buf: Option<(wgpu::Buffer, u64)>,
     /// Activation scratch SSBO for [`KernelKind::Scratch`]; grows lazily.
     scratch_buf: Option<(wgpu::Buffer, u64)>,
+    /// Cached bind group reused across dispatches while its buffers are
+    /// unchanged (Issue #322). Rebuilt only when a growable buffer is
+    /// reallocated or the scratch binding is resized.
+    bind_group: Option<wgpu::BindGroup>,
+    /// Signature of the buffers `bind_group` references, for reuse validation.
+    bind_group_sig: Option<BindGroupSig>,
+    /// Reallocation generation counters for the growable buffers — bumped each
+    /// time the corresponding buffer is grown so a cached bind group referencing
+    /// the old allocation is invalidated (Issue #322).
+    records_gen: u64,
+    partials_gen: u64,
+    scratch_gen: u64,
     /// Diagnostic counter — incremented per [`Self::score_chunk`] call.
     pub dispatch_count: usize,
+    /// Diagnostic counter — incremented each time the bind group is (re)built
+    /// rather than reused (Issue #322). Reused for the bind-group-reuse test.
+    pub bind_group_builds: usize,
 }
 
 impl BatchedRunner {
@@ -551,7 +593,13 @@ impl BatchedRunner {
             partials_buf: None,
             readback_buf: None,
             scratch_buf: None,
+            bind_group: None,
+            bind_group_sig: None,
+            records_gen: 0,
+            partials_gen: 0,
+            scratch_gen: 0,
             dispatch_count: 0,
+            bind_group_builds: 0,
         }
     }
 
@@ -666,47 +714,70 @@ impl BatchedRunner {
             None
         };
 
-        let mut bind_entries = vec![
-            wgpu::BindGroupEntry {
-                binding: 0,
-                resource: self.header_buf.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 1,
-                resource: records_buf.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 2,
-                resource: self.neurons_buf.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 3,
-                resource: self.synapses_buf.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 4,
-                resource: self.creatures_buf.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 5,
-                resource: partials_buf.as_entire_binding(),
-            },
-        ];
-        if let Some((scratch_buf, scratch_bytes)) = scratch_binding.as_ref() {
-            bind_entries.push(wgpu::BindGroupEntry {
-                binding: 6,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: scratch_buf,
-                    offset: 0,
-                    size: Some(std::num::NonZeroU64::new(*scratch_bytes).expect("scratch >= 64")),
-                }),
+        // Issue #322 — reuse the bind group across dispatches. It only becomes
+        // stale when a growable buffer is reallocated (tracked by the `*_gen`
+        // counters) or the scratch binding is resized, so rebuild solely on a
+        // signature change. This drops one `create_bind_group` + entries `Vec`
+        // allocation off every steady-state dispatch.
+        let scratch_bytes_bound = scratch_binding.as_ref().map(|(_, b)| *b).unwrap_or(0);
+        let sig = BindGroupSig {
+            records_gen: self.records_gen,
+            partials_gen: self.partials_gen,
+            scratch_gen: self.scratch_gen,
+            scratch_bytes: scratch_bytes_bound,
+        };
+        if bind_group_needs_rebuild(self.bind_group_sig, sig) {
+            let mut bind_entries = vec![
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self.header_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: records_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: self.neurons_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: self.synapses_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: self.creatures_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: partials_buf.as_entire_binding(),
+                },
+            ];
+            if let Some((scratch_buf, scratch_bytes)) = scratch_binding.as_ref() {
+                bind_entries.push(wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: scratch_buf,
+                        offset: 0,
+                        size: Some(
+                            std::num::NonZeroU64::new(*scratch_bytes).expect("scratch >= 64"),
+                        ),
+                    }),
+                });
+            }
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("forward_mse bind group"),
+                layout: &self.bind_group_layout,
+                entries: &bind_entries,
             });
+            self.bind_group = Some(bind_group);
+            self.bind_group_sig = Some(sig);
+            self.bind_group_builds += 1;
         }
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("forward_mse bind group"),
-            layout: &self.bind_group_layout,
-            entries: &bind_entries,
-        });
+        let bind_group = self
+            .bind_group
+            .as_ref()
+            .expect("bind group built above when the signature changed");
 
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
@@ -716,7 +787,7 @@ impl BatchedRunner {
                 timestamp_writes: None,
             });
             cpass.set_pipeline(&self.pipeline);
-            cpass.set_bind_group(0, &bind_group, &[]);
+            cpass.set_bind_group(0, bind_group, &[]);
             cpass.dispatch_workgroups(num_workgroups_x, self.num_creatures, 1);
         }
         encoder.copy_buffer_to_buffer(&partials_buf, 0, &readback_buf, 0, partials_len);
@@ -768,6 +839,8 @@ impl BatchedRunner {
                 mapped_at_creation: false,
             });
             self.records_buf = Some((buf, cap));
+            // A new allocation invalidates any cached bind group (Issue #322).
+            self.records_gen += 1;
         }
     }
 
@@ -786,6 +859,8 @@ impl BatchedRunner {
                 mapped_at_creation: false,
             });
             self.partials_buf = Some((buf, cap));
+            // A new allocation invalidates any cached bind group (Issue #322).
+            self.partials_gen += 1;
         }
     }
 
@@ -822,6 +897,8 @@ impl BatchedRunner {
                 mapped_at_creation: false,
             });
             self.scratch_buf = Some((buf, cap));
+            // A new allocation invalidates any cached bind group (Issue #322).
+            self.scratch_gen += 1;
         }
     }
 
@@ -1346,6 +1423,66 @@ mod tests {
 
     // Issue #273 — GPU readback (`map_async`) failure must surface as an `Err`
     // string the `--gpu auto` caller can absorb, not panic the process.
+
+    // Issue #322 — the bind group is reused across dispatches; the pure
+    // `bind_group_needs_rebuild` decision must fire only when a bound buffer's
+    // generation changes or the scratch binding is resized.
+
+    #[test]
+    fn bind_group_rebuilds_when_no_group_cached_yet() {
+        let sig = BindGroupSig {
+            records_gen: 1,
+            partials_gen: 1,
+            scratch_gen: 0,
+            scratch_bytes: 0,
+        };
+        // No cached signature (first dispatch) always needs a build.
+        assert!(bind_group_needs_rebuild(None, sig));
+    }
+
+    #[test]
+    fn bind_group_reused_when_signature_unchanged() {
+        let sig = BindGroupSig {
+            records_gen: 3,
+            partials_gen: 2,
+            scratch_gen: 0,
+            scratch_bytes: 0,
+        };
+        // Identical signature (steady-state private dispatch) reuses the group.
+        assert!(!bind_group_needs_rebuild(Some(sig), sig));
+    }
+
+    #[test]
+    fn bind_group_rebuilds_when_records_buffer_grows() {
+        let cached = BindGroupSig {
+            records_gen: 1,
+            partials_gen: 1,
+            scratch_gen: 0,
+            scratch_bytes: 0,
+        };
+        // The records buffer was reallocated (generation bumped) → rebuild.
+        let current = BindGroupSig {
+            records_gen: 2,
+            ..cached
+        };
+        assert!(bind_group_needs_rebuild(Some(cached), current));
+    }
+
+    #[test]
+    fn bind_group_rebuilds_when_scratch_binding_resized() {
+        let cached = BindGroupSig {
+            records_gen: 1,
+            partials_gen: 1,
+            scratch_gen: 1,
+            scratch_bytes: 4096,
+        };
+        // Same scratch allocation, but a smaller final chunk binds fewer bytes.
+        let current = BindGroupSig {
+            scratch_bytes: 2048,
+            ..cached
+        };
+        assert!(bind_group_needs_rebuild(Some(cached), current));
+    }
 
     #[test]
     fn map_readback_result_ok_on_successful_map() {

--- a/rust_scorer/tests/gpu_bind_group_reuse.rs
+++ b/rust_scorer/tests/gpu_bind_group_reuse.rs
@@ -1,0 +1,189 @@
+//! Issue #322 — the batched GPU runner reuses its bind group across dispatches.
+//!
+//! `create_bind_group` was called on every `score_chunk`; the bind group only
+//! becomes stale when a growable buffer is reallocated or the scratch binding is
+//! resized. These tests assert that steady-state, same-size chunks reuse a single
+//! bind group (one build for many dispatches) and that a larger chunk — which
+//! grows the records/partials buffers — forces exactly one rebuild, all while the
+//! GPU results still match the CPU baseline.
+//!
+//! Skips cleanly when no GPU adapter is present so CPU-only CI still passes.
+
+use std::sync::Arc;
+
+use neat_core::creature::{compile_creature, parse_creature_json};
+use neat_core::loss::mse_sum_batch_packed;
+
+use rust_scorer::gpu::forward_mse_batched::BatchedRunner;
+use rust_scorer::gpu::{GpuMode, resolve_backend, select_adapter};
+
+fn synthetic_creature_json(num_inputs: usize, num_outputs: usize, hidden: usize) -> String {
+    let mut neurons: Vec<String> = Vec::new();
+    for h in 0..hidden {
+        neurons.push(format!(
+            r#"{{"type":"hidden","uuid":"hidden-{h}","bias":0.05,"squash":"TANH"}}"#
+        ));
+    }
+    for o in 0..num_outputs {
+        neurons.push(format!(
+            r#"{{"type":"output","uuid":"output-{o}","bias":0.0,"squash":"IDENTITY"}}"#
+        ));
+    }
+    let mut synapses: Vec<String> = Vec::new();
+    for i in 0..num_inputs {
+        for h in 0..hidden {
+            let w = 0.05 + 0.001 * ((i * hidden + h) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"input-{i}","toUUID":"hidden-{h}","weight":{w}}}"#
+            ));
+        }
+    }
+    for h in 0..hidden {
+        for o in 0..num_outputs {
+            let w = 0.1 + 0.001 * ((h * num_outputs + o) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"hidden-{h}","toUUID":"output-{o}","weight":{w}}}"#
+            ));
+        }
+    }
+    format!(
+        r#"{{"input":{num_inputs},"output":{num_outputs},"forwardOnly":true,"semanticVersion":"4.0.0","neurons":[{}],"synapses":[{}]}}"#,
+        neurons.join(","),
+        synapses.join(","),
+    )
+}
+
+fn build_records(num_inputs: usize, num_outputs: usize, n_records: usize) -> Vec<f32> {
+    let values_per_record = num_inputs + num_outputs;
+    let mut floats = Vec::with_capacity(n_records * values_per_record);
+    for i in 0..n_records {
+        for k in 0..values_per_record {
+            let v = ((i.wrapping_mul(31) + k) as f32 * 1.0e-3).sin();
+            floats.push(v);
+        }
+    }
+    floats
+}
+
+/// Acquire a GPU context or `None` when no compatible adapter is present.
+fn gpu_ctx() -> Option<Arc<rust_scorer::gpu::GpuContext>> {
+    if resolve_backend(GpuMode::Auto)
+        .map(|b| b.as_str() == "cpu-fallback")
+        .unwrap_or(true)
+    {
+        eprintln!("skipping bind-group reuse test: no compatible adapter");
+        return None;
+    }
+    match select_adapter() {
+        Ok(Some(c)) => Some(Arc::new(c)),
+        _ => {
+            eprintln!("skipping bind-group reuse test: select_adapter returned no context");
+            None
+        }
+    }
+}
+
+#[test]
+fn same_size_chunks_reuse_one_bind_group() {
+    let Some(ctx) = gpu_ctx() else { return };
+
+    let (num_inputs, num_outputs, hidden) = (8, 2, 8);
+    let json = synthetic_creature_json(num_inputs, num_outputs, hidden);
+    let template = compile_creature(&parse_creature_json(&json).expect("parse")).expect("compile");
+    let nets: Vec<_> = (0..4).map(|_| template.clone()).collect();
+
+    let mut runner = BatchedRunner::new(ctx, &nets, num_inputs, num_outputs)
+        .expect("synthetic fixture is GPU-supported");
+
+    let n_records = 256;
+    let records = build_records(num_inputs, num_outputs, n_records);
+
+    // Five dispatches of identical shape.
+    for _ in 0..5 {
+        runner
+            .score_chunk(&records, n_records)
+            .expect("GPU readback should succeed");
+    }
+
+    assert_eq!(runner.dispatch_count, 5, "five chunks were dispatched");
+    assert_eq!(
+        runner.bind_group_builds, 1,
+        "identical-shape chunks must reuse a single bind group (built once)",
+    );
+}
+
+#[test]
+fn growing_chunk_forces_exactly_one_rebuild() {
+    let Some(ctx) = gpu_ctx() else { return };
+
+    let (num_inputs, num_outputs, hidden) = (8, 2, 8);
+    let json = synthetic_creature_json(num_inputs, num_outputs, hidden);
+    let template = compile_creature(&parse_creature_json(&json).expect("parse")).expect("compile");
+    let nets: Vec<_> = (0..4).map(|_| template.clone()).collect();
+
+    let mut runner = BatchedRunner::new(ctx, &nets, num_inputs, num_outputs)
+        .expect("synthetic fixture is GPU-supported");
+
+    // Two small same-size chunks: one build, reused once.
+    let small = build_records(num_inputs, num_outputs, 256);
+    runner.score_chunk(&small, 256).expect("small chunk 1");
+    runner.score_chunk(&small, 256).expect("small chunk 2");
+    assert_eq!(runner.bind_group_builds, 1, "small chunks share one group");
+
+    // A much larger chunk grows the records/partials buffers → one rebuild.
+    let large = build_records(num_inputs, num_outputs, 4096);
+    runner.score_chunk(&large, 4096).expect("large chunk");
+    assert_eq!(
+        runner.bind_group_builds, 2,
+        "growing the buffers forces exactly one bind-group rebuild",
+    );
+
+    // Returning to the small shape reuses the (now larger) buffers without a
+    // further rebuild — the records buffer capacity already covers it.
+    runner.score_chunk(&small, 256).expect("small chunk 3");
+    assert_eq!(
+        runner.bind_group_builds, 2,
+        "shrinking back to a covered shape must not rebuild the bind group",
+    );
+}
+
+#[test]
+fn reused_bind_group_preserves_cpu_parity() {
+    let Some(ctx) = gpu_ctx() else { return };
+
+    let (num_inputs, num_outputs, hidden) = (8, 2, 8);
+    let json = synthetic_creature_json(num_inputs, num_outputs, hidden);
+    let template = compile_creature(&parse_creature_json(&json).expect("parse")).expect("compile");
+    let mut nets: Vec<_> = (0..4).map(|_| template.clone()).collect();
+
+    let n_records = 512;
+    let records = build_records(num_inputs, num_outputs, n_records);
+    let cpu_sums: Vec<f64> = nets
+        .iter_mut()
+        .map(|net| mse_sum_batch_packed(net, &records, num_inputs, num_outputs, true))
+        .collect();
+
+    let mut runner = BatchedRunner::new(ctx, &nets, num_inputs, num_outputs)
+        .expect("synthetic fixture is GPU-supported");
+
+    // Dispatch the same chunk three times; the 2nd and 3rd reuse the bind group.
+    // Every dispatch must still agree with the CPU baseline.
+    for pass in 0..3 {
+        let gpu_sums = runner
+            .score_chunk(&records, n_records)
+            .expect("GPU readback should succeed");
+        assert_eq!(cpu_sums.len(), gpu_sums.len());
+        for (i, (cpu, gpu)) in cpu_sums.iter().zip(gpu_sums.iter()).enumerate() {
+            let denom = cpu.abs().max(1e-12);
+            let rel = (cpu - gpu).abs() / denom;
+            assert!(
+                rel < 1e-4,
+                "pass {pass} creature {i}: CPU={cpu} GPU={gpu} rel={rel} exceeds 1e-4",
+            );
+        }
+    }
+    assert_eq!(
+        runner.bind_group_builds, 1,
+        "the reused bind group served all three parity dispatches",
+    );
+}


### PR DESCRIPTION
# PR summary — Issue #322

## Summary

Reduce GPU per-dispatch overhead by **reusing the batched runner's bind group
across dispatches** — experiment 2 of #322 (parent #318). `Closes #322`.

`BatchedRunner::score_chunk` previously called `device.create_bind_group` — plus
allocating a fresh `bind_entries` `Vec` — on **every** dispatch. The immutable
per-creature SSBOs (`header`, `neurons`, `synapses`, `creatures`) never change,
so a bind group only goes stale when a growable buffer
(`records`/`partials`/`scratch`) is reallocated or the scratch binding is
resized. The runner now caches the bind group and rebuilds it **only** on that
signature change, tracked by a monotonic reallocation-generation counter per
growable buffer plus the bound scratch size.

This is a correctness-preserving dispatch-overhead reduction. It does **not**
flip `--gpu auto` routing — production GRQ topology is `ScratchOnly`, which still
selects CPU per #317/#319 — it lowers the fixed cost of every GPU dispatch on the
`--gpu on` and all-private `auto` paths.

The three remaining #322 experiments (64 MiB read default; async readback beyond
`inflight=2`, blocked by the #319 Metal SIGSEGV; Metal-native micro-benchmark)
need the proprietary full 521-bin GRQ corpus or are non-shipping spikes, and are
tracked in follow-up **#333**.

### Reuse decision

```mermaid
flowchart TD
    A[score_chunk] --> B[ensure records / partials / scratch buffers]
    B --> C{buffer reallocated<br/>or scratch resized?}
    C -->|signature changed| D[create_bind_group + cache signature<br/>bind_group_builds += 1]
    C -->|signature unchanged| E[reuse cached bind group]
    D --> F[dispatch]
    E --> F[dispatch]
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified with a
before/after benchmark plus unit + GPU parity tests.

**Benchmark** — [`gpu_pipeline_alloc_bench`](../../../rust_scorer/src/bin/gpu_pipeline_alloc_bench.rs)
(8 creatures, 100 000 records, `READ_BYTES=2560` → deliberately dispatch-heavy so
the per-dispatch fixed cost dominates). Host: **Apple M4 Pro** (Mac16,11), macOS,
Metal backend. Median of 3 runs.

| Metric | Baseline (create per dispatch) | Bind-group reuse | Δ |
|---|---|---|---|
| `gpu_dispatch_count` | 1563 | 1563 | — |
| allocations (scored) | 117 277 | 86 037 | **−31 240 (−26.6 %)** |
| `elapsed_secs` | 10.80 | 10.15 | **~−6.0 %** |

~20 heap allocations removed per dispatch (the `bind_entries` `Vec` plus the
wgpu-internal bind-group allocations). The saving is per-dispatch, so absolute
wall-time impact scales with dispatch count. Recorded in
[`docs/performance-baseline.md`](../../performance-baseline.md) under
"Production GPU dispatch overhead — 12 July 2026".

**Ship-gate note.** #322's full ship gate (≥3 % CPU win on the full 521-bin GRQ
corpus, combined with #319 + kernel work) governs flipping the production default
to GPU and needs proprietary data unavailable to the worker. This PR delivers the
self-contained, measurable dispatch-overhead reduction and tracks the residual
corpus/hardware-gated experiments in #333 rather than looping.

## Test Plan

CPU-only unit tests (run on CI) for the pure reuse decision, in
`rust_scorer/src/gpu/forward_mse_batched.rs`:

- `bind_group_rebuilds_when_no_group_cached_yet` — first dispatch always builds.
- `bind_group_reused_when_signature_unchanged` — steady state reuses.
- `bind_group_rebuilds_when_records_buffer_grows` — realloc invalidates.
- `bind_group_rebuilds_when_scratch_binding_resized` — resized scratch invalidates.

GPU-gated integration tests (run on the M4 Pro; skip cleanly with no adapter), in
`rust_scorer/tests/gpu_bind_group_reuse.rs`:

- `same_size_chunks_reuse_one_bind_group` — 5 identical dispatches build once.
- `growing_chunk_forces_exactly_one_rebuild` — a larger chunk rebuilds once; a
  return to a covered shape does not rebuild.
- `reused_bind_group_preserves_cpu_parity` — GPU sums match the CPU
  `mse_sum_batch_packed` baseline across three dispatches that reuse the group.

Existing CPU↔GPU parity suite (`tests/gpu_multi_score_parity.rs`) and
`./quality.sh` pass cleanly.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrhoh327-471eb2`<!-- vibe-worker-issue-322 -->