### PR TITLE
Run cargo-audit gate on milestone/* PRs (Issue #391)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -12,7 +12,10 @@ name: Cargo Audit
 # Triggers:
 #   * pull_request   — belt-and-braces alongside security.yml; cargo-audit
 #                      is fast (seconds) so the duplication is negligible
-#                      and keeps the standalone workflow self-contained.
+#                      and keeps the standalone workflow self-contained. The
+#                      filter includes `milestone/**` so the gate also runs on
+#                      milestone/<slug> sub-issue PRs — a bare "*" glob does
+#                      not match refs containing a slash (Issue #391).
 #   * schedule       — Mondays 06:00 UTC; catches new advisories weekly.
 #   * workflow_dispatch — manual trigger for ad-hoc audits.
 #
@@ -22,7 +25,7 @@ name: Cargo Audit
 
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["*", "milestone/**"]
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:

--- a/docs/archive/pr-summaries/pr-summary-391.md
+++ b/docs/archive/pr-summaries/pr-summary-391.md
@@ -1,0 +1,59 @@
+# PR Summary — Issue #391
+
+## Summary
+
+The standalone Cargo Audit CI workflow (`.github/workflows/cargo-audit.yml`)
+guarded its `pull_request` trigger with a bare `branches: ["*"]` glob. In GitHub
+Actions branch filters `*` matches any character **except** `/`, so it never
+matched milestone sub-issue branches named `milestone/<slug>`. Those PRs merged
+into the shared milestone branch without the cargo-audit gate ever running — the
+gap only surfaced later at the single rollup PR into the default branch.
+
+Added `milestone/**` to the filter so the gate runs on milestone PRs too,
+mirroring the earlier actionlint fix (Issue #390). The workflow validator
+`scripts/check-cargo-audit-workflow.sh` now enforces the milestone coverage as a
+new rule, and a BATS regression test locks the behaviour in. Closes #391.
+
+```mermaid
+flowchart LR
+    A[Milestone sub-issue PR<br/>base: milestone/slug] -->|before: "*" skips slashes| B[cargo-audit SKIPPED]
+    A -->|after: "*", "milestone/**"| C[cargo-audit RUNS ✅]
+```
+
+## Evidence
+
+Backend/CI change only — no web interface to screenshot. Verified via the
+workflow validator and its BATS suite.
+
+Validator against the real workflow (7/7 rules pass, including the new one):
+
+```
+OK   .../cargo-audit.yml: pull_request branch filter covers milestone/* branches
+```
+
+BATS suite (`tests/scripts/cargo_audit_workflow.bats`) — all 12 tests pass,
+including the new milestone regression test:
+
+```
+ok 1 passes on the canonical fixture
+ok 9 fails when the pull_request branch filter omits milestone branches
+...
+ok 12 real repository cargo-audit workflow satisfies every rule
+```
+
+`./quality.sh` passes cleanly (shellcheck, cargo-deny, fmt, clippy, check,
+build, test, doc, release build).
+
+## Test Plan
+
+- Updated `tests/scripts/cargo_audit_workflow.bats`:
+  - Canonical + rustsec fixtures now use `branches: ["*", "milestone/**"]`.
+  - `passes on the canonical fixture` asserts 7 `OK` rules (was 6).
+  - Added `fails when the pull_request branch filter omits milestone branches`,
+    which reverts the fixture to the bare `"*"` filter and asserts a non-zero
+    exit mentioning `milestone` — reproduces the #391 gap and passes after the
+    fix.
+- `scripts/check-cargo-audit-workflow.sh` gained rule 7 enforcing the
+  `milestone/*` filter, so any future regression of the real workflow is caught
+  by the existing `real repository cargo-audit workflow satisfies every rule`
+  test.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.21"
+version = "1.1.22"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-cargo-audit-workflow.sh
+++ b/scripts/check-cargo-audit-workflow.sh
@@ -13,6 +13,9 @@
 #   6. Invoke cargo-audit — either directly (`cargo audit` after a
 #      `cargo install cargo-audit` step) or via the official RustSec
 #      action (`rustsec/audit-check@vN`).
+#   7. Cover milestone/<slug> branches in the pull_request filter so the gate
+#      runs on milestone sub-issue PRs, not only top-level base branches
+#      (Issue #391). A bare "*" glob does not match refs containing a slash.
 #
 # The script takes a single optional `--workflow PATH` argument so BATS tests
 # can exercise it against fixtures. When called with no argument it validates
@@ -125,6 +128,17 @@ elif grep -qE '^[[:space:]]+(- )?run:[[:space:]]*cargo audit' "$WORKFLOW" \
   ok "cargo audit invoked directly"
 else
   fail "cargo audit is not invoked — neither rustsec/audit-check nor a 'cargo audit' run step found"
+fi
+
+# 7. pull_request branch filter must include milestone branches so the gate
+#    runs on milestone/<slug> sub-issue PRs. A bare "*" glob only matches
+#    single-level refs, so milestone/<slug> would otherwise skip the gate and
+#    merge unchecked into the milestone branch (Issue #391). The token
+#    `milestone/*` also matches the wider `milestone/**` glob.
+if grep -qE 'milestone/\*' "$WORKFLOW"; then
+  ok "pull_request branch filter covers milestone/* branches"
+else
+  fail "pull_request branch filter omits milestone/* — milestone PRs skip the gate"
 fi
 
 exit "$EXIT_CODE"

--- a/tests/scripts/cargo_audit_workflow.bats
+++ b/tests/scripts/cargo_audit_workflow.bats
@@ -30,7 +30,7 @@ name: Cargo Audit
 
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["*", "milestone/**"]
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
@@ -55,7 +55,7 @@ EOF
   [ "$status" -eq 0 ]
   # Issue #360: prove every rule was individually evaluated and passed via the
   # machine-checkable "OK   " marker rather than pinning informational wording.
-  [ "$(grep -c '^OK   ' <<<"$output")" -eq 6 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {
@@ -65,7 +65,7 @@ import sys
 path = sys.argv[1]
 with open(path) as fh:
     text = fh.read()
-text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+text = text.replace("  pull_request:\n    branches: [\"*\", \"milestone/**\"]\n", "")
 with open(path, "w") as fh:
     fh.write(text)
 PY
@@ -139,7 +139,7 @@ name: Cargo Audit
 # Issue #64 — uses the official rustsec/audit-check action.
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["*", "milestone/**"]
   schedule:
     - cron: "0 6 * * 1"
 permissions:
@@ -157,6 +157,15 @@ EOF
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
   [ "$status" -eq 0 ]
   [[ "$output" == *"cargo audit invoked"* ]]
+}
+
+@test "fails when the pull_request branch filter omits milestone branches" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  # Revert to the pre-fix bare "*" filter, which does not match milestone/<slug>.
+  sed -i.bak 's|branches: \["\*", "milestone/\*\*"\]|branches: ["*"]|' "$TMP_WF/cargo-audit.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"milestone"* ]]
 }
 
 @test "reports an error when the workflow file does not exist" {


### PR DESCRIPTION
# PR Summary — Issue #391

## Summary

The standalone Cargo Audit CI workflow (`.github/workflows/cargo-audit.yml`)
guarded its `pull_request` trigger with a bare `branches: ["*"]` glob. In GitHub
Actions branch filters `*` matches any character **except** `/`, so it never
matched milestone sub-issue branches named `milestone/<slug>`. Those PRs merged
into the shared milestone branch without the cargo-audit gate ever running — the
gap only surfaced later at the single rollup PR into the default branch.

Added `milestone/**` to the filter so the gate runs on milestone PRs too,
mirroring the earlier actionlint fix (Issue #390). The workflow validator
`scripts/check-cargo-audit-workflow.sh` now enforces the milestone coverage as a
new rule, and a BATS regression test locks the behaviour in. Closes #391.

```mermaid
flowchart LR
    A[Milestone sub-issue PR<br/>base: milestone/slug] -->|before: "*" skips slashes| B[cargo-audit SKIPPED]
    A -->|after: "*", "milestone/**"| C[cargo-audit RUNS ✅]
```

## Evidence

Backend/CI change only — no web interface to screenshot. Verified via the
workflow validator and its BATS suite.

Validator against the real workflow (7/7 rules pass, including the new one):

```text
OK   .../cargo-audit.yml: pull_request branch filter covers milestone/* branches
```

BATS suite (`tests/scripts/cargo_audit_workflow.bats`) — all 12 tests pass,
including the new milestone regression test:

```text
ok 1 passes on the canonical fixture
ok 9 fails when the pull_request branch filter omits milestone branches
...
ok 12 real repository cargo-audit workflow satisfies every rule
```

`./quality.sh` passes cleanly (shellcheck, cargo-deny, fmt, clippy, check,
build, test, doc, release build).

## Test Plan

- Updated `tests/scripts/cargo_audit_workflow.bats`:
  - Canonical + rustsec fixtures now use `branches: ["*", "milestone/**"]`.
  - `passes on the canonical fixture` asserts 7 `OK` rules (was 6).
  - Added `fails when the pull_request branch filter omits milestone branches`,
    which reverts the fixture to the bare `"*"` filter and asserts a non-zero
    exit mentioning `milestone` — reproduces the #391 gap and passes after the
    fix.
- `scripts/check-cargo-audit-workflow.sh` gained rule 7 enforcing the
  `milestone/*` filter, so any future regression of the real workflow is caught
  by the existing `real repository cargo-audit workflow satisfies every rule`
  test.



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrvgn7tx-bfdcc2`<!-- vibe-worker-issue-391 -->