### PR TITLE
Assert OK-marker count instead of verbatim success wording (Issue #360)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-360.md
+++ b/docs/archive/pr-summaries/pr-summary-360.md
@@ -1,0 +1,88 @@
+# PR Summary — Issue #360
+
+## Summary
+
+Replaced the verbatim informational success-message assertions in the happy-path
+("passes on the canonical fixture") test of every checker-script BATS suite with a
+single **machine-checkable marker count**. Each checker already emits one
+`OK`-prefixed line (literally `OK` then three spaces) per rule it evaluates and passes; the happy-path tests now
+assert the *number* of `OK`-prefixed lines rather than pinning the incidental prose of
+each success message.
+
+This resolves the audit finding (implementation-coupled assertions): a cosmetic
+rewording of a success message — or a suite-wide style change such as adding an
+`OK:` prefix or an emoji — no longer breaks dozens of tests with zero behavioural
+regression. The assertion still proves **every rule ran and passed** (a behaviour
+/ WHAT contract), because the exact `OK`-marker count only holds when each rule reached
+its pass branch. The exit-status assertion (`[ "$status" -eq 0 ]`) remains the
+primary contract, and the failure-path diagnostic assertions — a checker's genuine
+contract — are untouched.
+
+This is option (a) from the issue: assert a stable machine-checkable marker
+(the `OK`-prefix already emitted by every checker via its shared `ok()` helper)
+instead of prose. No checker script needed changing.
+
+Closes #360.
+
+## Approach
+
+```mermaid
+flowchart LR
+    A["Happy-path test"] --> B{"Old: assert 4-7<br/>verbatim prose<br/>fragments"}
+    A --> C["New: assert count of<br/>machine-checkable<br/>'OK   ' marker lines"]
+    B -.->|"breaks on any<br/>cosmetic reword"| D["🔴 false failure"]
+    C -->|"count holds only when<br/>every rule passes"| E["🟢 behaviour proven,<br/>wording free to change"]
+```
+
+Per-suite expected `OK`-marker counts (verified by running each checker against its
+canonical fixture):
+
+| Suite | count | Suite | count |
+| --- | --- | --- | --- |
+| actionlint_workflow | 5 | semgrep_workflow | 7 |
+| cargo_audit_workflow | 6 | security_policy | 5 |
+| cargo_quality_workflow | 7 | workflow_concurrency | 3 |
+| ci_permissions | 8 | workflow_job_graph | 15 |
+| dependency_review_workflow | 4 | workflow_timeouts | 3 |
+| gitleaks_workflow | 9 | prebuilt_tool_install | 2 |
+| markdown_lint_workflow | 7 | workflow_action_versions | 8 |
+| rust_lints | 5 | rust_toolchain | 3 |
+| sbom_workflow | 6 | | |
+
+### Note on `workflow_action_versions.bats`
+
+The cosmetic positive fragments (`actions/checkout@<SHA>`, `SHA-pinned`,
+`>= v5, SHA-pinned`) were replaced by the `OK`-marker count, but the negative guard
+`[[ "$output" != *"Node 20 exception, tracked"* ]]` was **retained**. That
+assertion is a genuine behavioural regression guard from Issue #136 (no action may
+regress onto the tracked Node 20 exception path — a compliant action still emits an
+`OK`-marker line, so the count alone would not catch it), not mere success-message
+wording. Its explanatory comment was updated accordingly.
+
+`security_policy.bats` likewise keeps its existing `[[ "$output" != *"FAIL"* ]]`
+assertion alongside the new count.
+
+## Evidence
+
+Backend/CLI (shell test) change only — no web interface to screenshot.
+
+- Verified the new assertion is **non-vacuous**: temporarily asserting a wrong
+  count (`-eq 99`) made `rust_toolchain.bats` "passes on the canonical fixture"
+  fail; restoring the correct count (`-eq 3`) made it pass again.
+- Full BATS suite (`bats tests/scripts`): **317 tests, 0 failures**.
+- `./scripts/spell-check.sh`: no typos found.
+
+## Test Plan
+
+- Modified the happy-path test in each of the 17 flagged suites under
+  `tests/scripts/` to assert the `OK`-marker count instead of verbatim prose:
+  `actionlint_workflow`, `cargo_audit_workflow`, `cargo_quality_workflow`,
+  `ci_permissions`, `dependency_review_workflow`, `gitleaks_workflow`,
+  `markdown_lint_workflow`, `rust_lints`, `rust_toolchain`, `sbom_workflow`,
+  `semgrep_workflow`, `security_policy`, `workflow_concurrency`,
+  `workflow_job_graph`, `workflow_timeouts`, `prebuilt_tool_install`,
+  `workflow_action_versions`.
+- No checker scripts changed; no tests removed or commented out (prose *positive*
+  fragments replaced by an equivalent, stronger behavioural assertion; genuine
+  negative/failure-path assertions retained).
+- Ran the full `tests/scripts` BATS suite (317 tests) — all pass.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.17"
+version = "1.1.18"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -60,11 +60,9 @@ EOF
   write_actionlint_workflow "$TMP_WF/actionlint.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"triggers on pull_request"* ]]
