### PR TITLE
Replace flaky compileTimeSecs wall-clock assertion with compile-count probe (Issue #355)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,6 +54,17 @@ jobs:
         # node20, and no v2.1 / v3 tag has shipped yet, so we SHA-pin to the
         # master commit. Issue #136 cleared the prior Node 20 exception.
         uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432  # v2 (master HEAD, Node 24, post upstream #48)
+        # This action compiles cargo-audit from source with `cargo install`.
+        # `rust-toolchain.toml` pins the repo to a concrete rustc for
+        # reproducible builds of *our* code, but that pin must not gate the
+        # build of a third-party *tool*: a transitive cargo-audit dep can raise
+        # its MSRV above our pin and break this step with no code change (e.g.
+        # kstring@2.0.4 requires rustc 1.96.0, our pin is older — PR #361).
+        # RUSTUP_TOOLCHAIN overrides rust-toolchain.toml (highest rustup
+        # precedence) so cargo-audit builds under the installed `stable`
+        # toolchain, decoupling the tool's build from our code's MSRV pin.
+        env:
+          RUSTUP_TOOLCHAIN: stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/archive/pr-summaries/pr-summary-355.md
+++ b/docs/archive/pr-summaries/pr-summary-355.md
@@ -1,0 +1,63 @@
+## Summary
+
+Replaced the flaky wall-clock threshold assertion (`compileTimeSecs < 1.0`) in
+`rust_scorer/tests/directory_mode_tdd.rs` with a behavioural (WHAT) guard on the
+real invariant it was meant to protect: directory-mode scoring compiles each
+creature **exactly once** (Issue #42), not once per (creature × worker).
+
+The old upper bound was both flaky and toothless — it could fail on a saturated
+CI runner without any regression, yet 32 sub-millisecond recompiles of the tiny
+fixtures would still land far under 1.0 s, so it could also pass *with* the
+regression. Wall-clock budgets belong in a benchmark, not the test runner.
+
+This PR takes both remedies the audit suggested: it **deletes** the toothless
+upper bound from the subprocess contract test (keeping the `compileTimeSecs >=
+0.0` JSON shape assertion) and **adds** a behavioural compile-count probe that
+asserts the invariant directly.
+
+Closes #355.
+
+## What changed
+
+- `rust_scorer/src/multi_score.rs`: added a process-global `compile_probe`
+  module (`reset` / `count` / `record_compile`), mirroring the existing
+  `training_pass_probe`. `record_compile()` is called at each `compile_creature`
+  site in the **batch scoring paths** (CPU and GPU) — not the CPU-only
+  pre-flight hostability/topology probes, which are not part of the scoring pass.
+- `rust_scorer/tests/directory_mode_tdd.rs`: removed the `compile_secs < 1.0`
+  wall-clock assertion; kept the non-negative JSON-shape assertion; updated the
+  doc comment to point at the new behavioural test.
+- `rust_scorer/tests/compile_once_assertion.rs` (new): resets the probe, scores
+  a directory of N creatures on the CPU path, and asserts the observed compile
+  count equals N. The pre-#42 per-worker recompile would report `N × workers`
+  on any multi-core host and fail the `assert_eq!`.
+
+```mermaid
+flowchart LR
+    A[score N creatures] --> B[compile_probe::reset]
+    B --> C[compile each creature once]
+    C -->|clone CompiledNetwork\nfor extra workers| D[score batch in one pass]
+    C -.record_compile() ×N.-> E[compile_probe::count == N]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the test
+suite.
+
+Affected tests (all green under `cargo test` and `./quality.sh`):
+
+- `compile_once_assertion::multi_creature_batch_compiles_each_creature_once`
+  (N ∈ {2, 5, 11}) — new behavioural guard reproducing the Issue #42 invariant.
+- `compile_once_assertion::single_creature_compiles_once`.
+- `directory_mode_tdd::directory_mode_emits_compile_time_secs` — JSON contract
+  still enforced, minus the flaky wall-clock cap.
+- `single_pass_assertion::*` — unchanged, still green (the sibling probe pattern
+  this change mirrors).
+
+## Test Plan
+
+- `cargo test -p rust_scorer --test compile_once_assertion --test
+  directory_mode_tdd --test single_pass_assertion` — all pass.
+- `./quality.sh` — full gate passes (fmt, clippy, check, build, test, doc,
+  release).

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.12"
+version = "1.1.13"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -92,6 +92,50 @@ pub mod training_pass_probe {
     }
 }
 
+/// Instrumentation for the "compile each creature exactly once" invariant
+/// (Issue #42, guarded by Issue #355).
+///
+/// The batch scoring paths compile every loaded creature **once** and clone the
+/// resulting [`neat_core::network::CompiledNetwork`] for any additional workers.
+/// This process-global counter lets an integration test observe how many
+/// `compile_creature` calls a scoring invocation performs and fail loudly if a
+/// future change reintroduces the pre-#42 per-worker recompile (which would make
+/// the compile count scale with total worker count instead of staying flat at
+/// the creature count `N`).
+///
+/// Usage from a test: call [`compile_probe::reset`], run one scoring
+/// invocation, then assert [`compile_probe::count`] equals the creature count.
+///
+/// This is a behavioural (WHAT) replacement for the machine-dependent
+/// wall-clock threshold that previously guarded the same regression: it asserts
+/// the invariant the spec requires (compiled exactly once per creature) rather
+/// than a duration the current implementation happens to achieve.
+pub mod compile_probe {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static CREATURE_COMPILES: AtomicU64 = AtomicU64::new(0);
+
+    /// Reset the compile counter to zero. Call immediately before a scoring
+    /// invocation whose compile count you want to observe.
+    #[allow(dead_code)] // used by the `compile_once_assertion` integration test.
+    pub fn reset() {
+        CREATURE_COMPILES.store(0, Ordering::SeqCst);
+    }
+
+    /// Number of `compile_creature` calls recorded since the last [`reset`].
+    #[allow(dead_code)] // used by the `compile_once_assertion` integration test.
+    pub fn count() -> u64 {
+        CREATURE_COMPILES.load(Ordering::SeqCst)
+    }
+
+    /// Record one `compile_creature` call in a batch scoring path. Called
+    /// immediately before each such compile (not the CPU-only pre-flight
+    /// hostability/topology probes, which are not part of the scoring pass).
+    pub(crate) fn record_compile() {
+        CREATURE_COMPILES.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
 struct LoadedCreature {
     key: String,
     path: PathBuf,
@@ -525,6 +569,7 @@ fn score_from_creature_dir_cpu(
     let compile_started = Instant::now();
     let mut flat_networks: Vec<CompiledNetwork> = Vec::with_capacity(total_workers);
     for (ci, c) in loaded.iter().enumerate() {
+        compile_probe::record_compile();
         let template = compile_creature(&c.creature).map_err(|e| {
             format!(
                 "Failed compiling worker network for creature '{}': {e}",
@@ -1042,6 +1087,7 @@ fn score_from_creature_dir_gpu_impl(
     let compile_started = Instant::now();
     let mut networks: Vec<CompiledNetwork> = Vec::with_capacity(loaded.len());
     for c in &loaded {
+        compile_probe::record_compile();
         let net = compile_creature(&c.creature).map_err(|e| {
             format!(
                 "Failed compiling network for creature '{}': {e}",

--- a/rust_scorer/tests/compile_once_assertion.rs
+++ b/rust_scorer/tests/compile_once_assertion.rs
@@ -1,0 +1,117 @@
+//! Issue #42 / #355: permanent automated assertion that multi-creature
+//! (directory/batch) scoring compiles each creature **exactly once**, cloning
+//! the resulting `CompiledNetwork` for any additional workers — independent of
+//! how many workers the pool allocates.
+//!
+//! This is the behavioural (WHAT) replacement for the machine-dependent
+//! wall-clock threshold (`compileTimeSecs < 1.0`) that previously guarded the
+//! same regression in `tests/directory_mode_tdd.rs`. Wall-clock budgets flake
+//! on saturated CI runners and were toothless here anyway: 32 sub-millisecond
+//! recompiles of tiny fixtures still land far under 1.0 s. This test instead
+//! resets a compile probe, runs one scoring invocation, and asserts the
+//! observed compile count equals the creature count `N`. The pre-#42
+//! regression compiled once per (creature × worker); on any multi-core host
+//! that yields far more than `N` compiles, so the `assert_eq!` below fails
+//! before the regression can land.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::gpu::GpuBackendLabel;
+use rust_scorer::multi_score::{compile_probe, score_from_creature_dir};
+
+/// The compile probe is a process-global counter, so tests in this binary that
+/// touch it must not run concurrently. Serialise them through this lock;
+/// recover from poisoning so one failing test does not cascade into the others.
+static PROBE_LOCK: Mutex<()> = Mutex::new(());
+
+/// A minimal forward-only identity creature (1 input, 1 output). Every creature
+/// in a directory-mode batch must share the same input/output shape.
+fn minimal_creature() -> &'static str {
+    r#"{"input":1,"output":1,"forwardOnly":true,"neurons":[{"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}],"synapses":[{"fromUUID":"input-0","toUUID":"output-0","weight":1.0}]}"#
+}
+
+/// Write `n` distinct creature JSON files (identical shape, distinct filenames)
+/// into `creatures_dir`.
+fn write_creatures(creatures_dir: &Path, n: usize) {
+    for i in 0..n {
+        std::fs::write(
+            creatures_dir.join(format!("creature-{i}.json")),
+            minimal_creature(),
+        )
+        .expect("write creature json");
+    }
+}
+
+/// Write a training corpus of `records` (input, output) pairs into a single
+/// `.bin` file.
+fn write_training_data(data_dir: &Path, records: &[(f32, f32)]) {
+    let mut file = std::fs::File::create(data_dir.join("0.bin")).expect("create bin");
+    for (input, output) in records {
+        file.write_all(&input.to_le_bytes()).expect("write input");
+        file.write_all(&output.to_le_bytes()).expect("write output");
+    }
+}
+
+/// Score `n_creatures` against a fixed corpus on the CPU path and return the
+/// number of `compile_creature` calls observed for that single invocation.
+fn compiles_for_batch(n_creatures: usize) -> u64 {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let creatures_dir = tmp.path().join("creatures");
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir(&data_dir).expect("create data dir");
+
+    write_creatures(&creatures_dir, n_creatures);
+    let records: Vec<(f32, f32)> = (0..64).map(|i| (i as f32 * 0.1, i as f32 * 0.1)).collect();
+    write_training_data(&data_dir, &records);
+
+    compile_probe::reset();
+    let scores = score_from_creature_dir(
+        &creatures_dir,
+        &data_dir,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+    )
+    .expect("scoring must succeed");
+
+    // Sanity: the run really scored every creature in the batch.
+    assert_eq!(
+        scores.len(),
+        n_creatures,
+        "expected a score for each of the {n_creatures} creatures",
+    );
+
+    compile_probe::count()
+}
+
+/// Core assertion: scoring N creatures compiles exactly N times, regardless of
+/// how many workers the pool allocates. The pre-#42 per-worker recompile would
+/// report `N × workers` compiles on any multi-core host and fail here.
+#[test]
+fn multi_creature_batch_compiles_each_creature_once() {
+    let _guard = PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    for &n in &[2_usize, 5, 11] {
+        let compiles = compiles_for_batch(n);
+        assert_eq!(
+            compiles, n as u64,
+            "scoring {n} creatures must compile exactly {n} times, observed {compiles}",
+        );
+    }
+}
+
+/// The single-creature path also compiles exactly once, pinning that N == 1 and
+/// N > 1 share the same compile-once contract.
+#[test]
+fn single_creature_compiles_once() {
+    let _guard = PROBE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let compiles = compiles_for_batch(1);
+    assert_eq!(
+        compiles, 1,
+        "scoring a single creature must compile exactly once, observed {compiles}",
+    );
+}

--- a/rust_scorer/tests/directory_mode_tdd.rs
+++ b/rust_scorer/tests/directory_mode_tdd.rs
@@ -273,12 +273,17 @@ fn directory_mode_record_aligned_fast_path_matches_slow_path() {
 /// (creature × worker) pair — for a 2-creature run on a 16-CPU host that is
 /// 32 compiles before any scoring runs. After the fix each creature is
 /// compiled exactly once and the resulting `CompiledNetwork` is cloned for
-/// any additional workers, so:
+/// any additional workers.
 ///
-/// 1. `compileTimeSecs` must appear in the JSON for every creature, and
-/// 2. it must be tightly bounded — well under the wall-clock budget that the
-///    old "compile per worker" loop required for an even slightly non-trivial
-///    creature.
+/// This subprocess test guards the **JSON contract only**: `compileTimeSecs`
+/// must appear for every creature and be a non-negative number.
+///
+/// Issue #355: the machine-dependent wall-clock upper bound (`compile_secs <
+/// 1.0`) that previously lived here was removed — it was flaky on saturated CI
+/// runners yet toothless against the very regression it documented (32
+/// sub-millisecond recompiles of these tiny fixtures still land far under
+/// 1.0 s). The "compiled exactly once per creature" invariant is now asserted
+/// behaviourally via `compile_probe` in `tests/compile_once_assertion.rs`.
 #[test]
 fn directory_mode_emits_compile_time_secs() {
     let bin = env!("CARGO_BIN_EXE_rust_scorer");
@@ -318,13 +323,9 @@ fn directory_mode_emits_compile_time_secs() {
             compile_secs >= 0.0,
             "compileTimeSecs must be non-negative for {key}, got {compile_secs}",
         );
-        // Defensive upper bound: a single tiny-creature compile + clone is
-        // sub-millisecond on every supported host. If the per-worker
-        // recompile regresses, this will balloon well past the cap.
-        assert!(
-            compile_secs < 1.0,
-            "compileTimeSecs unexpectedly large for {key}: {compile_secs}s",
-        );
+        // Issue #355: no wall-clock upper bound here — the "compiled exactly
+        // once per creature" invariant is asserted behaviourally via
+        // `compile_probe` in `tests/compile_once_assertion.rs`.
     }
 }
 


### PR DESCRIPTION
## Summary

Replaced the flaky wall-clock threshold assertion (`compileTimeSecs < 1.0`) in
`rust_scorer/tests/directory_mode_tdd.rs` with a behavioural (WHAT) guard on the
real invariant it was meant to protect: directory-mode scoring compiles each
creature **exactly once** (Issue #42), not once per (creature × worker).

The old upper bound was both flaky and toothless — it could fail on a saturated
CI runner without any regression, yet 32 sub-millisecond recompiles of the tiny
fixtures would still land far under 1.0 s, so it could also pass *with* the
regression. Wall-clock budgets belong in a benchmark, not the test runner.

This PR takes both remedies the audit suggested: it **deletes** the toothless
upper bound from the subprocess contract test (keeping the `compileTimeSecs >=
0.0` JSON shape assertion) and **adds** a behavioural compile-count probe that
asserts the invariant directly.

Closes #355.

## What changed

- `rust_scorer/src/multi_score.rs`: added a process-global `compile_probe`
  module (`reset` / `count` / `record_compile`), mirroring the existing
  `training_pass_probe`. `record_compile()` is called at each `compile_creature`
  site in the **batch scoring paths** (CPU and GPU) — not the CPU-only
  pre-flight hostability/topology probes, which are not part of the scoring pass.
- `rust_scorer/tests/directory_mode_tdd.rs`: removed the `compile_secs < 1.0`
  wall-clock assertion; kept the non-negative JSON-shape assertion; updated the
  doc comment to point at the new behavioural test.
- `rust_scorer/tests/compile_once_assertion.rs` (new): resets the probe, scores
  a directory of N creatures on the CPU path, and asserts the observed compile
  count equals N. The pre-#42 per-worker recompile would report `N × workers`
  on any multi-core host and fail the `assert_eq!`.

```mermaid
flowchart LR
    A[score N creatures] --> B[compile_probe::reset]
    B --> C[compile each creature once]
    C -->|clone CompiledNetwork\nfor extra workers| D[score batch in one pass]
    C -.record_compile() ×N.-> E[compile_probe::count == N]
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the test
suite.

Affected tests (all green under `cargo test` and `./quality.sh`):

- `compile_once_assertion::multi_creature_batch_compiles_each_creature_once`
  (N ∈ {2, 5, 11}) — new behavioural guard reproducing the Issue #42 invariant.
- `compile_once_assertion::single_creature_compiles_once`.
- `directory_mode_tdd::directory_mode_emits_compile_time_secs` — JSON contract
  still enforced, minus the flaky wall-clock cap.
- `single_pass_assertion::*` — unchanged, still green (the sibling probe pattern
  this change mirrors).

## Test Plan

- `cargo test -p rust_scorer --test compile_once_assertion --test
  directory_mode_tdd --test single_pass_assertion` — all pass.
- `./quality.sh` — full gate passes (fmt, clippy, check, build, test, doc,
  release).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrpmb6v1-5211cf`<!-- vibe-worker-issue-355 -->