### PR TITLE
Disable persist-credentials on shell-checks NEAT-AI-core checkout (Issue #379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,10 @@ jobs:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
           path: NEAT-AI-core
+          # shell-checks only reads the tree (lint/syntax/bats) and never pushes
+          # back, so the workflow GITHUB_TOKEN must not be written to .git/config
+          # where a later step could read it (Issue #379).
+          persist-credentials: false
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |

--- a/docs/archive/pr-summaries/pr-summary-379.md
+++ b/docs/archive/pr-summaries/pr-summary-379.md
@@ -1,0 +1,66 @@
+# PR Summary — Issue #379
+
+## Summary
+
+The `shell-checks` job in `.github/workflows/ci.yml` checked out the
+`stSoftwareAU/NEAT-AI-core` path dependency (line 267) with `actions/checkout`
+but **without** `persist-credentials: false`. By default checkout writes the
+workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
+step in the job — including a compromised dependency or injected script — could
+read it and act as the token. The `shell-checks` job only reads the tree
+(bash syntax check, ShellCheck, bats) and never pushes back to a repository or
+fetches a private submodule, so the persisted credential is unnecessary and
+only widens the blast radius of a compromised step.
+
+This PR adds `persist-credentials: false` to that checkout so the token is not
+written to disk, and adds a bats regression test that asserts the property
+against the shipped `ci.yml`. Scope is limited to this one checkout step
+(finding `BP-PERSIST-CREDS-ci-shell-checks-1`); the sibling `shell-checks`
+checkout at line 261 is owned by Issue #378 and is intentionally untouched.
+
+Closes #379.
+
+## Evidence
+
+This is a CI/workflow-hardening change with no web interface to screenshot.
+Verification is via the new bats test and the existing workflow validators.
+
+```mermaid
+flowchart LR
+    A[checkout NEAT-AI-core] -->|default| B[GITHUB_TOKEN written to .git/config]
+    B --> C[later step can read token]
+    A -->|persist-credentials: false| D[no token on disk]
+    D --> E[reduced blast radius]
+```
+
+Before → after (the added checkout input):
+
+```yaml
+      - name: Checkout NEAT-AI-core (path dependency for neat-core)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          ref: Develop
+          path: NEAT-AI-core
+          persist-credentials: false   # added
+```
+
+- New test (red before the fix, green after):
+  `tests/scripts/persist_credentials_shell_checks.bats`.
+- `actionlint .github/workflows/ci.yml` — clean.
+- Existing workflow validators still pass: `check-workflow-paths.sh`,
+  `check-ci-permissions.sh`, `check-ci-job-graph.sh`,
+  `check-readme-ci-alignment.sh`, `check-actionlint-workflow.sh`.
+- Full `bats tests/scripts` suite passes (exit 0).
+
+## Test Plan
+
+- Added `tests/scripts/persist_credentials_shell_checks.bats`:
+  - `shell-checks NEAT-AI-core checkout sets persist-credentials: false` —
+    parses the real `ci.yml`, isolates the `shell-checks` job, locates the
+    checkout step targeting `stSoftwareAU/NEAT-AI-core`, and asserts it sets
+    `persist-credentials: false`. This test fails against the pre-fix workflow
+    and passes after the change.
+  - `parser reports 'no' when the disable flag is absent` — guards the
+    assertion by proving the parser returns `no` on a synthetic workflow whose
+    NEAT-AI-core checkout omits the flag.

--- a/tests/scripts/persist_credentials_shell_checks.bats
+++ b/tests/scripts/persist_credentials_shell_checks.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# Regression test for Issue #379 — the `shell-checks` job's NEAT-AI-core
+# path-dependency checkout must not persist the workflow GITHUB_TOKEN on disk.
+#
+# `actions/checkout` writes the token into `.git/config` by default. The
+# `shell-checks` job only reads the tree (lint/syntax/bats), never pushes back,
+# so the credential must be disabled with `persist-credentials: false`.
+#
+# Parses the real ci.yml: isolates the `shell-checks:` job, finds the checkout
+# step whose `with:` targets `stSoftwareAU/NEAT-AI-core`, and asserts that same
+# step sets `persist-credentials: false`. Behaviour is asserted against the
+# shipped workflow so the fix and the file cannot drift apart.
+
+setup() {
+  CI_WF="${BATS_TEST_DIRNAME}/../../.github/workflows/ci.yml"
+  export CI_WF
+}
+
+# Emit "yes" iff, inside the `shell-checks` job, the checkout step that targets
+# repository stSoftwareAU/NEAT-AI-core also sets persist-credentials: false.
+neat_core_checkout_disables_persist() {
+  local file="$1"
+  awk '
+    # Track entry/exit of the shell-checks job (2-space indented job key).
+    /^  shell-checks:[[:space:]]*$/ { in_job = 1; next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { in_job = 0 }
+    in_job == 0 { next }
+
+    # A new step (6-space "- ...") closes the previous step scope.
+    /^      - / {
+      is_checkout = ($0 ~ /uses:[[:space:]]*actions\/checkout/) ? 1 : 0
+      is_neat = 0
+      has_disable = 0
+    }
+    /uses:[[:space:]]*actions\/checkout/ { is_checkout = 1 }
+    is_checkout && /repository:[[:space:]]*stSoftwareAU\/NEAT-AI-core/ { is_neat = 1 }
+    is_checkout && /persist-credentials:[[:space:]]*false/ { has_disable = 1 }
+    is_checkout && is_neat && has_disable { found = 1 }
+
+    END { print (found ? "yes" : "no") }
+  ' "$file"
+}
+
+@test "shell-checks NEAT-AI-core checkout sets persist-credentials: false" {
+  [ -f "$CI_WF" ]
+  run neat_core_checkout_disables_persist "$CI_WF"
+  [ "$status" -eq 0 ]
+  [ "$output" = "yes" ]
+}
+
+@test "parser reports 'no' when the disable flag is absent (guards the assertion)" {
+  local tmp
+  tmp="$(mktemp)"
+  cat >"$tmp" <<'EOF'
+jobs:
+  shell-checks:
+    steps:
+      - name: Checkout NEAT-AI-core
+        uses: actions/checkout@sha
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          ref: Develop
+          path: NEAT-AI-core
+  spell-check:
+    steps:
+      - run: echo ok
+EOF
+  run neat_core_checkout_disables_persist "$tmp"
+  rm -f "$tmp"
+  [ "$output" = "no" ]
+}


### PR DESCRIPTION
# PR Summary — Issue #379

## Summary

The `shell-checks` job in `.github/workflows/ci.yml` checked out the
`stSoftwareAU/NEAT-AI-core` path dependency (line 267) with `actions/checkout`
but **without** `persist-credentials: false`. By default checkout writes the
workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
step in the job — including a compromised dependency or injected script — could
read it and act as the token. The `shell-checks` job only reads the tree
(bash syntax check, ShellCheck, bats) and never pushes back to a repository or
fetches a private submodule, so the persisted credential is unnecessary and
only widens the blast radius of a compromised step.

This PR adds `persist-credentials: false` to that checkout so the token is not
written to disk, and adds a bats regression test that asserts the property
against the shipped `ci.yml`. Scope is limited to this one checkout step
(finding `BP-PERSIST-CREDS-ci-shell-checks-1`); the sibling `shell-checks`
checkout at line 261 is owned by Issue #378 and is intentionally untouched.

Closes #379.

## Evidence

This is a CI/workflow-hardening change with no web interface to screenshot.
Verification is via the new bats test and the existing workflow validators.

```mermaid
flowchart LR
    A[checkout NEAT-AI-core] -->|default| B[GITHUB_TOKEN written to .git/config]
    B --> C[later step can read token]
    A -->|persist-credentials: false| D[no token on disk]
    D --> E[reduced blast radius]
```

Before → after (the added checkout input):

```yaml
      - name: Checkout NEAT-AI-core (path dependency for neat-core)
        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
        with:
          repository: stSoftwareAU/NEAT-AI-core
          ref: Develop
          path: NEAT-AI-core
          persist-credentials: false   # added
```

- New test (red before the fix, green after):
  `tests/scripts/persist_credentials_shell_checks.bats`.
- `actionlint .github/workflows/ci.yml` — clean.
- Existing workflow validators still pass: `check-workflow-paths.sh`,
  `check-ci-permissions.sh`, `check-ci-job-graph.sh`,
  `check-readme-ci-alignment.sh`, `check-actionlint-workflow.sh`.
- Full `bats tests/scripts` suite passes (exit 0).

## Test Plan

- Added `tests/scripts/persist_credentials_shell_checks.bats`:
  - `shell-checks NEAT-AI-core checkout sets persist-credentials: false` —
    parses the real `ci.yml`, isolates the `shell-checks` job, locates the
    checkout step targeting `stSoftwareAU/NEAT-AI-core`, and asserts it sets
    `persist-credentials: false`. This test fails against the pre-fix workflow
    and passes after the change.
  - `parser reports 'no' when the disable flag is absent` — guards the
    assertion by proving the parser returns `no` on a synthetic workflow whose
    NEAT-AI-core checkout omits the flag.



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrtqolvo-517513`<!-- vibe-worker-issue-379 -->