### PR TITLE
Disable persist-credentials on markdownlint checkout (Issue #384)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # This job only reads the tree to lint markdown and never pushes back
+          # or fetches a private submodule, so the workflow GITHUB_TOKEN must not
+          # be written to .git/config where a later step could read it
+          # (Issue #384).
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6

--- a/docs/archive/pr-summaries/pr-summary-384.md
+++ b/docs/archive/pr-summaries/pr-summary-384.md
@@ -1,0 +1,51 @@
+# Harden markdownlint checkout with `persist-credentials: false` (Issue #384)
+
+## Summary
+
+The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran its single
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job — a compromised dependency or an injected script —
+could read it and act as the token. The job only reads the tree to lint
+markdown and never pushes back to the repository nor fetches a private
+submodule, so it does not need the persisted credential; keeping it on disk
+only widened the blast radius of a compromised step.
+
+This change sets `persist-credentials: false` on that checkout, mirroring the
+hardening already applied across `ci.yml` and `dependency-review.yml`. It also
+extends the `check-persist-credentials.sh` default validation set to cover
+`markdown-lint.yml` (following the Issue #383 precedent), so the shipped
+workflow and the enforced rule cannot drift apart.
+
+Closes #384.
+
+## Change flow
+
+```mermaid
+flowchart LR
+    A[markdownlint job] --> B[actions/checkout]
+    B -->|before: token in .git/config| C[later steps can read GITHUB_TOKEN]
+    B -->|after: persist-credentials false| D[no token on disk]
+```
+
+## Evidence
+
+Backend/CI change only — no web interface to screenshot. Verified via the shell
+validators and the bats suite:
+
+- `scripts/check-persist-credentials.sh` (default set) now reports
+  `job 'markdownlint' single checkout sets persist-credentials: false`.
+- `scripts/check-markdown-lint-workflow.sh` still passes every rule for the
+  edited workflow.
+- `scripts/check-workflow-action-versions.sh` confirms both `uses:` lines stay
+  SHA-pinned after the edit.
+- Full `bats tests/scripts` run: 332 tests pass.
+
+## Test Plan
+
+- Added `tests/scripts/persist_credentials.bats::real repository markdown-lint.yml
+  hardens its single checkout (Issue #384)` — asserts the real workflow's single
+  checkout sets `persist-credentials: false`. This test fails against the
+  unhardened workflow and passes after the fix.
+- Existing `persist_credentials.bats` and `markdown_lint_workflow.bats` suites
+  continue to pass unchanged.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.22"
+version = "1.1.23"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-persist-credentials.sh
+++ b/scripts/check-persist-credentials.sh
@@ -24,7 +24,8 @@
 # exercise it against fixtures. With no argument it validates `ci.yml` — the
 # file this rule was introduced for (Issue #380) — plus every sibling workflow
 # whose `BP-PERSIST-CREDS` audit finding has since been fixed and hardened
-# (`dependency-review.yml`, Issue #383). Sibling workflows are added to this
+# (`dependency-review.yml`, Issue #383; `markdown-lint.yml`, Issue #384).
+# Sibling workflows are added to this
 # default set only once their checkout is hardened, so an unfixed sibling cannot
 # fail this check. Point `--workflow` at any file to validate it directly.
 set -euo pipefail
@@ -35,10 +36,11 @@ Usage: check-persist-credentials.sh [--workflow PATH]...
 
 Options:
   --workflow PATH   Path to a workflow YAML file to validate. May be repeated.
-                    With no --workflow argument, .github/workflows/ci.yml and
-                    .github/workflows/dependency-review.yml (relative to the repo
+                    With no --workflow argument, .github/workflows/ci.yml,
+                    .github/workflows/dependency-review.yml and
+                    .github/workflows/markdown-lint.yml (relative to the repo
                     root) are checked — see the header note on scope
-                    (Issues #380, #383).
+                    (Issues #380, #383, #384).
   -h, --help        Show this message.
 
 Exits 0 when every credential-free single-checkout job sets
@@ -70,9 +72,11 @@ done
 if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   # Default set: ci.yml (Issue #380) plus sibling workflows whose checkout has
-  # since been hardened (Issue #383).
+  # since been hardened (dependency-review.yml — Issue #383;
+  # markdown-lint.yml — Issue #384).
   WORKFLOWS+=("$SCRIPT_DIR/../.github/workflows/ci.yml")
   WORKFLOWS+=("$SCRIPT_DIR/../.github/workflows/dependency-review.yml")
+  WORKFLOWS+=("$SCRIPT_DIR/../.github/workflows/markdown-lint.yml")
 fi
 
 if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then

--- a/tests/scripts/persist_credentials.bats
+++ b/tests/scripts/persist_credentials.bats
@@ -168,3 +168,10 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"job 'dependency-review' single checkout sets persist-credentials: false"* ]]
 }
+
+@test "real repository markdown-lint.yml hardens its single checkout (Issue #384)" {
+  ML_WF="${BATS_TEST_DIRNAME}/../../.github/workflows/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$ML_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"job 'markdownlint' single checkout sets persist-credentials: false"* ]]
+}


### PR DESCRIPTION
# Harden markdownlint checkout with `persist-credentials: false` (Issue #384)

## Summary

The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran its single
`actions/checkout` without `persist-credentials: false`. By default checkout
writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job — a compromised dependency or an injected script —
could read it and act as the token. The job only reads the tree to lint
markdown and never pushes back to the repository nor fetches a private
submodule, so it does not need the persisted credential; keeping it on disk
only widened the blast radius of a compromised step.

This change sets `persist-credentials: false` on that checkout, mirroring the
hardening already applied across `ci.yml` and `dependency-review.yml`. It also
extends the `check-persist-credentials.sh` default validation set to cover
`markdown-lint.yml` (following the Issue #383 precedent), so the shipped
workflow and the enforced rule cannot drift apart.

Closes #384.

## Change flow

```mermaid
flowchart LR
    A[markdownlint job] --> B[actions/checkout]
    B -->|before: token in .git/config| C[later steps can read GITHUB_TOKEN]
    B -->|after: persist-credentials false| D[no token on disk]
```

## Evidence

Backend/CI change only — no web interface to screenshot. Verified via the shell
validators and the bats suite:

- `scripts/check-persist-credentials.sh` (default set) now reports
  `job 'markdownlint' single checkout sets persist-credentials: false`.
- `scripts/check-markdown-lint-workflow.sh` still passes every rule for the
  edited workflow.
- `scripts/check-workflow-action-versions.sh` confirms both `uses:` lines stay
  SHA-pinned after the edit.
- Full `bats tests/scripts` run: 332 tests pass.

## Test Plan

- Added `tests/scripts/persist_credentials.bats::real repository markdown-lint.yml
  hardens its single checkout (Issue #384)` — asserts the real workflow's single
  checkout sets `persist-credentials: false`. This test fails against the
  unhardened workflow and passes after the fix.
- Existing `persist_credentials.bats` and `markdown_lint_workflow.bats` suites
  continue to pass unchanged.



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrtt83l8-1b5e34`<!-- vibe-worker-issue-384 -->