### PR TITLE
feat: serve RMSE on the existing GPU MSE kernel via host-side sqrt (Issue #339)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.2.9"
+version = "0.2.14"
 dependencies = [
  "serde",
  "serde_json",

--- a/docs/archive/pr-summaries/pr-summary-339.md
+++ b/docs/archive/pr-summaries/pr-summary-339.md
@@ -1,0 +1,97 @@
+# Serve RMSE on the existing GPU MSE kernel via a host-side `sqrt`
+
+## Summary
+
+`--cost RMSE` now runs on the **GPU** creature-directory path at full MSE
+speed, reusing the existing `forward_mse_batched` kernel with only a host-side
+`sqrt` at finalisation — **no new GPU kernel** (honouring the #318/#323
+GPU-exhaustion constraint). The kernel already returns the squared-error sum
+RMSE needs; only the `mean → sqrt(mean)` finalisation and the GPU-gating
+predicate change. Closes #339.
+
+RMSE's foundation (the `CostKind::Rmse` variant, its CPU dispatch, and the
+shared `finalise_mean` helper) was scoped to the dependency sub-issue #338,
+which had not yet landed on the milestone branch. Since #339 cannot compile or
+be tested without it, this PR delivers that foundation alongside the GPU work so
+the change is a self-contained, mergeable unit. Documentation of the new cost
+(README / CHANGELOG) remains with #341, and the upstream `BUILT_IN_COST_NAMES`
+sync remains with #340.
+
+### What changed
+
+- **`rust_scorer/src/cost.rs`**
+  - Added the `Rmse` variant (`--cost RMSE`, `costName: "RMSE"`).
+  - `gpu_supported()`: `matches!(self, Self::Mse | Self::Rmse)` — RMSE reuses
+    the MSE kernel, so it is genuinely GPU-supported.
+  - `accumulate_cost_sum`: RMSE dispatches to `mse_sum_batch_packed` unchanged —
+    the `sqrt` lives only in finalisation, never in the per-chunk sum.
+  - New shared `finalise_mean(error_sum, record_count)` helper: divides by the
+    record count and applies `sqrt` for — and only for — RMSE.
+- **Three finalisation sites now route through `finalise_mean`** so RMSE gets
+  its `sqrt` identically everywhere:
+  - `main.rs` single-creature path,
+  - `multi_score.rs` CPU creature-directory path,
+  - `multi_score.rs` GPU creature-directory path (the site the issue targets).
+- **`main.rs`** `--cost` help text and the `--gpu on` guard comment updated to
+  note RMSE is served by the MSE-only kernel via a host-side `sqrt`.
+- **Gating (`gpu/mod.rs`)** needed no logic change — `auto_should_use_gpu`,
+  `auto_should_use_gpu_directory`, `auto_cost_fallback_note`, and
+  `auto_topology_fallback_note` all key off `cost.gpu_supported()`, so RMSE is
+  treated like MSE automatically. Test coverage added to lock that.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    A["--cost RMSE"] --> B["gpu_supported() = true"]
+    B --> C["forward_mse_batched kernel<br/>(unchanged, squared-error sum)"]
+    C --> D["finalise_mean(sum, count)"]
+    D -->|"Rmse: sqrt(mean)"| E["error, costName: RMSE"]
+    D -.->|"Mse: mean"| E
+```
+
+## Evidence
+
+Backend/CLI change — no web UI to screenshot. Verified end-to-end on a real
+Metal GPU (this build host):
+
+| Command | `costName` | `error` | backend / kernel |
+| --- | --- | --- | --- |
+| `--gpu off  --cost MSE`  | `MSE`  | `0.25` | cpu-fallback |
+| `--gpu off  --cost RMSE` | `RMSE` | `0.50` | cpu-fallback |
+| `--gpu on   --cost RMSE` | `RMSE` | `0.50` | metal / `forward_mse_batched` |
+| `--gpu auto --cost RMSE` | `RMSE` | `0.50` | metal / `forward_mse_batched` |
+
+`RMSE = sqrt(MSE) = sqrt(0.25) = 0.5` confirms the host-side `sqrt`, and
+`--gpu on --cost RMSE` no longer hard-errors — it runs on the MSE kernel.
+
+The GPU↔CPU RMSE parity integration test ran (not skipped) on this host's GPU
+and passed, confirming GPU RMSE matches CPU RMSE within the #81 tolerance and
+equals `sqrt` of the MSE score on the same GPU run.
+
+## Test Plan
+
+Added / updated tests (all pass; `./quality.sh` green):
+
+- `rust_scorer/src/cost.rs`
+  - `gpu_supported_only_for_mse` → renamed/extended to
+    `gpu_supported_only_for_mse_and_rmse` (RMSE GPU-supported; the other six
+    are not).
+  - `finalise_mean_applies_sqrt_only_for_rmse` — `sqrt` for RMSE, plain mean
+    otherwise; RMSE == `sqrt` of the MSE finalisation.
+  - `accumulate_cost_sum_rmse_matches_mse_sum` — RMSE reuses the MSE
+    squared-error sum bit-for-bit.
+  - `from_cli_accepts_rmse` — `--cost RMSE` parses; case-sensitive.
+- `rust_scorer/src/gpu/mod.rs`
+  - `auto_should_use_gpu_directory_uses_gpu_for_rmse` — RMSE is GPU-eligible
+    like MSE.
+  - `auto_cost_fallback_note_absent_for_rmse_directory` — RMSE emits no
+    "not GPU-supported" CPU-fallback note.
+- `rust_scorer/src/main.rs`
+  - `test_cli_parses_rmse` — clap accepts `--cost RMSE`.
+  - `test_gpu_on_accepts_mse_and_rmse_only` — the `--gpu on` guard clears for
+    MSE/RMSE and still trips for CPU-only costs.
+- `rust_scorer/tests/gpu_rmse_parity.rs` (new, GPU-gated)
+  - `gpu_rmse_matches_cpu_rmse_and_is_sqrt_of_mse` — GPU↔CPU RMSE parity within
+    #81 tolerance **and** RMSE == `sqrt` of the MSE score on the same GPU run
+    (guards the finalisation routing at `multi_score.rs`).

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.8"
+version = "1.1.9"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -53,6 +53,12 @@ pub enum CostKind {
     #[default]
     #[value(name = "MSE")]
     Mse,
+    /// Root Mean Squared Error (Issue #339). Reuses the MSE squared-error
+    /// sum unchanged and differs only in a host-side `sqrt` at finalisation
+    /// (see [`CostKind::finalise_mean`]), so it runs on the GPU MSE kernel at
+    /// full MSE speed with no new kernel.
+    #[value(name = "RMSE")]
+    Rmse,
     /// Mean Absolute Error.
     #[value(name = "MAE")]
     Mae,
@@ -88,6 +94,7 @@ impl CostKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Mse => "MSE",
+            Self::Rmse => "RMSE",
             Self::Mae => "MAE",
             Self::Mape => "MAPE",
             Self::Msle => "MSLE",
@@ -134,19 +141,54 @@ impl CostKind {
 }
 
 impl CostKind {
-    /// Issue #121: which costs the GPU `forward_mse_batched` kernel can
-    /// service. Only [`CostKind::Mse`] today — every other cost forces a
-    /// CPU fallback (or a hard error under `--gpu on`).
+    /// Issue #121 / #339: which costs the GPU `forward_mse_batched` kernel can
+    /// service. [`CostKind::Mse`] and [`CostKind::Rmse`] today — RMSE reuses
+    /// the MSE squared-error sum unchanged and only adds a host-side `sqrt` at
+    /// finalisation (no new kernel, see [`CostKind::finalise_mean`]). Every
+    /// other cost forces a CPU fallback (or a hard error under `--gpu on`).
     ///
     /// # Examples
     ///
     /// ```
     /// use rust_scorer::cost::CostKind;
     /// assert!(CostKind::Mse.gpu_supported());
+    /// assert!(CostKind::Rmse.gpu_supported());
     /// assert!(!CostKind::Mae.gpu_supported());
     /// ```
     pub const fn gpu_supported(self) -> bool {
-        matches!(self, Self::Mse)
+        matches!(self, Self::Mse | Self::Rmse)
+    }
+
+    /// Finalise an accumulated per-record error sum into the mean loss the
+    /// scorer reports (Issue #339).
+    ///
+    /// Every scoring site accumulates the un-normalised loss sum over records
+    /// (see [`accumulate_cost_sum`]) and then divides by the record count.
+    /// [`CostKind::Rmse`] additionally takes the square root of that mean — it
+    /// reuses the MSE squared-error sum unchanged and differs only in this
+    /// host-side finalisation. Centralising the division (and the optional
+    /// `sqrt`) keeps the three finalisation sites — the single-creature path in
+    /// `main.rs` and the CPU and GPU creature-directory paths in
+    /// `multi_score.rs` — in lock-step so RMSE cannot silently report MSE-scale
+    /// numbers on one path.
+    ///
+    /// `record_count` must be non-zero; every call site rejects a zero-record
+    /// creature before finalising, so this helper does not re-guard the divide.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_scorer::cost::CostKind;
+    /// // MSE reports the plain mean; RMSE reports its square root.
+    /// assert_eq!(CostKind::Mse.finalise_mean(8.0, 2), 4.0);
+    /// assert_eq!(CostKind::Rmse.finalise_mean(8.0, 2), 2.0);
+    /// ```
+    pub fn finalise_mean(self, error_sum: f64, record_count: usize) -> f64 {
+        let mean = error_sum / record_count as f64;
+        match self {
+            Self::Rmse => mean.sqrt(),
+            _ => mean,
+        }
     }
 }
 