-  [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"actions/checkout pinned"* ]]
-  [[ "$output" == *"actionlint install step present"* ]]
-  [[ "$output" == *"actionlint invoked"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 5 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {

--- a/tests/scripts/cargo_audit_workflow.bats
+++ b/tests/scripts/cargo_audit_workflow.bats
@@ -53,12 +53,9 @@ EOF
   write_audit_workflow "$TMP_WF/cargo-audit.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"triggers on pull_request"* ]]
-  [[ "$output" == *"triggers on schedule"* ]]
-  [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"actions/checkout pinned"* ]]
-  [[ "$output" == *"dtolnay/rust-toolchain present"* ]]
-  [[ "$output" == *"cargo audit invoked"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 6 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {

--- a/tests/scripts/cargo_quality_workflow.bats
+++ b/tests/scripts/cargo_quality_workflow.bats
@@ -48,13 +48,9 @@ EOF
   write_quality_workflow "$TMP_WF/cargo-quality.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"triggers on pull_request"* ]]
-  [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"actions/checkout pinned"* ]]
-  [[ "$output" == *"dtolnay/rust-toolchain present"* ]]
-  [[ "$output" == *"rustfmt and clippy components requested"* ]]
-  [[ "$output" == *"cargo fmt --check invoked"* ]]
-  [[ "$output" == *"cargo clippy invoked with -D warnings"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {

--- a/tests/scripts/ci_permissions.bats
+++ b/tests/scripts/ci_permissions.bats
@@ -64,11 +64,9 @@ EOF
   write_good_workflow "$TMP_WF"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"workflow-level permissions block present"* ]]
-  [[ "$output" == *"top-level default grants contents: read"* ]]
-  [[ "$output" == *"top-level default declares no write scopes"* ]]
-  [[ "$output" == *"security job grants checks: write"* ]]
-  [[ "$output" == *"security job grants issues: write"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 8 ]
 }
 
 @test "fails when there is no workflow-level permissions block" {

--- a/tests/scripts/dependency_review_workflow.bats
+++ b/tests/scripts/dependency_review_workflow.bats
@@ -46,10 +46,9 @@ EOF
   write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"triggers on pull_request"* ]]
-  [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"actions/checkout pinned"* ]]
-  [[ "$output" == *"actions/dependency-review-action present"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 4 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {

--- a/tests/scripts/gitleaks_workflow.bats
+++ b/tests/scripts/gitleaks_workflow.bats
@@ -75,10 +75,9 @@ EOF
   write_hardened_workflow "$TMP_WF/gitleaks.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/gitleaks.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"pinned Gitleaks release URL present"* ]]
-  [[ "$output" == *"archive checksum verification present"* ]]
-  [[ "$output" == *"--log-opts limits scan to PR diff range"* ]]
-  [[ "$output" == *"strict bash (set -euo pipefail) present"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 9 ]
 }
 
 @test "fails when the workflow uses gitleaks-action instead of a pinned binary" {

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -52,13 +52,9 @@ EOF
   write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"triggers on pull_request"* ]]
-  [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"actions/checkout pinned"* ]]
-  [[ "$output" == *"actions/setup-node pinned"* ]]
-  [[ "$output" == *"markdownlint-cli2 install step present"* ]]
-  [[ "$output" == *"markdownlint-cli2 invoked"* ]]
-  [[ "$output" == *"push trigger targets the default branch (Develop)"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
 }
 
 @test "fails when the push trigger omits Develop (Issue #207)" {

--- a/tests/scripts/prebuilt_tool_install.bats
+++ b/tests/scripts/prebuilt_tool_install.bats
@@ -58,8 +58,9 @@ EOF
   write_prebuilt_workflow "$TMP_WF/wf.yml" "cargo-audit"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml" --tool cargo-audit
   [ "$status" -eq 0 ]
-  [[ "$output" == *"installs cargo-audit via prebuilt taiki-e/install-action"* ]]
-  [[ "$output" == *"no 'cargo install cargo-audit' source compile"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 2 ]
 }
 
 @test "fails when the tool is compiled from source via cargo install" {

--- a/tests/scripts/rust_lints.bats
+++ b/tests/scripts/rust_lints.bats
@@ -50,10 +50,9 @@ EOF
   write_lib "$TMP_LINTS/lib.rs"
   run "$SCRIPT_UNDER_TEST" --manifest "$TMP_LINTS/Cargo.toml" --lib "$TMP_LINTS/lib.rs"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[workspace.lints.rust] table present"* ]]
-  [[ "$output" == *"unsafe_op_in_unsafe_fn denied"* ]]
-  [[ "$output" == *"unused denied"* ]]
-  [[ "$output" == *"missing_docs scoped to the library surface"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 5 ]
 }
 
 @test "fails when the [workspace.lints.rust] table is missing" {

--- a/tests/scripts/rust_toolchain.bats
+++ b/tests/scripts/rust_toolchain.bats
@@ -32,9 +32,9 @@ EOF
   write_toolchain "$TMP_TC/rust-toolchain.toml"
   run "$SCRIPT_UNDER_TEST" --toolchain "$TMP_TC/rust-toolchain.toml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[toolchain] table present"* ]]
-  [[ "$output" == *"channel pinned to a concrete X.Y.Z version"* ]]
-  [[ "$output" == *"rustfmt and clippy components declared"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 3 ]
 }
 
 @test "fails when the [toolchain] table is missing" {

--- a/tests/scripts/sbom_workflow.bats
+++ b/tests/scripts/sbom_workflow.bats
@@ -63,12 +63,9 @@ EOF
   write_sbom_workflow "$TMP_WF/sbom.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"triggers on a build event"* ]]
-  [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"actions/checkout pinned"* ]]
-  [[ "$output" == *"dtolnay/rust-toolchain present"* ]]
-  [[ "$output" == *"CycloneDX SBOM generated"* ]]
-  [[ "$output" == *"SBOM uploaded as an artefact"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 6 ]
 }
 
 @test "fails when no build trigger is present" {

--- a/tests/scripts/security_policy.bats
+++ b/tests/scripts/security_policy.bats
@@ -50,9 +50,9 @@ EOF
   write_policy "$TMP_SEC/SECURITY.md"
   run "$SCRIPT_UNDER_TEST" --security-policy "$TMP_SEC/SECURITY.md"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"private reporting route"* ]]
-  [[ "$output" == *"supported-versions table"* ]]
-  [[ "$output" == *"emergency dependency-bump procedure"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 5 ]
   [[ "$output" != *"FAIL"* ]]
 }
 

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -89,13 +89,9 @@ EOF
   write_container_workflow "$TMP_WF/semgrep.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"triggers on pull_request"* ]]
-  [[ "$output" == *"permissions block grants only contents: read"* ]]
-  [[ "$output" == *"Semgrep container image is pinned by digest"* ]]
-  [[ "$output" == *"semgrep CLI invocation present"* ]]
-  [[ "$output" == *"explicit --config"* ]]
-  [[ "$output" == *"SEMGREP_APP_TOKEN sourced from secrets"* ]]
-  [[ "$output" == *"rationale comment references semgrep/semgrep-action equivalence"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
 }
 
 @test "passes on the semgrep/semgrep-action fixture" {

--- a/tests/scripts/workflow_action_versions.bats
+++ b/tests/scripts/workflow_action_versions.bats
@@ -56,13 +56,13 @@ EOF
   write_compliant_workflow "$TMP_WF/example.yml"
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"actions/checkout@${SHA_CHECKOUT}"* ]]
-  [[ "$output" == *"SHA-pinned"* ]]
+  # Issue #360: prove every action line was individually evaluated and passed via
+  # the machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 8 ]
   # Issue #136: dependency-review-action and audit-check both now ship on
   # Node 24 (>= v5 and master post #48 respectively) — no Node 20 exceptions
-  # remain in the policy. Assert the >= v<N> form replaces the old tracked
-  # exception banner.
-  [[ "$output" == *">= v5, SHA-pinned"* ]]
+  # remain in the policy. Guard against a regression to the tracked exception
+  # path (a genuine behavioural outcome, not just success wording).
   [[ "$output" != *"Node 20 exception, tracked"* ]]
 }
 

--- a/tests/scripts/workflow_concurrency.bats
+++ b/tests/scripts/workflow_concurrency.bats
@@ -47,9 +47,9 @@ EOF
   write_hardened_workflow "$TMP_WF/example.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"declares a top-level concurrency block"* ]]
-  [[ "$output" == *"keyed by github.ref"* ]]
-  [[ "$output" == *"cancel-in-progress is true"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 3 ]
 }
 
 @test "fails when the concurrency block is missing" {

--- a/tests/scripts/workflow_job_graph.bats
+++ b/tests/scripts/workflow_job_graph.bats
@@ -81,9 +81,9 @@ EOF
   write_good_workflow "$TMP_WF"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"job 'validation' defined"* ]]
-  [[ "$output" == *"aggregator 'ci-required' needs 'quality'"* ]]
-  [[ "$output" == *"aggregator 'ci-required' uses if: always()"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 15 ]
 }
 
 @test "fails when the aggregator job is missing" {

--- a/tests/scripts/workflow_timeouts.bats
+++ b/tests/scripts/workflow_timeouts.bats
@@ -53,9 +53,9 @@ EOF
   write_good_workflow "$TMP_WF"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"job 'quality' declares timeout-minutes: 30"* ]]
-  [[ "$output" == *"job 'lint' declares timeout-minutes: 10"* ]]
-  [[ "$output" == *"job 'security' is a reusable-workflow call"* ]]
+  # Issue #360: prove every rule was individually evaluated and passed via the
+  # machine-checkable "OK   " marker rather than pinning informational wording.
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 3 ]
 }
 
 @test "fails when a normal job has no timeout-minutes" {


### PR DESCRIPTION
# PR Summary — Issue #360

## Summary

Replaced the verbatim informational success-message assertions in the happy-path
("passes on the canonical fixture") test of every checker-script BATS suite with a
single **machine-checkable marker count**. Each checker already emits one
`OK`-prefixed line (literally `OK` then three spaces) per rule it evaluates and passes; the happy-path tests now
assert the *number* of `OK`-prefixed lines rather than pinning the incidental prose of
each success message.

This resolves the audit finding (implementation-coupled assertions): a cosmetic
rewording of a success message — or a suite-wide style change such as adding an
`OK:` prefix or an emoji — no longer breaks dozens of tests with zero behavioural
regression. The assertion still proves **every rule ran and passed** (a behaviour
/ WHAT contract), because the exact `OK`-marker count only holds when each rule reached
its pass branch. The exit-status assertion (`[ "$status" -eq 0 ]`) remains the
primary contract, and the failure-path diagnostic assertions — a checker's genuine
contract — are untouched.

This is option (a) from the issue: assert a stable machine-checkable marker
(the `OK`-prefix already emitted by every checker via its shared `ok()` helper)
instead of prose. No checker script needed changing.

Closes #360.

## Approach

```mermaid
flowchart LR
    A["Happy-path test"] --> B{"Old: assert 4-7<br/>verbatim prose<br/>fragments"}
    A --> C["New: assert count of<br/>machine-checkable<br/>'OK   ' marker lines"]
    B -.->|"breaks on any<br/>cosmetic reword"| D["🔴 false failure"]
    C -->|"count holds only when<br/>every rule passes"| E["🟢 behaviour proven,<br/>wording free to change"]
```

Per-suite expected `OK`-marker counts (verified by running each checker against its
canonical fixture):

| Suite | count | Suite | count |
| --- | --- | --- | --- |
| actionlint_workflow | 5 | semgrep_workflow | 7 |
| cargo_audit_workflow | 6 | security_policy | 5 |
| cargo_quality_workflow | 7 | workflow_concurrency | 3 |
| ci_permissions | 8 | workflow_job_graph | 15 |
| dependency_review_workflow | 4 | workflow_timeouts | 3 |
| gitleaks_workflow | 9 | prebuilt_tool_install | 2 |
| markdown_lint_workflow | 7 | workflow_action_versions | 8 |
| rust_lints | 5 | rust_toolchain | 3 |
| sbom_workflow | 6 | | |

### Note on `workflow_action_versions.bats`

The cosmetic positive fragments (`actions/checkout@<SHA>`, `SHA-pinned`,
`>= v5, SHA-pinned`) were replaced by the `OK`-marker count, but the negative guard
`[[ "$output" != *"Node 20 exception, tracked"* ]]` was **retained**. That
assertion is a genuine behavioural regression guard from Issue #136 (no action may
regress onto the tracked Node 20 exception path — a compliant action still emits an
`OK`-marker line, so the count alone would not catch it), not mere success-message
wording. Its explanatory comment was updated accordingly.

