### PR TITLE
Cover milestone PRs in the actionlint CI gate (Issue #390)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,7 +23,9 @@ name: Actionlint
 
 on:
   pull_request:
-    branches: ["*"]
+    # "*" matches only single-level base branches, so milestone/<slug> sub-issue
+    # PRs would skip this gate; "milestone/**" restores coverage (Issue #390).
+    branches: ["*", "milestone/**"]
   push:
     branches: [main, master, Develop]
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -919,8 +919,9 @@ validated by `scripts/check-dependency-review-workflow.sh` (invoked from
 
 A standalone Actionlint workflow (`.github/workflows/actionlint.yml`,
 Issue #195) runs [actionlint](https://github.com/rhysd/actionlint) — the
-standard GitHub Actions linter — on every pull request and on pushes to the
-default branches. actionlint catches workflow regressions that a plain YAML
+standard GitHub Actions linter — on every pull request (including PRs targeting
+`milestone/**` sub-issue branches, Issue #390) and on pushes to the default
+branches. actionlint catches workflow regressions that a plain YAML
 parse misses: invalid `runs-on` labels, broken `${{ }}` expressions, unknown
 `uses:` inputs, and shellcheck findings inside `run:` scripts. The binary is
 downloaded from a version-pinned upstream release by the official

--- a/docs/archive/pr-summaries/pr-summary-390.md
+++ b/docs/archive/pr-summaries/pr-summary-390.md
@@ -1,0 +1,51 @@
+# CI actionlint gate now runs on milestone PRs
+
+## Summary
+
+The standalone Actionlint quality workflow
+(`.github/workflows/actionlint.yml`) filtered `pull_request` events with
+`branches: ["*"]`. GitHub's branch-filter glob `*` matches only single-level
+refs — it does **not** match refs containing a `/`, so PRs targeting a
+`milestone/<slug>` sub-issue branch never triggered the gate. Those
+intermediate PRs merged into the milestone branch unlinted, with the gap only
+caught later by the single rollup PR into the default branch.
+
+The filter is now `branches: ["*", "milestone/**"]`, restoring the gate on
+milestone sub-issue PRs while preserving the existing top-level branch
+coverage. `milestone/**` matches the repo's existing convention already used by
+`auto-format.yml` and `version-increment.yml`.
+
+The workflow validator `scripts/check-actionlint-workflow.sh` gained a sixth
+rule that fails when the `pull_request` branch filter omits `milestone/*`, so
+this regression cannot silently return.
+
+Closes #390.
+
+## Evidence
+
+Backend/CI-config change — no web UI to screenshot. Verified via the BATS
+suite that drives the validator end-to-end against synthetic fixtures, plus the
+full `./quality.sh` gate (which invokes the validator against the real
+workflow) passing cleanly.
+
+```mermaid
+flowchart LR
+    A["milestone/&lt;slug&gt; sub-issue PR"] -->|before: branches ['*']| B["gate skipped<br/>(glob '*' ignores '/')"]
+    A -->|after: branches ['*', 'milestone/**']| C["actionlint gate runs"]
+    B --> D["merges unlinted"]
+    C --> E["regressions caught pre-merge"]
+```
+
+## Test Plan
+
+- Added `tests/scripts/actionlint_workflow.bats::"fails when the pull_request
+  branch filter omits milestone branches"` — reverts the fixture to the bare
+  `["*"]` filter and asserts the validator exits non-zero with a `milestone`
+  message (reproduces #390 against the unfixed config).
+- Updated the canonical-fixture test to expect **6** `OK` rule markers (the new
+  milestone rule) and the fixture/replace strings for the new branch filter.
+- `tests/scripts/actionlint_workflow.bats::"real repository actionlint workflow
+  satisfies every rule"` confirms the shipped `actionlint.yml` now passes the
+  milestone rule.
+- Full suite: `bats tests/scripts/actionlint_workflow.bats` → 11/11 pass.
+- `./quality.sh` → all quality checks passed.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.25"
+version = "1.1.26"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-actionlint-workflow.sh
+++ b/scripts/check-actionlint-workflow.sh
@@ -11,6 +11,9 @@
 #      download-actionlint.bash installer fetched from a version-pinned
 #      upstream ref — no third-party wrapper action).
 #   5. Invoke `actionlint` so the lint gate actually runs.
+#   6. Cover milestone/<slug> branches in the pull_request filter so the gate
+#      runs on milestone sub-issue PRs, not only top-level base branches
+#      (Issue #390). A bare "*" glob does not match refs containing a slash.
 #
 # The script takes a single optional `--workflow PATH` argument so BATS tests
 # can exercise it against fixtures. When called with no argument it validates
@@ -112,6 +115,17 @@ if grep -qE '^[[:space:]]+(- )?run:[[:space:]]*actionlint' "$WORKFLOW" \
   ok "actionlint invoked"
 else
   fail "actionlint is not invoked — no 'run: actionlint' step found"
+fi
+
+# 6. pull_request branch filter must include milestone branches so the gate
+#    runs on milestone/<slug> sub-issue PRs. A bare "*" glob only matches
+#    single-level refs, so milestone/<slug> would otherwise skip the gate and
+#    merge unchecked into the milestone branch (Issue #390). The token
+#    `milestone/*` also matches the wider `milestone/**` glob.
+if grep -qE 'milestone/\*' "$WORKFLOW"; then
+  ok "pull_request branch filter covers milestone/* branches"
+else
+  fail "pull_request branch filter omits milestone/* — milestone PRs skip the gate"
 fi
 
 exit "$EXIT_CODE"

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -26,7 +26,7 @@ name: Actionlint
 
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["*", "milestone/**"]
   push:
     branches: [main, master, Develop]
 
@@ -62,7 +62,7 @@ EOF
   [ "$status" -eq 0 ]
   # Issue #360: prove every rule was individually evaluated and passed via the
   # machine-checkable "OK   " marker rather than pinning informational wording.
-  [ "$(grep -c '^OK   ' <<<"$output")" -eq 5 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 6 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {
@@ -72,7 +72,7 @@ import sys
 path = sys.argv[1]
 with open(path) as fh:
     text = fh.read()
-text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+text = text.replace("  pull_request:\n    branches: [\"*\", \"milestone/**\"]\n", "")
 with open(path, "w") as fh:
     fh.write(text)
 PY
@@ -137,6 +137,15 @@ PY
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"not invoked"* ]]
+}
+
+@test "fails when the pull_request branch filter omits milestone branches" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  # Revert to the pre-fix bare "*" filter, which does not match milestone/<slug>.
+  sed -i.bak 's|branches: \["\*", "milestone/\*\*"\]|branches: ["*"]|' "$TMP_WF/actionlint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"milestone"* ]]
 }
 
 @test "reports an error when the workflow file does not exist" {


### PR DESCRIPTION
# CI actionlint gate now runs on milestone PRs

## Summary

The standalone Actionlint quality workflow
(`.github/workflows/actionlint.yml`) filtered `pull_request` events with
`branches: ["*"]`. GitHub's branch-filter glob `*` matches only single-level
refs — it does **not** match refs containing a `/`, so PRs targeting a
`milestone/<slug>` sub-issue branch never triggered the gate. Those
intermediate PRs merged into the milestone branch unlinted, with the gap only
caught later by the single rollup PR into the default branch.

The filter is now `branches: ["*", "milestone/**"]`, restoring the gate on
milestone sub-issue PRs while preserving the existing top-level branch
coverage. `milestone/**` matches the repo's existing convention already used by
`auto-format.yml` and `version-increment.yml`.

The workflow validator `scripts/check-actionlint-workflow.sh` gained a sixth
rule that fails when the `pull_request` branch filter omits `milestone/*`, so
this regression cannot silently return.

Closes #390.

## Evidence

Backend/CI-config change — no web UI to screenshot. Verified via the BATS
suite that drives the validator end-to-end against synthetic fixtures, plus the
full `./quality.sh` gate (which invokes the validator against the real
workflow) passing cleanly.

```mermaid
flowchart LR
    A["milestone/&lt;slug&gt; sub-issue PR"] -->|before: branches ['*']| B["gate skipped<br/>(glob '*' ignores '/')"]
    A -->|after: branches ['*', 'milestone/**']| C["actionlint gate runs"]
    B --> D["merges unlinted"]
    C --> E["regressions caught pre-merge"]
```

## Test Plan

- Added `tests/scripts/actionlint_workflow.bats::"fails when the pull_request
  branch filter omits milestone branches"` — reverts the fixture to the bare
  `["*"]` filter and asserts the validator exits non-zero with a `milestone`
  message (reproduces #390 against the unfixed config).
- Updated the canonical-fixture test to expect **6** `OK` rule markers (the new
  milestone rule) and the fixture/replace strings for the new branch filter.
- `tests/scripts/actionlint_workflow.bats::"real repository actionlint workflow
  satisfies every rule"` confirms the shipped `actionlint.yml` now passes the
  milestone rule.
- Full suite: `bats tests/scripts/actionlint_workflow.bats` → 11/11 pass.
- `./quality.sh` → all quality checks passed.
