### PR TITLE
Disable checkout credential persistence in security.yml (Issue #388)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # No step in this job pushes back or fetches a private submodule, so
+          # the GITHUB_TOKEN need not be written to .git/config (Issue #388).
+          persist-credentials: false
 
       # Path strategy for the NEAT-AI-core sibling (Issue #18):
       #   * `actions/checkout` refuses any `path:` that resolves outside
@@ -36,6 +40,9 @@ jobs:
           repository: stSoftwareAU/NEAT-AI-core
           ref: Develop
           path: NEAT-AI-core
+          # Public sibling clone, read-only — no credential need be persisted
+          # to disk for the rest of the job (Issue #388).
+          persist-credentials: false
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |

--- a/README.md
+++ b/README.md
@@ -770,6 +770,30 @@ lives in the called workflow's own job (`security.yml`).
 The rule is validated by `scripts/check-workflow-timeouts.sh` (wired into
 `quality.sh`) and covered end-to-end by `tests/scripts/workflow_timeouts.bats`.
 
+### Checkout credential persistence (Issue #388)
+
+Every `actions/checkout` step in the reusable `security.yml` sets
+`persist-credentials: false`. By default checkout writes the workflow's
+`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
+same job — including a compromised dependency or an injected script — can read
+it and act as the token. The `security` job only reads the checked-out code and
+runs `cargo audit` / dependency-review; it never pushes back and never fetches a
+private submodule, so keeping the credential on disk is pure blast radius.
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|token written to .git/config| B[later step reads it]
+    B --> C[acts as GITHUB_TOKEN]
+    D[persist-credentials: false] -->|token off disk| E[later step has nothing to steal]
+```
+
+If a checkout genuinely needs the persisted credential (e.g. it later pushes
+back or fetches a private submodule), document the exception with an inline
+`# best-practice-ignore: BP-PERSIST-CREDS — <reason>` comment above the `uses:`
+line. The rule is validated by `scripts/check-persist-credentials.sh` (wired
+into `quality.sh`) and covered end-to-end by
+`tests/scripts/persist_credentials.bats`.
+
 ### Pre-quality dependency bump (`bump-deps.sh`)
 
 `bump-deps.sh` lives at the repo root and is invoked by the Vibe Coder

--- a/docs/archive/pr-summaries/pr-summary-388.md
+++ b/docs/archive/pr-summaries/pr-summary-388.md
@@ -1,0 +1,72 @@
+# Disable checkout credential persistence in `security.yml` (Issue #388)
+
+## Summary
+
+The `security` reusable workflow ran both `actions/checkout` steps with the
+default `persist-credentials: true`, writing the workflow's `GITHUB_TOKEN` into
+`.git/config` as an auth header. Any later step in the job — a compromised
+dependency, an injected script — could read that token and act as it. The job
+only reads the checked-out code and runs `cargo audit` / dependency-review; it
+never pushes back and never fetches a private submodule, so the persisted
+credential was pure blast radius.
+
+This PR adds `persist-credentials: false` to both checkout steps, plus a
+`quality.sh`-wired guard so the property cannot silently regress. Closes #388.
+
+## Changes
+
+- `.github/workflows/security.yml` — `persist-credentials: false` on both the
+  main checkout and the NEAT-AI-core sibling checkout.
+- `scripts/check-persist-credentials.sh` — new indentation-aware YAML scanner
+  (same house style as `check-ci-permissions.sh`) that fails when any
+  `actions/checkout` step in the target workflow omits `persist-credentials:
+  false`. A documented `# best-practice-ignore: BP-PERSIST-CREDS — <reason>`
+  comment above the `uses:` line is honoured as an explicit exception.
+- `quality.sh` — runs the new check alongside the other workflow-hygiene gates.
+- `README.md` — new "Checkout credential persistence" subsection documenting the
+  rule and its escape hatch.
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|token written to .git/config| B[later step reads it]
+    B --> C[acts as GITHUB_TOKEN]
+    D[persist-credentials: false] -->|token off disk| E[later step has nothing to steal]
+```
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verification is the new
+check script plus its BATS suite.
+
+`scripts/check-persist-credentials.sh` against the fixed workflow:
+
+```
+OK   .../security.yml: checkout at line 23 sets persist-credentials: false
+OK   .../security.yml: checkout at line 38 sets persist-credentials: false
+```
+
+`shellcheck` (clean) and `actionlint .github/workflows/security.yml` (clean)
+both pass.
+
+## Test Plan
+
+- Added `tests/scripts/persist_credentials.bats` (8 tests):
+  - passes when every checkout disables persistence;
+  - fails when a checkout omits `persist-credentials: false` (reproduces the
+    pre-fix state);
+  - fails when only one of two checkouts disables it;
+  - honours a documented `BP-PERSIST-CREDS` ignore;
+  - fails when no checkout step is present;
+  - errors on a missing workflow file / unknown flag;
+  - asserts the real repo `security.yml` passes the rule.
+- All new BATS tests pass; `shellcheck` and `actionlint` are clean.
+
+### Note on the local quality gate
+
+`./quality.sh` reports one unrelated failure —
+`tests/scripts/cargo_metadata.bats::cargo metadata exposes the repository
+field` — because this local checkout has no sibling `NEAT-AI-core` clone at
+`../../NEAT-AI-core/neat-core`, so `cargo metadata` cannot resolve the
+`neat-core` path dependency. It is environmental (CI checks the sibling out, as
+this very workflow does) and cannot be affected by a workflow-YAML / shell /
+docs change. Every workflow-hygiene check and the new suite pass.

--- a/docs/archive/pr-summaries/pr-summary-388.md
+++ b/docs/archive/pr-summaries/pr-summary-388.md
@@ -40,7 +40,7 @@ check script plus its BATS suite.
 
 `scripts/check-persist-credentials.sh` against the fixed workflow:
 
-```
+```text
 OK   .../security.yml: checkout at line 23 sets persist-credentials: false
 OK   .../security.yml: checkout at line 38 sets persist-credentials: false
 ```

--- a/quality.sh
+++ b/quality.sh
@@ -99,6 +99,9 @@ echo "🔢 Validating workflow action versions for Node 24 compat (Issue #24)...
 echo "🔑 Validating CI least-privilege token scope (Issue #155)..."
 ./scripts/check-ci-permissions.sh
 
+echo "🔐 Validating security.yml checkouts disable credential persistence (Issue #388)..."
+./scripts/check-persist-credentials.sh
+
 echo "⏱️  Validating per-job timeout-minutes across workflows (Issue #154)..."
 ./scripts/check-workflow-timeouts.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.19"
+version = "1.1.20"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-persist-credentials.sh
+++ b/scripts/check-persist-credentials.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Validate that every `actions/checkout` step in the reusable security workflow
+# disables credential persistence (Issue #388).
+#
+# Background: by default `actions/checkout` writes the workflow's GITHUB_TOKEN
+# into `.git/config` as an auth header. Any later step in the same job — a
+# compromised dependency, an injected script, a supply-chain payload — can then
+# read that token and act as it. The `security` job only reads the checked-out
+# code and runs cargo-audit / dependency-review; it never pushes back and never
+# fetches a private submodule, so the persisted credential is pure blast radius.
+# Setting `persist-credentials: false` keeps the token off disk.
+#
+# Rule enforced: for the target workflow, every checkout step must either
+#   1. declare `persist-credentials: false` in its `with:` block, or
+#   2. carry an inline `# best-practice-ignore: BP-PERSIST-CREDS ...` comment
+#      documenting why the credential is genuinely required.
+#
+# The script takes an optional `--workflow PATH` argument so BATS tests can
+# exercise it against fixtures. With no argument it validates
+# `.github/workflows/security.yml` relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-persist-credentials.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the workflow YAML file (default:
+                    .github/workflows/security.yml relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when every actions/checkout step disables credential persistence (or
+carries a documented best-practice-ignore). Exits non-zero with a descriptive
+message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --workflow" >&2
+        usage >&2
+        exit 2
+      fi
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/security.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+EXIT_CODE=0
+fail() {
+  echo "FAIL $WORKFLOW: $*" >&2
+  EXIT_CODE=1
+}
+ok() {
+  echo "OK   $WORKFLOW: $*"
+}
+
+# Emit one report line per checkout step found:
+#   STEP\t<line>\t<persist_ok|persist_missing|ignored>
+# A minimal indentation-aware scanner walks the YAML rather than pulling in a
+# YAML parser — the same approach as check-ci-permissions.sh.
+report="$(
+  python3 - "$WORKFLOW" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+def indent_of(line):
+    return len(line) - len(line.lstrip(" "))
+
+def is_blank_or_comment(line):
+    s = line.strip()
+    return (not s) or s.startswith("#")
+
+CHECKOUT = re.compile(r"uses:\s*actions/checkout(@|\s|$)")
+IGNORE = re.compile(r"#\s*best-practice-ignore:\s*BP-PERSIST-CREDS")
+
+for i, line in enumerate(lines):
+    if not CHECKOUT.search(line):
+        continue
+
+    step_indent = indent_of(line)
+
+    # A documented ignore may sit on the `uses:` line itself or on a comment
+    # line immediately above it (skipping intervening blank lines).
+    ignored = bool(IGNORE.search(line))
+    if not ignored:
+        j = i - 1
+        while j >= 0 and lines[j].strip() == "":
+            j -= 1
+        if j >= 0 and IGNORE.search(lines[j]):
+            ignored = True
+
+    # Scan the rest of this step for the persist flag. Sibling step keys
+    # (`with:`, `env:`) align with the `uses:` key at step_indent; the flag
+    # itself is a child of `with:` at step_indent+2. Stop at the first line
+    # dedented below step_indent — that is the next step or the steps-list end.
+    persist_ok = False
+    k = i + 1
+    while k < len(lines):
+        cur = lines[k]
+        if is_blank_or_comment(cur):
+            k += 1
+            continue
+        if indent_of(cur) < step_indent:
+            break
+        if re.search(r"persist-credentials:\s*false\b", cur):
+            persist_ok = True
+            break
+        k += 1
+
+    if persist_ok:
+        state = "persist_ok"
+    elif ignored:
+        state = "ignored"
+    else:
+        state = "persist_missing"
+    print(f"STEP\t{i + 1}\t{state}")
+PY
+)"
+
+checkout_count="$(grep -c $'^STEP\t' <<<"$report" || true)"
+if [[ "$checkout_count" -eq 0 ]]; then
+  fail "no 'actions/checkout' step found — expected at least one to validate"
+  exit "$EXIT_CODE"
+fi
+
+while IFS=$'\t' read -r tag lineno state; do
+  [[ "$tag" == "STEP" ]] || continue
+  case "$state" in
+    persist_ok)
+      ok "checkout at line $lineno sets persist-credentials: false"
+      ;;
+    ignored)
+      ok "checkout at line $lineno carries a documented BP-PERSIST-CREDS ignore"
+      ;;
+    *)
+      fail "checkout at line $lineno must set 'persist-credentials: false' (or document a BP-PERSIST-CREDS ignore) so the GITHUB_TOKEN is not written to .git/config"
+      ;;
+  esac
+done <<<"$report"
+
+exit "$EXIT_CODE"