`security_policy.bats` likewise keeps its existing `[[ "$output" != *"FAIL"* ]]`
assertion alongside the new count.

## Evidence

Backend/CLI (shell test) change only — no web interface to screenshot.

- Verified the new assertion is **non-vacuous**: temporarily asserting a wrong
  count (`-eq 99`) made `rust_toolchain.bats` "passes on the canonical fixture"
  fail; restoring the correct count (`-eq 3`) made it pass again.
- Full BATS suite (`bats tests/scripts`): **317 tests, 0 failures**.
- `./scripts/spell-check.sh`: no typos found.

## Test Plan

- Modified the happy-path test in each of the 17 flagged suites under
  `tests/scripts/` to assert the `OK`-marker count instead of verbatim prose:
  `actionlint_workflow`, `cargo_audit_workflow`, `cargo_quality_workflow`,
  `ci_permissions`, `dependency_review_workflow`, `gitleaks_workflow`,
  `markdown_lint_workflow`, `rust_lints`, `rust_toolchain`, `sbom_workflow`,
  `semgrep_workflow`, `security_policy`, `workflow_concurrency`,
  `workflow_job_graph`, `workflow_timeouts`, `prebuilt_tool_install`,
  `workflow_action_versions`.
- No checker scripts changed; no tests removed or commented out (prose *positive*
  fragments replaced by an equivalent, stronger behavioural assertion; genuine
  negative/failure-path assertions retained).
- Ran the full `tests/scripts` BATS suite (317 tests) — all pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrr5otjb-10406b`<!-- vibe-worker-issue-360 -->