### PR TITLE
Harden dependency-review checkout with persist-credentials: false (Issue #383)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -42,6 +42,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # dependency-review only diffs the PR manifest against the base and
+          # never pushes back, so the workflow GITHUB_TOKEN must not be written
+          # to .git/config where a later step could read it (Issue #383).
+          persist-credentials: false
 
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0

--- a/docs/archive/pr-summaries/pr-summary-383.md
+++ b/docs/archive/pr-summaries/pr-summary-383.md
@@ -1,0 +1,60 @@
+# Harden `dependency-review` checkout — `persist-credentials: false` (Issue #383)
+
+## Summary
+
+The standalone `dependency-review` workflow's `actions/checkout` step ran with
+`actions/checkout`'s default `persist-credentials: true`, which writes the
+workflow `GITHUB_TOKEN` into `.git/config` as an auth header. The job only diffs
+the PR manifest against the base branch and never pushes back to the repository
+or fetches a private submodule, so the persisted credential is unnecessary and
+only widens the blast radius of a compromised step.
+
+This PR adds `persist-credentials: false` to that checkout step (mirroring the
+already-hardened `ci.yml` jobs, Issue #381) and extends the
+`check-persist-credentials.sh` gate's default set to include
+`dependency-review.yml` so the hardening cannot silently regress.
+
+Closes #383.
+
+## Changes
+
+- `.github/workflows/dependency-review.yml` — add `persist-credentials: false`
+  to the checkout step with an explanatory comment.
+- `scripts/check-persist-credentials.sh` — add `dependency-review.yml` to the
+  default workflow set now that its checkout is hardened; update header/usage
+  docs.
+- `tests/scripts/persist_credentials.bats` — add a regression test asserting the
+  real `dependency-review.yml` sets `persist-credentials: false`, and broaden
+  the default-set assertion.
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified via the
+repository's own gate and the bats suite:
+
+```
+$ ./scripts/check-persist-credentials.sh
+OK   .../dependency-review.yml: job 'dependency-review' single checkout sets persist-credentials: false
+exit=0
+
+$ bats tests/scripts/persist_credentials.bats
+1..10
+ok 10 real repository dependency-review.yml hardens its single checkout (Issue #383)
+```
+
+`shellcheck`, `actionlint`, and `check-dependency-review-workflow.sh` all pass.
+
+```mermaid
+flowchart LR
+    A["actions/checkout (default)"] -->|"writes GITHUB_TOKEN to .git/config"| B["later step can read token"]
+    C["actions/checkout<br/>persist-credentials: false"] -->|"no token on disk"| D["reduced blast radius"]
+```
+
+## Test Plan
+
+- `tests/scripts/persist_credentials.bats` — new test `real repository
+  dependency-review.yml hardens its single checkout (Issue #383)` reproduces the
+  finding (would fail against the unhardened workflow) and passes after the fix.
+- Existing `persist_credentials.bats` suite (10 tests) passes.
+- `./scripts/check-persist-credentials.sh` now validates both `ci.yml` and
+  `dependency-review.yml` and exits 0.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.21"
+version = "1.1.22"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-persist-credentials.sh
+++ b/scripts/check-persist-credentials.sh
@@ -22,10 +22,11 @@
 #
 # The script accepts zero or more `--workflow PATH` arguments so BATS tests can
 # exercise it against fixtures. With no argument it validates `ci.yml` — the
-# file this rule was introduced for (Issue #380). Sibling workflows carry their
-# own `BP-PERSIST-CREDS` audit findings; broadening this gate to every workflow
-# is deferred until those land, so an unfixed sibling cannot fail this check.
-# Point `--workflow` at any file to validate it directly.
+# file this rule was introduced for (Issue #380) — plus every sibling workflow
+# whose `BP-PERSIST-CREDS` audit finding has since been fixed and hardened
+# (`dependency-review.yml`, Issue #383). Sibling workflows are added to this
+# default set only once their checkout is hardened, so an unfixed sibling cannot
+# fail this check. Point `--workflow` at any file to validate it directly.
 set -euo pipefail
 
 usage() {
@@ -34,9 +35,10 @@ Usage: check-persist-credentials.sh [--workflow PATH]...
 
 Options:
   --workflow PATH   Path to a workflow YAML file to validate. May be repeated.
-                    With no --workflow argument, .github/workflows/ci.yml
-                    (relative to the repo root) is checked — see the header note
-                    on scope (Issue #380).
+                    With no --workflow argument, .github/workflows/ci.yml and
+                    .github/workflows/dependency-review.yml (relative to the repo
+                    root) are checked — see the header note on scope
+                    (Issues #380, #383).
   -h, --help        Show this message.
 
 Exits 0 when every credential-free single-checkout job sets
@@ -67,7 +69,10 @@ done
 
 if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # Default set: ci.yml (Issue #380) plus sibling workflows whose checkout has
+  # since been hardened (Issue #383).
   WORKFLOWS+=("$SCRIPT_DIR/../.github/workflows/ci.yml")
+  WORKFLOWS+=("$SCRIPT_DIR/../.github/workflows/dependency-review.yml")
 fi
 
 if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then

--- a/tests/scripts/persist_credentials.bats
+++ b/tests/scripts/persist_credentials.bats
@@ -156,8 +156,15 @@ EOF
   [[ "$output" == *"Usage"* ]]
 }
 
-@test "real repository ci.yml satisfies the persist-credentials rule" {
+@test "real repository default workflows satisfy the persist-credentials rule" {
   run "$SCRIPT_UNDER_TEST"
   [ "$status" -eq 0 ]
   [[ "$output" != *"FAIL"* ]]
+}
+
+@test "real repository dependency-review.yml hardens its single checkout (Issue #383)" {
+  DR_WF="${BATS_TEST_DIRNAME}/../../.github/workflows/dependency-review.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$DR_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"job 'dependency-review' single checkout sets persist-credentials: false"* ]]
 }


### PR DESCRIPTION
# Harden `dependency-review` checkout — `persist-credentials: false` (Issue #383)

## Summary

The standalone `dependency-review` workflow's `actions/checkout` step ran with
`actions/checkout`'s default `persist-credentials: true`, which writes the
workflow `GITHUB_TOKEN` into `.git/config` as an auth header. The job only diffs
the PR manifest against the base branch and never pushes back to the repository
or fetches a private submodule, so the persisted credential is unnecessary and
only widens the blast radius of a compromised step.

This PR adds `persist-credentials: false` to that checkout step (mirroring the
already-hardened `ci.yml` jobs, Issue #381) and extends the
`check-persist-credentials.sh` gate's default set to include
`dependency-review.yml` so the hardening cannot silently regress.

Closes #383.

## Changes

- `.github/workflows/dependency-review.yml` — add `persist-credentials: false`
  to the checkout step with an explanatory comment.
- `scripts/check-persist-credentials.sh` — add `dependency-review.yml` to the
  default workflow set now that its checkout is hardened; update header/usage
  docs.
- `tests/scripts/persist_credentials.bats` — add a regression test asserting the
  real `dependency-review.yml` sets `persist-credentials: false`, and broaden
  the default-set assertion.

## Evidence

Backend/CI-config change only — no web interface to screenshot. Verified via the
repository's own gate and the bats suite:

```
$ ./scripts/check-persist-credentials.sh
OK   .../dependency-review.yml: job 'dependency-review' single checkout sets persist-credentials: false
exit=0

$ bats tests/scripts/persist_credentials.bats
1..10
ok 10 real repository dependency-review.yml hardens its single checkout (Issue #383)
```

`shellcheck`, `actionlint`, and `check-dependency-review-workflow.sh` all pass.

```mermaid
flowchart LR
    A["actions/checkout (default)"] -->|"writes GITHUB_TOKEN to .git/config"| B["later step can read token"]
    C["actions/checkout<br/>persist-credentials: false"] -->|"no token on disk"| D["reduced blast radius"]
```

## Test Plan

- `tests/scripts/persist_credentials.bats` — new test `real repository
  dependency-review.yml hardens its single checkout (Issue #383)` reproduces the
  finding (would fail against the unhardened workflow) and passes after the fix.
- Existing `persist_credentials.bats` suite (10 tests) passes.
- `./scripts/check-persist-credentials.sh` now validates both `ci.yml` and
  `dependency-review.yml` and exits 0.
