### PR TITLE
Remove source-text grep assertion from no_scheduled_dep_bump.bats (Issue #359)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-359.md
+++ b/docs/archive/pr-summaries/pr-summary-359.md
@@ -1,0 +1,62 @@
+## Summary
+
+Removed the sole source-text grep assertion from `tests/scripts/no_scheduled_dep_bump.bats`. Closes #359.
+
+The deleted test (`"quality.sh no longer invokes the removed upgrade-deps validator"`)
+ran `grep -F "check-upgrade-deps-workflow.sh" quality.sh` and asserted the string was
+absent. This verified nothing about behaviour — only that an incidental string was missing
+from `quality.sh`'s source. It was doubly weak:
+
+- As an absence-grep it could not catch the guarded regression reintroduced under a
+  different script name.
+- It would false-fail if `quality.sh` ever mentioned the old name in a comment (e.g. a
+  changelog note about the Issue #105 removal).
+
+The observable (WHAT) intent — "no scheduled dependency-bump path exists" — is already
+policed at the behavioural level by the remaining tests in the same file:
+
+- File-absence checks (the validator helper `scripts/check-upgrade-deps-workflow.sh` and
+  the manifest-change helper) — any attempt to re-wire the validator reappears here
+  regardless of how `quality.sh` refers to it.
+- The workflow cron scan that rejects any scheduled job naming `cargo upgrade` or
+  `bump-deps.sh`.
+
+Per the issue, option (a) (rewrite behaviourally) would only duplicate the existing
+file-absence check at line 23, so the redundant grep was deleted (option b). An explanatory
+comment was left in its place documenting why, so the removal is not mistaken for a
+coverage gap.
+
+## Evidence
+
+Backend/CLI test-only change — no web interface to screenshot.
+
+The affected suite passes after the change:
+
+```
+1..4
+ok 1 the weekly upgrade-dependencies workflow does not exist
+ok 2 the workflow validator helper for the removed schedule is gone
+ok 3 the manifest-change helper for the removed schedule is gone
+ok 4 no workflow under .github/workflows schedules a cargo dependency bump
+```
+
+The full `./quality.sh` gate passes cleanly (`✅ All quality checks passed!`).
+
+```mermaid
+flowchart TD
+    intent["Intent: no scheduled dependency-bump path exists"]
+    intent --> a["File-absence: upgrade-dependencies.yml gone"]
+    intent --> b["File-absence: check-upgrade-deps-workflow.sh gone"]
+    intent --> c["File-absence: check-upgrade-has-changes.sh gone"]
+    intent --> d["Workflow cron scan: no scheduled cargo upgrade / bump-deps.sh"]
+    intent -.removed.-> e["source-text grep of quality.sh (deleted)"]
+    style e stroke-dasharray: 5 5
+```
+
+## Test Plan
+
+- Modified `tests/scripts/no_scheduled_dep_bump.bats`: deleted the source-text grep
+  assertion (`quality.sh no longer invokes the removed upgrade-deps validator`); the
+  behavioural checks in the same file continue to enforce the Issue #105 policy.
+- Ran `bats tests/scripts/no_scheduled_dep_bump.bats < /dev/null` — 4 tests pass.
+- Ran `./quality.sh < /dev/null` — all checks pass.

--- a/docs/archive/pr-summaries/pr-summary-359.md
+++ b/docs/archive/pr-summaries/pr-summary-359.md
@@ -32,7 +32,7 @@ Backend/CLI test-only change — no web interface to screenshot.
 
 The affected suite passes after the change:
 
-```
+```text
 1..4
 ok 1 the weekly upgrade-dependencies workflow does not exist
 ok 2 the workflow validator helper for the removed schedule is gone

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.16"
+version = "1.1.17"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/tests/scripts/no_scheduled_dep_bump.bats
+++ b/tests/scripts/no_scheduled_dep_bump.bats
@@ -46,7 +46,11 @@ setup() {
   [ "$found_offender" -eq 0 ]
 }
 
-@test "quality.sh no longer invokes the removed upgrade-deps validator" {
-  run grep -F "check-upgrade-deps-workflow.sh" "$REPO_ROOT/quality.sh"
-  [ "$status" -ne 0 ]
-}
+# Note (Issue #359): a former test grepped `quality.sh`'s source for the
+# string "check-upgrade-deps-workflow.sh" and asserted its absence. That was a
+# source-text assertion, not a behavioural one — it verified nothing about how
+# the removed schedule is policed and would false-fail on an innocuous comment
+# mentioning the old name. The observable intent ("no scheduled dependency-bump
+# path exists") is fully covered by the file-absence checks above (the validator
+# helper at line 23 cannot be re-wired without reappearing) and the workflow
+# cron scan, so the redundant grep was deleted rather than duplicated here.


### PR DESCRIPTION
## Summary

Removed the sole source-text grep assertion from `tests/scripts/no_scheduled_dep_bump.bats`. Closes #359.

The deleted test (`"quality.sh no longer invokes the removed upgrade-deps validator"`)
ran `grep -F "check-upgrade-deps-workflow.sh" quality.sh` and asserted the string was
absent. This verified nothing about behaviour — only that an incidental string was missing
from `quality.sh`'s source. It was doubly weak:

- As an absence-grep it could not catch the guarded regression reintroduced under a
  different script name.
- It would false-fail if `quality.sh` ever mentioned the old name in a comment (e.g. a
  changelog note about the Issue #105 removal).

The observable (WHAT) intent — "no scheduled dependency-bump path exists" — is already
policed at the behavioural level by the remaining tests in the same file:

- File-absence checks (the validator helper `scripts/check-upgrade-deps-workflow.sh` and
  the manifest-change helper) — any attempt to re-wire the validator reappears here
  regardless of how `quality.sh` refers to it.
- The workflow cron scan that rejects any scheduled job naming `cargo upgrade` or
  `bump-deps.sh`.

Per the issue, option (a) (rewrite behaviourally) would only duplicate the existing
file-absence check at line 23, so the redundant grep was deleted (option b). An explanatory
comment was left in its place documenting why, so the removal is not mistaken for a
coverage gap.

## Evidence

Backend/CLI test-only change — no web interface to screenshot.

The affected suite passes after the change:

```text
1..4
ok 1 the weekly upgrade-dependencies workflow does not exist
ok 2 the workflow validator helper for the removed schedule is gone
ok 3 the manifest-change helper for the removed schedule is gone
ok 4 no workflow under .github/workflows schedules a cargo dependency bump
```

The full `./quality.sh` gate passes cleanly (`✅ All quality checks passed!`).

```mermaid
flowchart TD
    intent["Intent: no scheduled dependency-bump path exists"]
    intent --> a["File-absence: upgrade-dependencies.yml gone"]
    intent --> b["File-absence: check-upgrade-deps-workflow.sh gone"]
    intent --> c["File-absence: check-upgrade-has-changes.sh gone"]
    intent --> d["Workflow cron scan: no scheduled cargo upgrade / bump-deps.sh"]
    intent -.removed.-> e["source-text grep of quality.sh (deleted)"]
    style e stroke-dasharray: 5 5
```

## Test Plan

- Modified `tests/scripts/no_scheduled_dep_bump.bats`: deleted the source-text grep
  assertion (`quality.sh no longer invokes the removed upgrade-deps validator`); the
  behavioural checks in the same file continue to enforce the Issue #105 policy.
- Ran `bats tests/scripts/no_scheduled_dep_bump.bats < /dev/null` — 4 tests pass.
- Ran `./quality.sh < /dev/null` — all checks pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrqrqwdg-50d1b7`<!-- vibe-worker-issue-359 -->