### PR TITLE
Disable credential persistence in semgrep.yml checkout (Issue #389)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -52,6 +52,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # No step in this job pushes back or fetches a private submodule, so
+          # the GITHUB_TOKEN need not be written to .git/config (Issue #389).
+          persist-credentials: false
 
       - name: Run Semgrep
         run: semgrep ci --config p/default

--- a/docs/archive/pr-summaries/pr-summary-389.md
+++ b/docs/archive/pr-summaries/pr-summary-389.md
@@ -1,0 +1,49 @@
+# Harden `semgrep.yml` checkout — disable credential persistence
+
+## Summary
+
+Job `semgrep` in `.github/workflows/semgrep.yml` ran `actions/checkout` without
+`persist-credentials: false`, so the workflow's `GITHUB_TOKEN` was written into
+`.git/config` where any later step in the job could read it. The job only reads
+the checked-out code to run Semgrep — it never pushes back and never fetches a
+private submodule — so the persisted credential was pure blast radius.
+
+The fix adds `persist-credentials: false` to the checkout step, matching the
+existing convention already used in `security.yml`. To stop this regressing, the
+per-repo gate `scripts/check-persist-credentials.sh` (previously guarding only
+`security.yml`) now validates `semgrep.yml` too, with a regression test.
+
+Closes #389.
+
+## Change flow
+
+```mermaid
+flowchart LR
+    A["checkout in semgrep.yml"] -->|before| B["GITHUB_TOKEN written to .git/config"]
+    A -->|after: persist-credentials: false| C["token kept off disk"]
+    D["check-persist-credentials.sh"] -->|now guards| A
+    D -->|already guarded| E["security.yml"]
+```
+
+## Evidence
+
+Backend/CI change only — no web interface to screenshot. Verified via the guard
+script and BATS suite:
+
+- `scripts/check-persist-credentials.sh` (default run) reports `OK` for every
+  checkout in both `security.yml` and `semgrep.yml`.
+- Regression check: stripping `persist-credentials: false` from a copy of
+  `semgrep.yml` makes the guard exit non-zero with the
+  `must set 'persist-credentials: false'` message.
+- `shellcheck` and `actionlint` both pass on the changed files.
+
+## Test Plan
+
+- Extended `tests/scripts/persist_credentials.bats`:
+  - `real repository semgrep.yml disables credential persistence (Issue #389)`
+    — asserts the shipped `semgrep.yml` passes the guard.
+  - `default run validates every guarded workflow (security.yml and semgrep.yml)`
+    — asserts the no-argument run covers both workflows.
+  - Pinned the existing `security.yml` test to an explicit `--workflow` path so
+    single-file behaviour stays covered alongside the new default-set run.
+- All 10 BATS cases pass.

--- a/quality.sh
+++ b/quality.sh
@@ -99,7 +99,7 @@ echo "🔢 Validating workflow action versions for Node 24 compat (Issue #24)...
 echo "🔑 Validating CI least-privilege token scope (Issue #155)..."
 ./scripts/check-ci-permissions.sh
 
-echo "🔐 Validating security.yml checkouts disable credential persistence (Issue #388)..."
+echo "🔐 Validating guarded workflow checkouts disable credential persistence (Issues #388, #389)..."
 ./scripts/check-persist-credentials.sh
 
 echo "⏱️  Validating per-job timeout-minutes across workflows (Issue #154)..."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.20"
+version = "1.1.21"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-persist-credentials.sh
+++ b/scripts/check-persist-credentials.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Validate that every `actions/checkout` step in the reusable security workflow
-# disables credential persistence (Issue #388).
+# Validate that every `actions/checkout` step in the guarded workflows
+# disables credential persistence (Issues #388, #389).
 #
 # Background: by default `actions/checkout` writes the workflow's GITHUB_TOKEN
 # into `.git/config` as an auth header. Any later step in the same job — a
@@ -16,8 +16,8 @@
 #      documenting why the credential is genuinely required.
 #
 # The script takes an optional `--workflow PATH` argument so BATS tests can
-# exercise it against fixtures. With no argument it validates
-# `.github/workflows/security.yml` relative to the repo root.
+# exercise it against fixtures. With no argument it validates every guarded
+# workflow (`security.yml`, `semgrep.yml`) relative to the repo root.
 set -euo pipefail
 
 usage() {
@@ -25,8 +25,9 @@ usage() {
 Usage: check-persist-credentials.sh [--workflow PATH]
 
 Options:
-  --workflow PATH   Path to the workflow YAML file (default:
-                    .github/workflows/security.yml relative to the repo root).
+  --workflow PATH   Path to a single workflow YAML file to validate. When
+                    omitted, every guarded workflow under
+                    .github/workflows/ (security.yml, semgrep.yml) is checked.
   -h, --help        Show this message.
 
 Exits 0 when every actions/checkout step disables credential persistence (or
@@ -59,24 +60,37 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$WORKFLOW" ]]; then
+# Build the list of workflows to validate. An explicit --workflow overrides the
+# default set; otherwise every guarded workflow is checked in one run.
+WORKFLOWS=()
+if [[ -n "$WORKFLOW" ]]; then
+  WORKFLOWS=("$WORKFLOW")
+else
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/security.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
+  WORKFLOWS=(
+    "$SCRIPT_DIR/../.github/workflows/security.yml"
+    "$SCRIPT_DIR/../.github/workflows/semgrep.yml"
+  )
 fi
 
 EXIT_CODE=0
-fail() {
-  echo "FAIL $WORKFLOW: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $WORKFLOW: $*"
-}
+
+validate_workflow() {
+  local WORKFLOW="$1"
+
+  if [[ ! -f "$WORKFLOW" ]]; then
+    echo "Workflow file not found: $WORKFLOW" >&2
+    EXIT_CODE=2
+    return
+  fi
+
+  fail() {
+    echo "FAIL $WORKFLOW: $*" >&2
+    EXIT_CODE=1
+  }
+  ok() {
+    echo "OK   $WORKFLOW: $*"
+  }
 
 # Emit one report line per checkout step found:
 #   STEP\t<line>\t<persist_ok|persist_missing|ignored>
@@ -145,25 +159,30 @@ for i, line in enumerate(lines):
 PY
 )"
 
-checkout_count="$(grep -c $'^STEP\t' <<<"$report" || true)"
-if [[ "$checkout_count" -eq 0 ]]; then
-  fail "no 'actions/checkout' step found — expected at least one to validate"
-  exit "$EXIT_CODE"
-fi
+  checkout_count="$(grep -c $'^STEP\t' <<<"$report" || true)"
+  if [[ "$checkout_count" -eq 0 ]]; then
+    fail "no 'actions/checkout' step found — expected at least one to validate"
+    return
+  fi
 
-while IFS=$'\t' read -r tag lineno state; do
-  [[ "$tag" == "STEP" ]] || continue
-  case "$state" in
-    persist_ok)
-      ok "checkout at line $lineno sets persist-credentials: false"
-      ;;
-    ignored)
-      ok "checkout at line $lineno carries a documented BP-PERSIST-CREDS ignore"
-      ;;
-    *)
-      fail "checkout at line $lineno must set 'persist-credentials: false' (or document a BP-PERSIST-CREDS ignore) so the GITHUB_TOKEN is not written to .git/config"
-      ;;
-  esac
-done <<<"$report"
+  while IFS=$'\t' read -r tag lineno state; do
+    [[ "$tag" == "STEP" ]] || continue
+    case "$state" in
+      persist_ok)
+        ok "checkout at line $lineno sets persist-credentials: false"
+        ;;
+      ignored)
+        ok "checkout at line $lineno carries a documented BP-PERSIST-CREDS ignore"
+        ;;
+      *)
+        fail "checkout at line $lineno must set 'persist-credentials: false' (or document a BP-PERSIST-CREDS ignore) so the GITHUB_TOKEN is not written to .git/config"
+        ;;
+    esac
+  done <<<"$report"
+}
+
+for wf in "${WORKFLOWS[@]}"; do
+  validate_workflow "$wf"
+done
 
 exit "$EXIT_CODE"