--- a/tests/scripts/persist_credentials.bats
+++ b/tests/scripts/persist_credentials.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-persist-credentials.sh — Issue #388.
+#
+# Exercises the credential-persistence validator end-to-end with synthetic
+# workflow YAML in temporary directories, plus one assertion against the real
+# repo security.yml so the enforced rule and the shipped workflow cannot drift
+# apart.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-persist-credentials.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF_DIR="$(mktemp -d)"
+  TMP_WF="$TMP_WF_DIR/security.yml"
+  export TMP_WF_DIR TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF_DIR"
+}
+
+# Canonical fixture: two checkout steps, both disabling credential persistence.
+write_good_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Security
+on: [workflow_call]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@abc123  # v5
+        with:
+          persist-credentials: false
+
+      - name: Checkout sibling
+        uses: actions/checkout@abc123  # v5
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          path: NEAT-AI-core
+          persist-credentials: false
+
+      - name: Run audit
+        run: cargo audit
+EOF
+}
+
+@test "passes when every checkout disables credential persistence" {
+  write_good_workflow "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 2 ]
+}
+
+@test "fails when a checkout omits persist-credentials: false" {
+  cat >"$TMP_WF" <<'EOF'
+name: Security
+on: [workflow_call]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@abc123  # v5
+
+      - name: Run audit
+        run: cargo audit
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must set 'persist-credentials: false'"* ]]
+}
+
+@test "fails when only one of two checkouts disables persistence" {
+  cat >"$TMP_WF" <<'EOF'
+name: Security
+on: [workflow_call]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@abc123  # v5
+        with:
+          persist-credentials: false
+
+      - name: Checkout sibling
+        uses: actions/checkout@abc123  # v5
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          path: NEAT-AI-core
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 1 ]
+  [[ "$output" == *"must set 'persist-credentials: false'"* ]]
+}
+
+@test "passes when a checkout carries a documented BP-PERSIST-CREDS ignore" {
+  cat >"$TMP_WF" <<'EOF'
+name: Security
+on: [workflow_call]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        # best-practice-ignore: BP-PERSIST-CREDS — pushes tags back to the repo
+        uses: actions/checkout@abc123  # v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"documented BP-PERSIST-CREDS ignore"* ]]
+}
+
+@test "fails when the workflow has no checkout step to validate" {
+  cat >"$TMP_WF" <<'EOF'
+name: Security
+on: [workflow_call]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run audit
+        run: cargo audit
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'actions/checkout' step found"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository security.yml disables credential persistence everywhere" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Disable checkout credential persistence in `security.yml` (Issue #388)

## Summary

The `security` reusable workflow ran both `actions/checkout` steps with the
default `persist-credentials: true`, writing the workflow's `GITHUB_TOKEN` into
`.git/config` as an auth header. Any later step in the job — a compromised
dependency, an injected script — could read that token and act as it. The job
only reads the checked-out code and runs `cargo audit` / dependency-review; it
never pushes back and never fetches a private submodule, so the persisted
credential was pure blast radius.

This PR adds `persist-credentials: false` to both checkout steps, plus a
`quality.sh`-wired guard so the property cannot silently regress. Closes #388.

## Changes

- `.github/workflows/security.yml` — `persist-credentials: false` on both the
  main checkout and the NEAT-AI-core sibling checkout.
- `scripts/check-persist-credentials.sh` — new indentation-aware YAML scanner
  (same house style as `check-ci-permissions.sh`) that fails when any
  `actions/checkout` step in the target workflow omits `persist-credentials:
  false`. A documented `# best-practice-ignore: BP-PERSIST-CREDS — <reason>`
  comment above the `uses:` line is honoured as an explicit exception.
- `quality.sh` — runs the new check alongside the other workflow-hygiene gates.
- `README.md` — new "Checkout credential persistence" subsection documenting the
  rule and its escape hatch.

```mermaid
flowchart LR
    A[checkout default] -->|token written to .git/config| B[later step reads it]
    B --> C[acts as GITHUB_TOKEN]
    D[persist-credentials: false] -->|token off disk| E[later step has nothing to steal]
```

## Evidence

Backend/CI change — no web interface to screenshot. Verification is the new
check script plus its BATS suite.

`scripts/check-persist-credentials.sh` against the fixed workflow:

```
OK   .../security.yml: checkout at line 23 sets persist-credentials: false
OK   .../security.yml: checkout at line 38 sets persist-credentials: false
```

`shellcheck` (clean) and `actionlint .github/workflows/security.yml` (clean)
both pass.

## Test Plan

- Added `tests/scripts/persist_credentials.bats` (8 tests):
  - passes when every checkout disables persistence;
  - fails when a checkout omits `persist-credentials: false` (reproduces the
    pre-fix state);
  - fails when only one of two checkouts disables it;
  - honours a documented `BP-PERSIST-CREDS` ignore;
  - fails when no checkout step is present;
  - errors on a missing workflow file / unknown flag;
  - asserts the real repo `security.yml` passes the rule.
- All new BATS tests pass; `shellcheck` and `actionlint` are clean.

### Note on the local quality gate

`./quality.sh` reports one unrelated failure —
`tests/scripts/cargo_metadata.bats::cargo metadata exposes the repository
field` — because this local checkout has no sibling `NEAT-AI-core` clone at
`../../NEAT-AI-core/neat-core`, so `cargo metadata` cannot resolve the
`neat-core` path dependency. It is environmental (CI checks the sibling out, as
this very workflow does) and cannot be affected by a workflow-YAML / shell /
docs change. Every workflow-hygiene check and the new suite pass.