@@ -224,7 +266,10 @@ pub fn accumulate_cost_sum(
         ));
     }
     Ok(match kind {
-        CostKind::Mse => {
+        // Issue #339: RMSE reuses the MSE squared-error sum unchanged — the
+        // only difference is the host-side `sqrt` applied in
+        // [`CostKind::finalise_mean`], never here in the per-chunk sum.
+        CostKind::Mse | CostKind::Rmse => {
             loss::mse_sum_batch_packed(network, chunk, input_size, num_outputs, forward_only)
         }
         CostKind::Mae => {
@@ -379,12 +424,17 @@ mod tests {
         }
     }
 
-    /// Issue #121: only MSE is GPU-supported today; every other cost must
-    /// run on CPU. Locks the predicate so a future kernel that supports
-    /// more costs has an obvious one-line update + test failure.
+    /// Issue #121/#339: MSE and RMSE are GPU-supported (RMSE reuses the MSE
+    /// kernel with a host-side `sqrt`); every other cost must run on CPU.
+    /// Locks the predicate so a regression that drops RMSE back to CPU — or
+    /// that accidentally makes another cost GPU-eligible — fails immediately.
     #[test]
-    fn gpu_supported_only_for_mse() {
+    fn gpu_supported_only_for_mse_and_rmse() {
         assert!(CostKind::Mse.gpu_supported());
+        assert!(
+            CostKind::Rmse.gpu_supported(),
+            "RMSE must be GPU-supported: it reuses the MSE kernel (Issue #339)"
+        );
         for v in [
             CostKind::Mae,
             CostKind::Mape,
@@ -399,6 +449,82 @@ mod tests {
                 v.as_str()
             );
         }
+    }
+
+    /// Issue #339: `finalise_mean` divides the accumulated error sum by the
+    /// record count and applies a `sqrt` for — and only for — RMSE. This is
+    /// the host-side finalisation that turns the shared MSE squared-error sum
+    /// into an RMSE score, so it must be exact for RMSE and a plain mean for
+    /// every other cost.
+    #[test]
+    fn finalise_mean_applies_sqrt_only_for_rmse() {
+        // sum=8 over 2 records → mean 4.0; RMSE = sqrt(4) = 2.0.
+        assert_eq!(CostKind::Mse.finalise_mean(8.0, 2), 4.0);
+        assert_eq!(CostKind::Rmse.finalise_mean(8.0, 2), 2.0);
+        // Every non-RMSE cost reports the plain mean (no sqrt).
+        for v in [
+            CostKind::Mse,
+            CostKind::Mae,
+            CostKind::Mape,
+            CostKind::Msle,
+            CostKind::Hinge,
+            CostKind::CrossEntropy,
+            CostKind::CategoricalError,
+        ] {
+            assert_eq!(
+                v.finalise_mean(9.0, 3),
+                3.0,
+                "{} must report the plain mean without a sqrt",
+                v.as_str()
+            );
+        }
+        // RMSE is exactly the sqrt of the MSE finalisation over the same sum.
+        let sum = 12.5_f64;
+        let count = 5;
+        let mse = CostKind::Mse.finalise_mean(sum, count);
+        let rmse = CostKind::Rmse.finalise_mean(sum, count);
+        assert!((rmse - mse.sqrt()).abs() < 1e-12);
+    }
+
+    /// Issue #339: RMSE must reuse the MSE squared-error sum unchanged — the
+    /// `sqrt` lives only in `finalise_mean`, never in the per-chunk dispatch.
+    /// So `accumulate_cost_sum` for RMSE must equal the MSE sum bit-for-bit.
+    #[test]
+    fn accumulate_cost_sum_rmse_matches_mse_sum() {
+        use neat_core::creature::{compile_creature, parse_creature_json};
+        let json = r#"{"input":1,"output":1,"forwardOnly":true,"neurons":[
+            {"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}
+        ],"synapses":[
+            {"fromUUID":"input-0","toUUID":"output-0","weight":1.0}
+        ]}"#;
+        let creature = parse_creature_json(json).unwrap();
+        // |diff| = 1.5 per record so the squared-error sum is non-trivial.
+        let chunk = vec![2.0_f32, 0.5_f32, -1.0_f32, 0.5_f32];
+
+        let mut net_mse = compile_creature(&creature).unwrap();
+        let mse = accumulate_cost_sum(CostKind::Mse, &mut net_mse, &chunk, 1, 1, true).unwrap();
+        let mut net_rmse = compile_creature(&creature).unwrap();
+        let rmse = accumulate_cost_sum(CostKind::Rmse, &mut net_rmse, &chunk, 1, 1, true).unwrap();
+        assert_eq!(
+            mse, rmse,
+            "RMSE must reuse the MSE squared-error sum unchanged (mse={mse}, rmse={rmse})"
+        );
+        assert!(
+            mse > 0.0,
+            "expected a positive squared-error sum, got {mse}"
+        );
+    }
+
+    /// Issue #339: RMSE parses via `from_cli` and renders back as `RMSE`.
+    /// RMSE is not (yet) an upstream `BUILT_IN_COST_NAMES` value — that sync
+    /// is Issue #340 — so it lives alongside the seven built-ins rather than
+    /// inside the "every built-in" contract tests.
+    #[test]
+    fn from_cli_accepts_rmse() {
+        assert_eq!(CostKind::from_cli("RMSE").unwrap(), CostKind::Rmse);
+        assert_eq!(CostKind::Rmse.as_str(), "RMSE");
+        // Case-sensitive, like the other names.
+        assert!(CostKind::from_cli("rmse").is_err());
     }
 
     /// Issue #134: now that `categorical_error_sum_batch_packed` has

--- a/rust_scorer/src/gpu/mod.rs
+++ b/rust_scorer/src/gpu/mod.rs
@@ -546,6 +546,17 @@ mod tests {
     }
 
     #[test]
+    fn auto_should_use_gpu_directory_uses_gpu_for_rmse() {
+        // Issue #339 — RMSE reuses the MSE kernel, so `auto` must treat it
+        // exactly like MSE and pick GPU on the directory path (never fall to
+        // CPU purely because the cost is RMSE).
+        assert!(auto_should_use_gpu(
+            ScoringPath::CreatureDirectory,
+            crate::cost::CostKind::Rmse
+        ));
+    }
+
+    #[test]
     fn auto_should_use_gpu_directory_declines_scratch_topology() {
         use crate::multi_score::gpu_directory_topology_for_dir;
         use neat_core::creature::{compile_creature, parse_creature_json};
@@ -641,6 +652,21 @@ mod tests {
                 GpuMode::Auto,
                 ScoringPath::CreatureDirectory,
                 crate::cost::CostKind::Mse
+            ),
+            None
+        );
+    }
+
+    /// Issue #339: RMSE is GPU-supported, so — like MSE — it must not emit the
+    /// "cost is not GPU-supported" CPU-fallback note. A regression that dropped
+    /// RMSE back to CPU would surface here as an unexpected `Some(note)`.
+    #[test]
+    fn auto_cost_fallback_note_absent_for_rmse_directory() {
+        assert_eq!(
+            auto_cost_fallback_note(
+                GpuMode::Auto,
+                ScoringPath::CreatureDirectory,
+                crate::cost::CostKind::Rmse
             ),
             None
         );

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -100,9 +100,12 @@ struct Cli {
     /// `categorical_error_sum_batch_packed` helper landed via
     /// `NEAT-AI-core#88`.
     ///
-    /// GPU constraint: the `forward_mse_batched` kernel is **MSE-only**.
-    /// Non-MSE costs under `--gpu auto` silently fall back to the CPU
-    /// pipeline; under `--gpu on` they hard-error before any scoring runs.
+    /// GPU constraint: the `forward_mse_batched` kernel is **MSE-only** —
+    /// there is no separate RMSE kernel. `RMSE` reuses it (Issue #339),
+    /// adding only a host-side `sqrt` at finalisation, so both `MSE` and
+    /// `RMSE` run on the GPU at full MSE speed. The other costs under
+    /// `--gpu auto` silently fall back to the CPU pipeline; under `--gpu on`
+    /// they hard-error before any scoring runs.
     ///
     /// See the README "Cost function selector" section for per-cost
     /// usage examples.
@@ -210,12 +213,13 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         None => SampleSpec::full(),
     };
 
-    // Issue #121: `--gpu on --cost X != MSE` is a hard error — the GPU kernel
-    // only knows how to compute MSE today, so silently downgrading would
-    // produce a wrong scoring result. Check this before adapter selection so
-    // the error always mentions the unsupported cost, even on machines without
-    // a GPU. `--gpu auto` (the default) falls back to CPU instead; `--gpu off`
-    // never touches the GPU and is fine.
+    // Issue #121/#339: `--gpu on` with a cost the kernel cannot serve is a hard
+    // error — the GPU kernel computes squared-error sums, so MSE and RMSE are
+    // supported (RMSE via a host-side `sqrt`) but every other cost would be a
+    // wrong scoring result if silently downgraded. Check this before adapter
+    // selection so the error always mentions the unsupported cost, even on
+    // machines without a GPU. `--gpu auto` (the default) falls back to CPU
+    // instead; `--gpu off` never touches the GPU and is fine.
     if matches!(mode, GpuMode::On) && !cli.cost.gpu_supported() {
         return Err(format!(
             "GPU kernel not implemented for cost {}: forward_mse_batched only handles MSE \
@@ -511,7 +515,9 @@ fn score_from_json(
             (total_error, record_count, 0_usize, 0_usize)
         };
 
-    let avg_error = total_error / record_count as f64;
+    // Issue #339: route through the shared finaliser so RMSE gets its host-side
+    // `sqrt` here, identically to the two directory-mode sites in `multi_score`.
+    let avg_error = cost.finalise_mean(total_error, record_count);
 
     // Issue #289: the scoring API now returns the typed `ScoringError`; flatten
     // to the binary's `String` error contract at the boundary.
@@ -1249,6 +1255,49 @@ mod tests {
             ])
             .unwrap_or_else(|e| panic!("clap rejected --cost {name}: {e}"));
             assert_eq!(parsed.cost, expected);
+        }
+    }
+
+    /// Issue #339: `--cost RMSE` must parse to `CostKind::Rmse`. RMSE is a
+    /// scorer-side extension (not yet an upstream `BUILT_IN_COST_NAMES` value —
+    /// that sync is Issue #340), so it is asserted separately from the
+    /// "every built-in" contract test above.
+    #[test]
+    fn test_cli_parses_rmse() {
+        use clap::Parser;
+        let parsed = Cli::try_parse_from([
+            "rust_scorer",
+            "--cost",
+            "RMSE",
+            "/tmp/creature.json",
+            "/tmp/data",
+        ])
+        .expect("clap must accept --cost RMSE");
+        assert_eq!(parsed.cost, CostKind::Rmse);
+    }
+
+    /// Issue #339: `--gpu on --cost RMSE` must clear the up-front guard that
+    /// hard-errors non-GPU-supported costs. The guard at the top of `run`
+    /// fires only when `!cli.cost.gpu_supported()`; RMSE is GPU-supported (it
+    /// reuses the MSE kernel), so it clears the guard exactly like MSE while
+    /// the CPU-only costs still trip it.
+    #[test]
+    fn test_gpu_on_accepts_mse_and_rmse_only() {
+        assert!(CostKind::Mse.gpu_supported());
+        assert!(CostKind::Rmse.gpu_supported());
+        for cost in [
+            CostKind::Mae,
+            CostKind::Mape,
+            CostKind::Msle,
+            CostKind::Hinge,
+            CostKind::CrossEntropy,
+            CostKind::CategoricalError,
+        ] {
+            assert!(
+                !cost.gpu_supported(),
+                "{} must still trip the --gpu on guard",
+                cost.as_str()
+            );
         }
     }
 

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -744,7 +744,9 @@ fn score_from_creature_dir_cpu(
                 loaded_creature.path.display()
             ));
         }