--- a/tests/scripts/persist_credentials.bats
+++ b/tests/scripts/persist_credentials.bats
@@ -148,7 +148,21 @@ EOF
 }
 
 @test "real repository security.yml disables credential persistence everywhere" {
+  run "$SCRIPT_UNDER_TEST" --workflow "${BATS_TEST_DIRNAME}/../../.github/workflows/security.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "real repository semgrep.yml disables credential persistence (Issue #389)" {
+  run "$SCRIPT_UNDER_TEST" --workflow "${BATS_TEST_DIRNAME}/../../.github/workflows/semgrep.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "default run validates every guarded workflow (security.yml and semgrep.yml)" {
   run "$SCRIPT_UNDER_TEST"
   [ "$status" -eq 0 ]
   [[ "$output" != *"FAIL"* ]]
+  [[ "$output" == *"security.yml"* ]]
+  [[ "$output" == *"semgrep.yml"* ]]
 }


### PR DESCRIPTION
# Harden `semgrep.yml` checkout — disable credential persistence

## Summary

Job `semgrep` in `.github/workflows/semgrep.yml` ran `actions/checkout` without
`persist-credentials: false`, so the workflow's `GITHUB_TOKEN` was written into
`.git/config` where any later step in the job could read it. The job only reads
the checked-out code to run Semgrep — it never pushes back and never fetches a
private submodule — so the persisted credential was pure blast radius.

The fix adds `persist-credentials: false` to the checkout step, matching the
existing convention already used in `security.yml`. To stop this regressing, the
per-repo gate `scripts/check-persist-credentials.sh` (previously guarding only
`security.yml`) now validates `semgrep.yml` too, with a regression test.

Closes #389.

## Change flow

```mermaid
flowchart LR
    A["checkout in semgrep.yml"] -->|before| B["GITHUB_TOKEN written to .git/config"]
    A -->|after: persist-credentials: false| C["token kept off disk"]
    D["check-persist-credentials.sh"] -->|now guards| A
    D -->|already guarded| E["security.yml"]
```

## Evidence

Backend/CI change only — no web interface to screenshot. Verified via the guard
script and BATS suite:

- `scripts/check-persist-credentials.sh` (default run) reports `OK` for every
  checkout in both `security.yml` and `semgrep.yml`.
- Regression check: stripping `persist-credentials: false` from a copy of
  `semgrep.yml` makes the guard exit non-zero with the
  `must set 'persist-credentials: false'` message.
- `shellcheck` and `actionlint` both pass on the changed files.

## Test Plan

- Extended `tests/scripts/persist_credentials.bats`:
  - `real repository semgrep.yml disables credential persistence (Issue #389)`
    — asserts the shipped `semgrep.yml` passes the guard.
  - `default run validates every guarded workflow (security.yml and semgrep.yml)`
    — asserts the no-argument run covers both workflows.
  - Pinned the existing `security.yml` test to an explicit `--workflow` path so
    single-file behaviour stays covered alongside the new default-set run.
- All 10 BATS cases pass.



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrvdumj1-9475c3`<!-- vibe-worker-issue-389 -->