### PR TITLE
Disable persist-credentials on validation job checkouts (Issue #381)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # validation only reads the tree (required-file check + cargo metadata)
+          # and never pushes back, so the workflow GITHUB_TOKEN must not be
+          # written to .git/config where a later step could read it (Issue #381).
+          persist-credentials: false
 
       # NEAT-AI-core checkout path strategy — see note in the `quality` job
       # above. Summary: in-workspace clone + sibling symlink so Cargo resolves
@@ -199,6 +204,10 @@ jobs:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
           path: NEAT-AI-core
+          # This job only reads the neat-core tree (cargo metadata resolves the
+          # path dependency); it never pushes back, so the token must not persist
+          # on disk (Issue #381).
+          persist-credentials: false
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |

--- a/docs/archive/pr-summaries/pr-summary-381.md
+++ b/docs/archive/pr-summaries/pr-summary-381.md
@@ -1,0 +1,47 @@
+## Summary
+
+Hardened the `validation` job in `.github/workflows/ci.yml` so its
+`actions/checkout` steps no longer persist the workflow `GITHUB_TOKEN` on disk.
+By default `actions/checkout` writes the token into `.git/config` as an auth
+header, where any later step in the job — including a compromised dependency or
+an injected script — can read it and act as the token. The `validation` job only
+reads the tree (required-file check + `cargo metadata`) and never pushes back to
+the repository, so it does not need the persisted credential. Added
+`persist-credentials: false` to both the primary self-checkout and the
+NEAT-AI-core path-dependency checkout, mirroring the fix applied to `shell-checks`
+in Issue #379.
+
+Closes #381.
+
+## Evidence
+
+Backend/CI-only change — there is no web interface to screenshot.
+
+The idle-task finding (`BP-PERSIST-CREDS-ci-validation-0`) targeted
+`.github/workflows/ci.yml`:191, the `validation` job's step 0 checkout.
+
+```mermaid
+flowchart LR
+    A[actions/checkout default] -->|writes GITHUB_TOKEN to .git/config| B[.git/config auth header]
+    B --> C[Any later step can read the token]
+    D[persist-credentials: false] -->|token never written| E[No credential on disk]
+```
+
+Verified with the persist-credentials validator and the new regression test:
+
+- `./scripts/check-persist-credentials.sh` — passes.
+- `bats tests/scripts/persist_credentials_validation.bats` — the new test
+  asserts, against the shipped `ci.yml`, that the `validation` job's self
+  checkout sets `persist-credentials: false`.
+
+## Test Plan
+
+- Added `tests/scripts/persist_credentials_validation.bats`:
+  - `validation self checkout sets persist-credentials: false` — parses the real
+    `ci.yml`, isolates the `validation:` job, and asserts the self checkout
+    disables credential persistence (reproduces the finding; fails against the
+    unfixed workflow).
+  - `parser reports 'no' when the disable flag is absent` — guards the assertion
+    against a false positive.
+- Existing `tests/scripts/persist_credentials*.bats` continue to pass.
+- `./quality.sh` run locally.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.20"
+version = "1.1.21"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/tests/scripts/persist_credentials_validation.bats
+++ b/tests/scripts/persist_credentials_validation.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Regression test for Issue #381 — the `validation` job's primary "Checkout
+# code" step must not persist the workflow GITHUB_TOKEN on disk.
+#
+# `actions/checkout` writes the token into `.git/config` by default. The
+# `validation` job only reads the tree (required-file check + cargo metadata),
+# never pushes back, so the credential must be disabled with
+# `persist-credentials: false`.
+#
+# Parses the real ci.yml: isolates the `validation:` job, finds the self
+# checkout step (the one with no `repository:` override), and asserts that same
+# step sets `persist-credentials: false`. Behaviour is asserted against the
+# shipped workflow so the fix and the file cannot drift apart.
+
+setup() {
+  CI_WF="${BATS_TEST_DIRNAME}/../../.github/workflows/ci.yml"
+  export CI_WF
+}
+
+# Emit "yes" iff, inside the `validation` job, the self checkout step (an
+# actions/checkout with no `repository:` override) also sets
+# persist-credentials: false.
+self_checkout_disables_persist() {
+  local file="$1"
+  awk '
+    # Evaluate the just-finished step before opening a new scope.
+    function close_step() {
+      if (is_checkout && is_self && has_disable) found = 1
+    }
+
+    # Track entry/exit of the validation job (2-space indented job key).
+    /^  validation:[[:space:]]*$/ { in_job = 1; next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { if (in_job) { close_step() }; in_job = 0 }
+    in_job == 0 { next }
+
+    # A new step (6-space "- ...") closes the previous step scope.
+    /^      - / {
+      close_step()
+      is_checkout = ($0 ~ /uses:[[:space:]]*actions\/checkout/) ? 1 : 0
+      is_self = 1            # assume self-checkout until a repository: appears
+      has_disable = 0
+    }
+    /uses:[[:space:]]*actions\/checkout/ { is_checkout = 1 }
+    is_checkout && /repository:[[:space:]]/ { is_self = 0 }
+    is_checkout && /persist-credentials:[[:space:]]*false/ { has_disable = 1 }
+
+    END { close_step(); print (found ? "yes" : "no") }
+  ' "$file"
+}
+
+@test "validation self checkout sets persist-credentials: false" {
+  [ -f "$CI_WF" ]
+  run self_checkout_disables_persist "$CI_WF"
+  [ "$status" -eq 0 ]
+  [ "$output" = "yes" ]
+}
+
+@test "parser reports 'no' when the disable flag is absent (guards the assertion)" {
+  local tmp
+  tmp="$(mktemp)"
+  cat >"$tmp" <<'EOF'
+jobs:
+  validation:
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@sha
+      - name: Checkout NEAT-AI-core
+        uses: actions/checkout@sha
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          persist-credentials: false
+  spell-check:
+    steps:
+      - run: echo ok
+EOF
+  run self_checkout_disables_persist "$tmp"
+  rm -f "$tmp"
+  [ "$output" = "no" ]
+}


### PR DESCRIPTION
## Summary

Hardened the `validation` job in `.github/workflows/ci.yml` so its
`actions/checkout` steps no longer persist the workflow `GITHUB_TOKEN` on disk.
By default `actions/checkout` writes the token into `.git/config` as an auth
header, where any later step in the job — including a compromised dependency or
an injected script — can read it and act as the token. The `validation` job only
reads the tree (required-file check + `cargo metadata`) and never pushes back to
the repository, so it does not need the persisted credential. Added
`persist-credentials: false` to both the primary self-checkout and the
NEAT-AI-core path-dependency checkout, mirroring the fix applied to `shell-checks`
in Issue #379.

Closes #381.

## Evidence

Backend/CI-only change — there is no web interface to screenshot.

The idle-task finding (`BP-PERSIST-CREDS-ci-validation-0`) targeted
`.github/workflows/ci.yml`:191, the `validation` job's step 0 checkout.

```mermaid
flowchart LR
    A[actions/checkout default] -->|writes GITHUB_TOKEN to .git/config| B[.git/config auth header]
    B --> C[Any later step can read the token]
    D[persist-credentials: false] -->|token never written| E[No credential on disk]
```

Verified with the persist-credentials validator and the new regression test:

- `./scripts/check-persist-credentials.sh` — passes.
- `bats tests/scripts/persist_credentials_validation.bats` — the new test
  asserts, against the shipped `ci.yml`, that the `validation` job's self
  checkout sets `persist-credentials: false`.

## Test Plan

- Added `tests/scripts/persist_credentials_validation.bats`:
  - `validation self checkout sets persist-credentials: false` — parses the real
    `ci.yml`, isolates the `validation:` job, and asserts the self checkout
    disables credential persistence (reproduces the finding; fails against the
    unfixed workflow).
  - `parser reports 'no' when the disable flag is absent` — guards the assertion
    against a false positive.
- Existing `tests/scripts/persist_credentials*.bats` continue to pass.
- `./quality.sh` run locally.