-        let avg_error = total_mse[ci] / scored as f64;
+        // Issue #339: shared finaliser — RMSE takes a host-side `sqrt` of the
+        // mean here, reusing the MSE squared-error sum unchanged.
+        let avg_error = cost.finalise_mean(total_mse[ci], scored);
         // Issue #289: the scoring API now returns the typed `ScoringError`;
         // flatten to this module's `String` error contract at the boundary.
         let components =
@@ -1230,7 +1232,11 @@ fn score_from_creature_dir_gpu_impl(
     let gpu_kernel_label = runners.kernel_label();
     let mut results = BTreeMap::new();
     for (loaded_creature, mse_sum) in loaded.iter().zip(total_mse.iter()) {
-        let avg_error = *mse_sum / total_records as f64;
+        // Issue #339: the GPU creature-directory finalisation. `mse_sum` is the
+        // squared-error sum the `forward_mse_batched` kernel returns; routing it
+        // through the shared finaliser gives RMSE its host-side `sqrt` on the GPU
+        // path too (no new kernel), matching the CPU path bit-for-bit.
+        let avg_error = cost.finalise_mean(*mse_sum, total_records);
         // Issue #289: the scoring API now returns the typed `ScoringError`;
         // flatten to this module's `String` error contract at the boundary.
         let components =

--- a/rust_scorer/tests/gpu_rmse_parity.rs
+++ b/rust_scorer/tests/gpu_rmse_parity.rs
@@ -1,0 +1,195 @@
+//! Issue #339 — RMSE served on the existing GPU MSE kernel via a host-side
+//! `sqrt`.
+//!
+//! `--cost RMSE` reuses `forward_mse_batched` unchanged (the kernel returns the
+//! squared-error sum RMSE needs); only the creature-directory finalisation in
+//! `multi_score.rs` differs, taking `sqrt(mean)` instead of `mean`. This test
+//! locks two contracts on the GPU directory path:
+//!
+//! 1. **GPU↔CPU RMSE parity** — GPU RMSE agrees with CPU RMSE within the #81
+//!    CPU↔GPU tolerance, so the shared MSE kernel serves RMSE correctly.
+//! 2. **The `sqrt` finalisation is really applied** — RMSE equals the square
+//!    root of the MSE score on the *same* GPU run. A missing `sqrt` (a
+//!    regression that stopped routing line ~1233 through `finalise_mean`) would
+//!    report MSE-scale numbers under `costName: "RMSE"` and fail here.
+//!
+//! Skips cleanly when no GPU adapter is available so CPU-only CI still passes.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::gpu::{GpuBackendLabel, GpuMode, resolve_backend, select_adapter};
+use rust_scorer::multi_score::{score_from_creature_dir, score_from_creature_dir_gpu};
+
+const NUM_INPUTS: usize = 8;
+const NUM_OUTPUTS: usize = 2;
+
+/// Small all-private synthetic creature (8 + 8 + 2 = 18 neurons, well under the
+/// 256-neuron shader cap) so the GPU path routes to `forward_mse_batched`.
+fn synthetic_creature_json(hidden: usize) -> String {
+    let mut neurons: Vec<String> = Vec::new();
+    for h in 0..hidden {
+        neurons.push(format!(
+            r#"{{"type":"hidden","uuid":"hidden-{h}","bias":0.05,"squash":"TANH"}}"#
+        ));
+    }
+    for o in 0..NUM_OUTPUTS {
+        neurons.push(format!(
+            r#"{{"type":"output","uuid":"output-{o}","bias":0.0,"squash":"IDENTITY"}}"#
+        ));
+    }
+    let mut synapses: Vec<String> = Vec::new();
+    for i in 0..NUM_INPUTS {
+        for h in 0..hidden {
+            let w = 0.05 + 0.001 * ((i * hidden + h) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"input-{i}","toUUID":"hidden-{h}","weight":{w}}}"#
+            ));
+        }
+    }
+    for h in 0..hidden {
+        for o in 0..NUM_OUTPUTS {
+            let w = 0.1 + 0.001 * ((h * NUM_OUTPUTS + o) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"hidden-{h}","toUUID":"output-{o}","weight":{w}}}"#
+            ));
+        }
+    }
+    format!(
+        r#"{{"input":{NUM_INPUTS},"output":{NUM_OUTPUTS},"forwardOnly":true,"semanticVersion":"4.0.0","neurons":[{}],"synapses":[{}]}}"#,
+        neurons.join(","),
+        synapses.join(","),
+    )
+}
+
+fn write_fixture(
+    root: &Path,
+    num_creatures: usize,
+    n_records: usize,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let creatures_dir = root.join("creatures");
+    let data_dir = root.join("data");
+    std::fs::create_dir_all(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+
+    let json = synthetic_creature_json(8);
+    for c in 0..num_creatures {
+        std::fs::write(creatures_dir.join(format!("creature-{c}.json")), &json)
+            .expect("write creature");
+    }
+
+    let mut bytes = Vec::with_capacity(n_records * (NUM_INPUTS + NUM_OUTPUTS) * 4);
+    for i in 0..n_records {
+        for k in 0..(NUM_INPUTS + NUM_OUTPUTS) {
+            // Non-trivial targets so the squared-error sum (and thus RMSE) is
+            // clearly non-zero and the sqrt is observable.
+            let v = 0.5 * ((i.wrapping_mul(31) + k) as f32 * 1.7e-3).sin();
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    let mut f = std::fs::File::create(data_dir.join("0.bin")).expect("create bin");
+    f.write_all(&bytes).expect("write bin");
+    f.flush().expect("flush bin");
+
+    (creatures_dir, data_dir)
+}
+
+#[test]
+fn gpu_rmse_matches_cpu_rmse_and_is_sqrt_of_mse() {
+    // Skip cleanly when no GPU is available — CI runners are CPU-only.
+    if resolve_backend(GpuMode::Auto)
+        .map(|b| b.as_str() == "cpu-fallback")
+        .unwrap_or(true)
+    {
+        eprintln!("skipping GPU RMSE parity: no compatible adapter");
+        return;
+    }
+    let ctx = match select_adapter() {
+        Ok(Some(c)) if c.backend != GpuBackendLabel::CpuFallback => Arc::new(c),
+        _ => {
+            eprintln!("skipping GPU RMSE parity: select_adapter returned no context");
+            return;
+        }
+    };
+    let backend = ctx.backend;
+
+    let root = std::env::temp_dir().join("gpu_rmse_parity_fixture");
+    let _ = std::fs::remove_dir_all(&root);
+    let (creatures_dir, data_dir) = write_fixture(&root, 4, 8_192);
+
+    // GPU: score the same directory under both MSE and RMSE. The kernel is
+    // identical; only the host-side finalisation differs.
+    let gpu_mse = score_from_creature_dir_gpu(
+        &creatures_dir,
+        &data_dir,
+        backend,
+        ctx.clone(),
+        1,
+        CostKind::Mse,
+    )
+    .expect("GPU MSE scoring");
+    let gpu_rmse =
+        score_from_creature_dir_gpu(&creatures_dir, &data_dir, backend, ctx, 1, CostKind::Rmse)
+            .expect("GPU RMSE scoring");
+
+    // CPU RMSE baseline for the cross-backend parity assertion.
+    let cpu_rmse = score_from_creature_dir(
+        &creatures_dir,
+        &data_dir,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Rmse,
+    )
+    .expect("CPU RMSE scoring");
+
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        !gpu_rmse.is_empty(),
+        "expected at least one scored creature"
+    );
+    assert_eq!(gpu_rmse.len(), gpu_mse.len());
+    assert_eq!(gpu_rmse.len(), cpu_rmse.len());
+
+    for (key, rmse_res) in &gpu_rmse {
+        // costName must round-trip as RMSE.
+        assert_eq!(
+            rmse_res.cost_name, "RMSE",
+            "creature '{key}': costName must be RMSE, got {}",
+            rmse_res.cost_name
+        );
+
+        // (2) The host-side sqrt is really applied: RMSE == sqrt(MSE mean) on
+        // the same GPU run. `error` is the finalised mean loss.
+        let mse_res = gpu_mse
+            .get(key)
+            .unwrap_or_else(|| panic!("creature '{key}' missing from GPU MSE run"));
+        let expected_rmse = mse_res.error.sqrt();
+        assert!(
+            (rmse_res.error - expected_rmse).abs() <= 1e-9 * expected_rmse.max(1.0),
+            "creature '{key}': GPU RMSE {} must equal sqrt(GPU MSE {}) = {}",
+            rmse_res.error,
+            mse_res.error,
+            expected_rmse
+        );
+        assert!(
+            rmse_res.error > 0.0,
+            "creature '{key}': RMSE must be positive (a missing sqrt would still be positive, \
+             but a zero here means the fixture is degenerate)"
+        );
+
+        // (1) GPU RMSE agrees with CPU RMSE within the #81 CPU↔GPU tolerance.
+        let cpu_res = cpu_rmse
+            .get(key)
+            .unwrap_or_else(|| panic!("creature '{key}' missing from CPU RMSE run"));
+        let denom = cpu_res.error.abs().max(1e-12);
+        let rel = (cpu_res.error - rmse_res.error).abs() / denom;
+        assert!(
+            rel < 1e-3,
+            "creature '{key}': CPU RMSE={} GPU RMSE={} relative_error={rel} exceeds 1e-3",
+            cpu_res.error,
+            rmse_res.error
+        );
+    }
+}


### PR DESCRIPTION
# Serve RMSE on the existing GPU MSE kernel via a host-side `sqrt`

## Summary

`--cost RMSE` now runs on the **GPU** creature-directory path at full MSE
speed, reusing the existing `forward_mse_batched` kernel with only a host-side
`sqrt` at finalisation — **no new GPU kernel** (honouring the #318/#323
GPU-exhaustion constraint). The kernel already returns the squared-error sum
RMSE needs; only the `mean → sqrt(mean)` finalisation and the GPU-gating
predicate change. Closes #339.

RMSE's foundation (the `CostKind::Rmse` variant, its CPU dispatch, and the
shared `finalise_mean` helper) was scoped to the dependency sub-issue #338,
which had not yet landed on the milestone branch. Since #339 cannot compile or
be tested without it, this PR delivers that foundation alongside the GPU work so
the change is a self-contained, mergeable unit. Documentation of the new cost
(README / CHANGELOG) remains with #341, and the upstream `BUILT_IN_COST_NAMES`
sync remains with #340.

### What changed

- **`rust_scorer/src/cost.rs`**
  - Added the `Rmse` variant (`--cost RMSE`, `costName: "RMSE"`).
  - `gpu_supported()`: `matches!(self, Self::Mse | Self::Rmse)` — RMSE reuses
    the MSE kernel, so it is genuinely GPU-supported.
  - `accumulate_cost_sum`: RMSE dispatches to `mse_sum_batch_packed` unchanged —
    the `sqrt` lives only in finalisation, never in the per-chunk sum.
  - New shared `finalise_mean(error_sum, record_count)` helper: divides by the
    record count and applies `sqrt` for — and only for — RMSE.
- **Three finalisation sites now route through `finalise_mean`** so RMSE gets
  its `sqrt` identically everywhere:
  - `main.rs` single-creature path,
  - `multi_score.rs` CPU creature-directory path,
  - `multi_score.rs` GPU creature-directory path (the site the issue targets).
- **`main.rs`** `--cost` help text and the `--gpu on` guard comment updated to
  note RMSE is served by the MSE-only kernel via a host-side `sqrt`.
- **Gating (`gpu/mod.rs`)** needed no logic change — `auto_should_use_gpu`,
  `auto_should_use_gpu_directory`, `auto_cost_fallback_note`, and
  `auto_topology_fallback_note` all key off `cost.gpu_supported()`, so RMSE is
  treated like MSE automatically. Test coverage added to lock that.

### Data flow

```mermaid
flowchart LR
    A["--cost RMSE"] --> B["gpu_supported() = true"]
    B --> C["forward_mse_batched kernel<br/>(unchanged, squared-error sum)"]
    C --> D["finalise_mean(sum, count)"]
    D -->|"Rmse: sqrt(mean)"| E["error, costName: RMSE"]
    D -.->|"Mse: mean"| E
```

## Evidence

Backend/CLI change — no web UI to screenshot. Verified end-to-end on a real
Metal GPU (this build host):

| Command | `costName` | `error` | backend / kernel |
| --- | --- | --- | --- |
| `--gpu off  --cost MSE`  | `MSE`  | `0.25` | cpu-fallback |
| `--gpu off  --cost RMSE` | `RMSE` | `0.50` | cpu-fallback |
| `--gpu on   --cost RMSE` | `RMSE` | `0.50` | metal / `forward_mse_batched` |
| `--gpu auto --cost RMSE` | `RMSE` | `0.50` | metal / `forward_mse_batched` |

`RMSE = sqrt(MSE) = sqrt(0.25) = 0.5` confirms the host-side `sqrt`, and
`--gpu on --cost RMSE` no longer hard-errors — it runs on the MSE kernel.

The GPU↔CPU RMSE parity integration test ran (not skipped) on this host's GPU
and passed, confirming GPU RMSE matches CPU RMSE within the #81 tolerance and
equals `sqrt` of the MSE score on the same GPU run.

## Test Plan

Added / updated tests (all pass; `./quality.sh` green):

- `rust_scorer/src/cost.rs`
  - `gpu_supported_only_for_mse` → renamed/extended to
    `gpu_supported_only_for_mse_and_rmse` (RMSE GPU-supported; the other six
    are not).
  - `finalise_mean_applies_sqrt_only_for_rmse` — `sqrt` for RMSE, plain mean
    otherwise; RMSE == `sqrt` of the MSE finalisation.
  - `accumulate_cost_sum_rmse_matches_mse_sum` — RMSE reuses the MSE
    squared-error sum bit-for-bit.
  - `from_cli_accepts_rmse` — `--cost RMSE` parses; case-sensitive.
- `rust_scorer/src/gpu/mod.rs`
  - `auto_should_use_gpu_directory_uses_gpu_for_rmse` — RMSE is GPU-eligible
    like MSE.
  - `auto_cost_fallback_note_absent_for_rmse_directory` — RMSE emits no
    "not GPU-supported" CPU-fallback note.
- `rust_scorer/src/main.rs`
  - `test_cli_parses_rmse` — clap accepts `--cost RMSE`.
  - `test_gpu_on_accepts_mse_and_rmse_only` — the `--gpu on` guard clears for
    MSE/RMSE and still trips for CPU-only costs.
- `rust_scorer/tests/gpu_rmse_parity.rs` (new, GPU-gated)
  - `gpu_rmse_matches_cpu_rmse_and_is_sqrt_of_mse` — GPU↔CPU RMSE parity within
    #81 tolerance **and** RMSE == `sqrt` of the MSE score on the same GPU run
    (guards the finalisation routing at `multi_score.rs`).



## Milestone
This PR is part of the **#337 Support RMSE as a cost function** milestone and targets the `milestone/337-support-rmse-as-a-cost-function` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrk8oe4d-4a456b`<!-- vibe-worker-issue-339 -->