### PR TITLE
Harden sbom job self checkout with persist-credentials: false (Issue #385)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -45,6 +45,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # Least-privilege token handling (Issue #385): this job only reads the
+          # checked-out code to build the SBOM — it never pushes back — so the
+          # workflow GITHUB_TOKEN must not be written to `.git/config`, where a
+          # later step could read it and act as the token.
+          persist-credentials: false
 
       # Path strategy for the NEAT-AI-core sibling (Issue #18): clone it INTO
       # the workspace, then symlink so Cargo resolves the

--- a/docs/archive/pr-summaries/pr-summary-385.md
+++ b/docs/archive/pr-summaries/pr-summary-385.md
@@ -1,0 +1,75 @@
+# PR Summary — Issue #385
+
+## Summary
+
+The `sbom` job's checkout of the current repository ran `actions/checkout`
+without `persist-credentials: false`, so the action wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
+including a compromised dependency or an injected script — could read it and act
+as the token. This job only reads the checked-out code to build the CycloneDX
+SBOM and never pushes back, so the persisted credential is unnecessary blast
+radius.
+
+This PR adds `persist-credentials: false` to the self checkout in
+`.github/workflows/sbom.yml`, and hardens the per-repo gate so the fix cannot
+silently regress. **Closes #385.**
+
+Scope note: the second checkout in the job fetches a *different* repository
+(`stSoftwareAU/NEAT-AI-core`, identified by its `repository:` input) and
+legitimately needs a credential to fetch, so it remains exempt.
+
+## Changes
+
+- **`.github/workflows/sbom.yml`** — added `persist-credentials: false` to the
+  current-repo (self) checkout step.
+- **`scripts/check-sbom-workflow.sh`** — added rule 7: the self checkout (a
+  checkout with no `repository:` input) must set `persist-credentials: false`.
+  A cross-repo checkout (one carrying `repository:`) stays exempt because it
+  needs a credential to fetch a different repo.
+- **`tests/scripts/sbom_workflow.bats`** — added the `persist-credentials: false`
+  line to the canonical fixture, bumped the OK-marker count 6 → 7, and added two
+  behavioural tests: one asserting the validator fails when the self checkout
+  omits the setting, and one asserting the cross-repo checkout stays exempt.
+
+## Why this is the right layer
+
+```mermaid
+flowchart LR
+    A[actions/checkout self] -->|default| B[GITHUB_TOKEN in .git/config]
+    B --> C[Later step can read token]
+    A -->|persist-credentials: false| D[No token on disk]
+    D --> E[Reduced blast radius]
+```
+
+The dedicated `check-persist-credentials.sh` gate exempts *any* job with more
+than one checkout (a multi-checkout job is treated as a static sign a credential
+is needed). That coarse heuristic left this specific self checkout unguarded, so
+the regression protection lives in the sbom-specific validator instead, keeping
+the change scoped to this one workflow.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+per-repo gates and the bats suite:
+
+- **Regression test fails against the unfixed workflow** — stripping
+  `persist-credentials: false` from the self checkout makes rule 7 fail with
+  `self checkout of the current repo must set 'persist-credentials: false'
+  (Issue #385)` (exit 1).
+- **Validator passes on the fixed workflow** — `./scripts/check-sbom-workflow.sh`
+  reports 7 OK markers, exit 0.
+- **`./scripts/check-persist-credentials.sh`** — passes (exit 0); the sbom job
+  stays exempt under the shared gate, unchanged.
+- **`./quality.sh`** — passes cleanly (exit 0), including actionlint and the full
+  bats + Rust test suites.
+
+## Test Plan
+
+- `tests/scripts/sbom_workflow.bats::fails when the self checkout does not set persist-credentials: false`
+  — reproduces the unfixed state and asserts the validator rejects it.
+- `tests/scripts/sbom_workflow.bats::passes when only the cross-repo checkout omits persist-credentials`
+  — asserts the cross-repo (`repository:`) checkout stays exempt.
+- `tests/scripts/sbom_workflow.bats::passes on the canonical fixture` — updated
+  to expect 7 OK markers.
+- `tests/scripts/sbom_workflow.bats::real repository SBOM workflow satisfies every rule`
+  — the real `sbom.yml` now satisfies the new rule.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.23"
+version = "1.1.24"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-sbom-workflow.sh
+++ b/scripts/check-sbom-workflow.sh
@@ -124,4 +124,36 @@ else
   fail "SBOM is not uploaded — an actions/upload-artifact step is required"
 fi
 
+# 7. The self checkout (current repository — a checkout with no `repository:`
+#    input) must set `persist-credentials: false` (Issue #385). This job only
+#    reads the checked-out code to build the SBOM, so the workflow GITHUB_TOKEN
+#    must not be persisted to `.git/config` where a later step could read it.
+#    A cross-repo checkout (one with `repository:`, e.g. NEAT-AI-core) is
+#    exempt — it legitimately needs a credential to fetch a different repo.
+read -r self_seen self_ok < <(awk '
+  BEGIN { self_seen = 0; self_ok = 0 }
+  function flush() {
+    if (in_checkout && !has_repo) {
+      self_seen = 1
+      if (has_persist) self_ok = 1
+    }
+  }
+  /^[[:space:]]*-[[:space:]]/ {
+    flush()
+    in_checkout = 0; has_repo = 0; has_persist = 0
+  }
+  /uses:[[:space:]]*actions\/checkout@/ { in_checkout = 1 }
+  /^[[:space:]]*repository:/            { if (in_checkout) has_repo = 1 }
+  /persist-credentials:[[:space:]]*false/ { if (in_checkout) has_persist = 1 }
+  END { flush(); print self_seen "\t" self_ok }
+' "$WORKFLOW")
+
+if [[ "$self_seen" != "1" ]]; then
+  ok "no self checkout of the current repository to harden"
+elif [[ "$self_ok" == "1" ]]; then
+  ok "self checkout sets persist-credentials: false"
+else
+  fail "self checkout of the current repo must set 'persist-credentials: false' (Issue #385)"
+fi
+
 exit "$EXIT_CODE"

--- a/tests/scripts/sbom_workflow.bats
+++ b/tests/scripts/sbom_workflow.bats
@@ -42,6 +42,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/checkout@v5
         with:
           repository: stSoftwareAU/NEAT-AI-core
@@ -65,7 +67,39 @@ EOF
   [ "$status" -eq 0 ]
   # Issue #360: prove every rule was individually evaluated and passed via the
   # machine-checkable "OK   " marker rather than pinning informational wording.
-  [ "$(grep -c '^OK   ' <<<"$output")" -eq 6 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
+}
+
+@test "fails when the self checkout does not set persist-credentials: false" {
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  # Drop the `persist-credentials: false` from the self (current repo) checkout.
+  python3 - "$TMP_WF/sbom.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "      - uses: actions/checkout@v5\n"
+    "        with:\n"
+    "          persist-credentials: false\n",
+    "      - uses: actions/checkout@v5\n",
+    1,
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"persist-credentials: false"* ]]
+}
+
+@test "passes when only the cross-repo checkout omits persist-credentials" {
+  # The NEAT-AI-core checkout carries a `repository:` input, so it is exempt —
+  # the rule targets only the self checkout of the current repository.
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"self checkout sets persist-credentials: false"* ]]
 }
 
 @test "fails when no build trigger is present" {


### PR DESCRIPTION
# PR Summary — Issue #385

## Summary

The `sbom` job's checkout of the current repository ran `actions/checkout`
without `persist-credentials: false`, so the action wrote the workflow
`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
including a compromised dependency or an injected script — could read it and act
as the token. This job only reads the checked-out code to build the CycloneDX
SBOM and never pushes back, so the persisted credential is unnecessary blast
radius.

This PR adds `persist-credentials: false` to the self checkout in
`.github/workflows/sbom.yml`, and hardens the per-repo gate so the fix cannot
silently regress. **Closes #385.**

Scope note: the second checkout in the job fetches a *different* repository
(`stSoftwareAU/NEAT-AI-core`, identified by its `repository:` input) and
legitimately needs a credential to fetch, so it remains exempt.

## Changes

- **`.github/workflows/sbom.yml`** — added `persist-credentials: false` to the
  current-repo (self) checkout step.
- **`scripts/check-sbom-workflow.sh`** — added rule 7: the self checkout (a
  checkout with no `repository:` input) must set `persist-credentials: false`.
  A cross-repo checkout (one carrying `repository:`) stays exempt because it
  needs a credential to fetch a different repo.
- **`tests/scripts/sbom_workflow.bats`** — added the `persist-credentials: false`
  line to the canonical fixture, bumped the OK-marker count 6 → 7, and added two
  behavioural tests: one asserting the validator fails when the self checkout
  omits the setting, and one asserting the cross-repo checkout stays exempt.

## Why this is the right layer

```mermaid
flowchart LR
    A[actions/checkout self] -->|default| B[GITHUB_TOKEN in .git/config]
    B --> C[Later step can read token]
    A -->|persist-credentials: false| D[No token on disk]
    D --> E[Reduced blast radius]
```

The dedicated `check-persist-credentials.sh` gate exempts *any* job with more
than one checkout (a multi-checkout job is treated as a static sign a credential
is needed). That coarse heuristic left this specific self checkout unguarded, so
the regression protection lives in the sbom-specific validator instead, keeping
the change scoped to this one workflow.

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the
per-repo gates and the bats suite:

- **Regression test fails against the unfixed workflow** — stripping
  `persist-credentials: false` from the self checkout makes rule 7 fail with
  `self checkout of the current repo must set 'persist-credentials: false'
  (Issue #385)` (exit 1).
- **Validator passes on the fixed workflow** — `./scripts/check-sbom-workflow.sh`
  reports 7 OK markers, exit 0.
- **`./scripts/check-persist-credentials.sh`** — passes (exit 0); the sbom job
  stays exempt under the shared gate, unchanged.
- **`./quality.sh`** — passes cleanly (exit 0), including actionlint and the full
  bats + Rust test suites.

## Test Plan

- `tests/scripts/sbom_workflow.bats::fails when the self checkout does not set persist-credentials: false`
  — reproduces the unfixed state and asserts the validator rejects it.
- `tests/scripts/sbom_workflow.bats::passes when only the cross-repo checkout omits persist-credentials`
  — asserts the cross-repo (`repository:`) checkout stays exempt.
- `tests/scripts/sbom_workflow.bats::passes on the canonical fixture` — updated
  to expect 7 OK markers.
- `tests/scripts/sbom_workflow.bats::real repository SBOM workflow satisfies every rule`
  — the real `sbom.yml` now satisfies the new rule.
