### PR TITLE
Fix cargo-quality branch filter to cover milestone PRs (Issue #392)

### DIFF
--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -4,9 +4,12 @@ name: Cargo Quality
 #
 # Why a dedicated workflow when ci.yml already runs fmt + clippy?
 #   * ci.yml only triggers on pushes/PRs against `Develop`. This workflow
-#     fires on PRs against ANY branch (`branches: ["*"]`), so feature
+#     fires on PRs against ANY branch (`branches: ["**"]`), so feature
 #     branches and stacked PRs targeting non-Develop bases also get fmt
-#     and clippy coverage.
+#     and clippy coverage. `**` is used rather than `*` because GitHub's
+#     `*` glob does not match across `/`, so `["*"]` would silently skip
+#     milestone/<slug> sub-issue PRs (Issue #392); `**` matches nested
+#     branch names too.
 #   * Keeps a small, fast, single-purpose gate that is cheap to re-run
 #     when iterating on style or lint fixes.
 #
@@ -20,7 +23,7 @@ name: Cargo Quality
 
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
   workflow_dispatch:
 
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.24"
+version = "1.1.21"
 dependencies = [
  "bytemuck",
  "clap",
@@ -1157,14 +1157,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1282,7 +1282,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1732,18 +1732,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -912,8 +912,8 @@ A standalone Cargo Quality workflow (`.github/workflows/cargo-quality.yml`,
 Issue #66) runs `cargo fmt --check` and `cargo clippy -- -D warnings` on
 pull requests against **any** branch (`branches: ["**"]`). `**` is used
 rather than `*` because GitHub's `*` glob does not match across `/`, so a
-`["*"]` filter would silently skip `milestone/<slug>` sub-issue PRs (Issue
-#392); `**` also matches nested branch names. `ci.yml` only fires for PRs
+`["*"]` filter would silently skip `milestone/<slug>` sub-issue PRs
+(Issue #392); `**` also matches nested branch names. `ci.yml` only fires for PRs
 targeting `Develop`, so this dedicated workflow gives feature branches and
 stacked PRs the same fmt + clippy gate without spinning up the full CI
 graph. The workflow is validated by

--- a/README.md
+++ b/README.md
@@ -910,10 +910,13 @@ covered end-to-end by `tests/scripts/prebuilt_tool_install.bats`.
 
 A standalone Cargo Quality workflow (`.github/workflows/cargo-quality.yml`,
 Issue #66) runs `cargo fmt --check` and `cargo clippy -- -D warnings` on
-pull requests against **any** branch (`branches: ["*"]`). `ci.yml` only
-fires for PRs targeting `Develop`, so this dedicated workflow gives feature
-branches and stacked PRs the same fmt + clippy gate without spinning up the
-full CI graph. The workflow is validated by
+pull requests against **any** branch (`branches: ["**"]`). `**` is used
+rather than `*` because GitHub's `*` glob does not match across `/`, so a
+`["*"]` filter would silently skip `milestone/<slug>` sub-issue PRs (Issue
+#392); `**` also matches nested branch names. `ci.yml` only fires for PRs
+targeting `Develop`, so this dedicated workflow gives feature branches and
+stacked PRs the same fmt + clippy gate without spinning up the full CI
+graph. The workflow is validated by
 `scripts/check-cargo-quality-workflow.sh` (invoked from `quality.sh`) and
 covered end-to-end by `tests/scripts/cargo_quality_workflow.bats`.
 

--- a/docs/archive/pr-summaries/pr-summary-392.md
+++ b/docs/archive/pr-summaries/pr-summary-392.md
@@ -1,0 +1,61 @@
+# Fix cargo-quality branch filter to cover milestone PRs
+
+## Summary
+
+The standalone Cargo Quality workflow (`.github/workflows/cargo-quality.yml`)
+used `pull_request.branches: ["*"]`, which its own comment described as firing
+on PRs against "ANY branch". That is not what `*` does: GitHub's `*` glob does
+**not** match across `/`, so `["*"]` matches `Develop` and `main` but **not**
+`milestone/<slug>` branches. Milestone sub-issue PRs target a shared
+`milestone/<name>` branch, so the fmt + clippy gate silently never ran on them —
+every intermediate sub-issue PR merged into the milestone branch unchecked, and
+the gap only surfaced at the single rollup PR into the default branch.
+
+The fix switches the filter to `["**"]`, which matches any branch including
+nested-slash `milestone/<slug>` and stacked-PR branches, realising the
+workflow's documented "ANY branch" intent. The issue's suggested
+`[Develop, main, milestone/*]` also works, but `**` is the minimal,
+intent-preserving change and additionally covers other nested branch names.
+
+A new rule (rule 7) was added to `scripts/check-cargo-quality-workflow.sh` so
+the gate now rejects any `pull_request.branches` filter that cannot match
+`milestone/<slug>` (i.e. requires `**` or an explicit `milestone/` glob) —
+preventing a regression back to a `/`-blind `*`. The README prose was updated to
+match.
+
+Closes #392.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified via the repo's own
+workflow-validation gate and BATS suite.
+
+- `./scripts/check-cargo-quality-workflow.sh` now reports 8 `OK` rules
+  (including the new milestone-coverage rule) against the fixed workflow.
+- Full BATS suite passes (327 tests), including the two new cases below.
+
+```mermaid
+flowchart LR
+    subgraph Before["branches: [\"*\"] — * does not cross /"]
+        P1[PR into Develop] --> G1[gate runs]
+        P2[PR into milestone/foo] -. skipped .-> X[no gate]
+    end
+    subgraph After["branches: [\"**\"] — ** matches any branch"]
+        P3[PR into Develop] --> G2[gate runs]
+        P4[PR into milestone/foo] --> G3[gate runs]
+    end
+```
+
+## Test Plan
+
+- Added `tests/scripts/cargo_quality_workflow.bats::"fails when the branch filter
+  skips milestone/<slug> PRs (Issue #392)"` — mutates the fixture back to
+  `["*"]` and asserts the gate exits non-zero (reproduces the bug against the
+  unfixed filter).
+- Added `tests/scripts/cargo_quality_workflow.bats::"passes when the branch
+  filter uses an explicit milestone/* glob"` — confirms
+  `[Develop, main, milestone/*]` is accepted.
+- Updated the canonical fixture to `["**"]` and the `OK`-marker count assertion
+  from 7 to 8 to cover the new rule; kept every existing failure case.
+- `real repository cargo-quality workflow satisfies every rule` passes against
+  the fixed `.github/workflows/cargo-quality.yml`.

--- a/scripts/check-cargo-quality-workflow.sh
+++ b/scripts/check-cargo-quality-workflow.sh
@@ -9,6 +9,10 @@
 #      `rustfmt` and `clippy` components.
 #   5. Invoke `cargo fmt --check` (any flag form) so unformatted code fails CI.
 #   6. Invoke `cargo clippy` with `-D warnings` so lints fail CI.
+#   7. Use a pull_request `branches:` filter that matches milestone/<slug>
+#      branches (Issue #392). GitHub's `*` glob does NOT cross `/`, so `["*"]`
+#      silently skips milestone sub-issue PRs; require `**` or an explicit
+#      `milestone/` glob so the gate runs on them.
 #
 # The script takes a single optional `--workflow PATH` argument so BATS tests
 # can exercise it against fixtures. When called with no argument it validates
@@ -121,6 +125,19 @@ if grep -qE 'cargo[[:space:]]+clippy' "$WORKFLOW" \
   ok "cargo clippy invoked with -D warnings"
 else
   fail "cargo clippy must be invoked with '-D warnings' so lints fail CI"
+fi
+
+# 7. pull_request branch filter matches milestone/<slug> branches (Issue #392).
+#    GitHub's `*` glob does not match across `/`, so a `["*"]` filter skips
+#    milestone/<slug> PRs and the gate never runs on milestone sub-issue PRs.
+#    Require `**` (matches any branch) or an explicit `milestone/` glob.
+branches_filter="$(grep -E '^[[:space:]]*branches:' "$WORKFLOW" || true)"
+if [[ -z "$branches_filter" ]]; then
+  fail "no pull_request 'branches:' filter found — cannot verify milestone coverage"
+elif echo "$branches_filter" | grep -qE '\*\*|milestone/'; then
+  ok "pull_request branch filter matches milestone/<slug> branches"
+else
+  fail "pull_request branch filter does not match milestone/<slug> — '*' does not cross '/'; use '**' or add 'milestone/*'"
 fi
 
 exit "$EXIT_CODE"

--- a/tests/scripts/cargo_quality_workflow.bats
+++ b/tests/scripts/cargo_quality_workflow.bats
@@ -26,7 +26,7 @@ name: Cargo Quality
 
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 permissions:
   contents: read
@@ -50,7 +50,7 @@ EOF
   [ "$status" -eq 0 ]
   # Issue #360: prove every rule was individually evaluated and passed via the
   # machine-checkable "OK   " marker rather than pinning informational wording.
-  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 8 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {
@@ -60,7 +60,7 @@ import sys
 path = sys.argv[1]
 with open(path) as fh:
     text = fh.read()
-text = text.replace("  pull_request:\n    branches: [\"*\"]\n", "")
+text = text.replace("  pull_request:\n    branches: [\"**\"]\n", "")
 with open(path, "w") as fh:
     fh.write(text)
 PY
@@ -127,6 +127,25 @@ PY
   [ "$status" -ne 0 ]
   [[ "$output" == *"cargo clippy"* ]]
   [[ "$output" == *"-D warnings"* ]]
+}
+
+@test "fails when the branch filter skips milestone/<slug> PRs (Issue #392)" {
+  # A `["*"]` filter looks like "any branch" but GitHub's `*` glob does not
+  # cross `/`, so milestone/<slug> PRs are silently skipped. The gate must
+  # reject it.
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak 's|branches: \["\*\*"\]|branches: ["*"]|' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not match milestone/<slug>"* ]]
+}
+
+@test "passes when the branch filter uses an explicit milestone/* glob" {
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak 's|branches: \["\*\*"\]|branches: [Develop, main, milestone/*]|' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"matches milestone/<slug>"* ]]
 }
 
 @test "reports an error when the workflow file does not exist" {


### PR DESCRIPTION
# Fix cargo-quality branch filter to cover milestone PRs

## Summary

The standalone Cargo Quality workflow (`.github/workflows/cargo-quality.yml`)
used `pull_request.branches: ["*"]`, which its own comment described as firing
on PRs against "ANY branch". That is not what `*` does: GitHub's `*` glob does
**not** match across `/`, so `["*"]` matches `Develop` and `main` but **not**
`milestone/<slug>` branches. Milestone sub-issue PRs target a shared
`milestone/<name>` branch, so the fmt + clippy gate silently never ran on them —
every intermediate sub-issue PR merged into the milestone branch unchecked, and
the gap only surfaced at the single rollup PR into the default branch.

The fix switches the filter to `["**"]`, which matches any branch including
nested-slash `milestone/<slug>` and stacked-PR branches, realising the
workflow's documented "ANY branch" intent. The issue's suggested
`[Develop, main, milestone/*]` also works, but `**` is the minimal,
intent-preserving change and additionally covers other nested branch names.

A new rule (rule 7) was added to `scripts/check-cargo-quality-workflow.sh` so
the gate now rejects any `pull_request.branches` filter that cannot match
`milestone/<slug>` (i.e. requires `**` or an explicit `milestone/` glob) —
preventing a regression back to a `/`-blind `*`. The README prose was updated to
match.

Closes #392.

## Evidence

Backend/CI change — no web interface to screenshot. Verified via the repo's own
workflow-validation gate and BATS suite.

- `./scripts/check-cargo-quality-workflow.sh` now reports 8 `OK` rules
  (including the new milestone-coverage rule) against the fixed workflow.
- Full BATS suite passes (327 tests), including the two new cases below.

```mermaid
flowchart LR
    subgraph Before["branches: [\"*\"] — * does not cross /"]
        P1[PR into Develop] --> G1[gate runs]
        P2[PR into milestone/foo] -. skipped .-> X[no gate]
    end
    subgraph After["branches: [\"**\"] — ** matches any branch"]
        P3[PR into Develop] --> G2[gate runs]
        P4[PR into milestone/foo] --> G3[gate runs]
    end
```

## Test Plan

- Added `tests/scripts/cargo_quality_workflow.bats::"fails when the branch filter
  skips milestone/<slug> PRs (Issue #392)"` — mutates the fixture back to
  `["*"]` and asserts the gate exits non-zero (reproduces the bug against the
  unfixed filter).
- Added `tests/scripts/cargo_quality_workflow.bats::"passes when the branch
  filter uses an explicit milestone/* glob"` — confirms
  `[Develop, main, milestone/*]` is accepted.
- Updated the canonical fixture to `["**"]` and the `OK`-marker count assertion
  from 7 to 8 to cover the new rule; kept every existing failure case.
- `real repository cargo-quality workflow satisfies every rule` passes against
  the fixed `.github/workflows/cargo-quality.yml`.



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrvgn7tx-bfdcc2`<!-- vibe-worker-issue-392 -->