### PR TITLE
Gate milestone PRs in CI quality workflow (Issue #393)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - Develop
+      # Milestone sub-issue PRs target a shared `milestone/<slug>` branch
+      # (planning delivery workflow). Gate them here so each intermediate PR is
+      # checked, not just the single rollup PR into Develop (Issue #393).
+      - milestone/*
   workflow_dispatch:
 
 # Least-privilege default token scope (Issue #155). Without this block every

--- a/README.md
+++ b/README.md
@@ -913,10 +913,15 @@ Issue #66) runs `cargo fmt --check` and `cargo clippy -- -D warnings` on
 pull requests against **any** branch (`branches: ["**"]`). `**` is used
 rather than `*` because GitHub's `*` glob does not match across `/`, so a
 `["*"]` filter would silently skip `milestone/<slug>` sub-issue PRs
-(Issue #392); `**` also matches nested branch names. `ci.yml` only fires for PRs
-targeting `Develop`, so this dedicated workflow gives feature branches and
-stacked PRs the same fmt + clippy gate without spinning up the full CI
-graph. The workflow is validated by
+(Issue #392); `**` also matches nested branch names. `ci.yml` fires for PRs
+targeting `Develop` and `milestone/*` (Issue #393) — milestone branch names are
+`milestone/<slug>` with no nested slashes, so the single-level `milestone/*`
+glob gates every sub-issue PR rather than only the rollup PR into `Develop`.
+This dedicated workflow still gives other feature branches and stacked PRs the
+same fmt + clippy gate without spinning up the full CI graph. The milestone
+filter on `ci.yml` is validated by
+`scripts/check-milestone-branch-filter.sh` (invoked from `quality.sh`) and
+covered end-to-end by `tests/scripts/milestone_branch_filter.bats`. The workflow is validated by
 `scripts/check-cargo-quality-workflow.sh` (invoked from `quality.sh`) and
 covered end-to-end by `tests/scripts/cargo_quality_workflow.bats`.
 

--- a/docs/archive/pr-summaries/pr-summary-393.md
+++ b/docs/archive/pr-summaries/pr-summary-393.md
@@ -1,0 +1,73 @@
+# CI quality workflow now gates milestone PRs
+
+## Summary
+
+The CI quality workflow (`.github/workflows/ci.yml`) only fired on pull requests
+targeting `Develop`, so its `pull_request.branches` filter matched none of the
+`milestone/<slug>` feature branches. Milestone sub-issue PRs target a shared
+`milestone/<slug>` branch, so the gate never ran on them and they merged into
+the milestone branch unchecked — the gap surfaced only later at the single
+rollup PR into the default branch.
+
+This adds `milestone/*` to the workflow's `pull_request.branches` filter so the
+gate runs on every intermediate sub-issue PR too. Milestone branch names are
+`milestone/<slug>` with no nested slashes, so the single-level `milestone/*`
+glob is sufficient.
+
+A purpose-built validator (`scripts/check-milestone-branch-filter.sh`, invoked
+from `quality.sh`) fails loudly unless the filter includes the `milestone/*`
+glob, and `tests/scripts/milestone_branch_filter.bats` covers it end-to-end so
+the gate cannot silently regress.
+
+Closes #393.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified via the validator
+and its bats suite.
+
+```mermaid
+flowchart LR
+    subgraph before["Before"]
+        a1[milestone sub-issue PR] -->|filter matches only Develop| a2[merged UNCHECKED]
+    end
+    subgraph after["After (milestone/* added)"]
+        b1[milestone sub-issue PR] -->|filter matches milestone/*| b2[CI gate runs] --> b3[merged only if green]
+    end
+```
+
+Validator against the fixed workflow:
+
+```
+$ ./scripts/check-milestone-branch-filter.sh
+OK   .github/workflows/ci.yml: pull_request.branches includes 'milestone/*' — milestone PRs are gated
+```
+
+New bats suite (all pass):
+
+```
+1..7
+ok 1 passes when pull_request.branches includes milestone/*
+ok 2 fails when the milestone/* glob is absent
+ok 3 fails when there is no pull_request.branches filter at all
+ok 4 accepts the inline list form of branches
+ok 5 reports an error when the workflow file does not exist
+ok 6 unknown flag prints usage and exits non-zero
+ok 7 the repository CI workflow gates milestone PRs
+```
+
+Full existing bats suite continues to pass (344 tests, 0 failures);
+`shellcheck --severity=warning` and `codespell` are clean.
+
+## Test Plan
+
+- Added `scripts/check-milestone-branch-filter.sh` — parses
+  `on.pull_request.branches` from `ci.yml` and fails unless `milestone/*` is
+  present (both inline and block list forms).
+- Added `tests/scripts/milestone_branch_filter.bats` — 7 cases covering the
+  happy path, the absent-glob regression (fails against the pre-fix workflow),
+  a missing branches filter, the inline list form, a missing file, an unknown
+  flag, and the real repository `ci.yml`.
+- Wired the validator into `quality.sh` alongside the other workflow checks.
+- Updated `README.md` to reflect that `ci.yml` now also gates `milestone/*`
+  PRs, with a pointer to the validator and its bats suite.

--- a/quality.sh
+++ b/quality.sh
@@ -93,6 +93,9 @@ echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 echo "🧭 Validating CI job dependency graph (Issue #23)..."
 ./scripts/check-ci-job-graph.sh
 
+echo "🎯 Validating CI gates milestone PRs (Issue #393)..."
+./scripts/check-milestone-branch-filter.sh
+
 echo "🔢 Validating workflow action versions for Node 24 compat (Issue #24)..."
 ./scripts/check-workflow-action-versions.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.22"
+version = "1.1.23"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-milestone-branch-filter.sh
+++ b/scripts/check-milestone-branch-filter.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Validate that the CI workflow's pull_request branch filter matches milestone
+# feature branches (Issue #393).
+#
+# Milestone sub-issue PRs target a shared `milestone/<slug>` branch (planning
+# delivery workflow). If the CI quality workflow's `pull_request.branches`
+# filter does not match `milestone/*`, the gate never runs on those PRs and
+# they merge into the milestone branch unchecked — the gap only surfaces later
+# at the single rollup PR into the default branch. This validator fails loudly
+# unless the filter includes a `milestone/*` glob so every intermediate
+# sub-issue PR is gated too.
+#
+# This validator is purpose-built: it scans `ci.yml` with a minimal Python
+# scanner rather than pulling in a YAML parser. Designed for reuse from BATS
+# tests.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-milestone-branch-filter.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the CI workflow YAML file (default:
+                    .github/workflows/ci.yml relative to repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow's on.pull_request.branches filter includes a
+`milestone/*` glob. Exits non-zero with a descriptive message otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+# Extract the `on.pull_request.branches` list, one entry per line. The scanner
+# walks the `on:` map, descends into `pull_request:`, then collects the
+# `branches:` sequence in both inline (`[a, b]`) and block (`- a`) forms.
+branches="$(
+  python3 - "$WORKFLOW" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def strip_item(raw: str) -> str:
+    raw = raw.strip()
+    if (raw.startswith('"') and raw.endswith('"')) or (
+        raw.startswith("'") and raw.endswith("'")
+    ):
+        raw = raw[1:-1]
+    return raw
+
+
+# Locate the top-level `on:` map (column 0). It may be written as `on:` or the
+# YAML-normalised `true:` — accept only the literal `on:` here.
+on_start = None
+for i, line in enumerate(lines):
+    if line.rstrip() == "on:":
+        on_start = i + 1
+        break
+
+if on_start is None:
+    sys.exit(0)
+
+# Walk children of `on:` to find `pull_request:`.
+pr_start = None
+pr_indent = None
+i = on_start
+while i < len(lines):
+    line = lines[i]
+    if not line.strip() or line.lstrip().startswith("#"):
+        i += 1
+        continue
+    ind = indent_of(line)
+    if ind == 0:
+        break  # left the `on:` map
+    if pr_indent is None:
+        pr_indent = ind
+    if ind == pr_indent and line.strip().rstrip(":") == "pull_request":
+        pr_start = i + 1
+        break
+    i += 1
+
+if pr_start is None:
+    sys.exit(0)
+
+# Walk children of `pull_request:` to find `branches:`.
+i = pr_start
+child_indent = None
+while i < len(lines):
+    line = lines[i]
+    if not line.strip() or line.lstrip().startswith("#"):
+        i += 1
+        continue
+    ind = indent_of(line)
+    if ind <= (pr_indent or 0):
+        break  # left the pull_request block
+    if child_indent is None:
+        child_indent = ind
+    if ind == child_indent and line.strip().startswith("branches:"):
+        tail = line.strip()[len("branches:"):].strip()
+        if tail:
+            # inline form: branches: [a, b] or branches: a
+            tail = tail.strip("[]")
+            for item in tail.split(","):
+                item = strip_item(item)
+                if item:
+                    print(item)
+        else:
+            # block sequence form
+            m = i + 1
+            while m < len(lines):
+                nxt = lines[m]
+                if not nxt.strip() or nxt.lstrip().startswith("#"):
+                    m += 1
+                    continue
+                ni = indent_of(nxt)
+                if ni <= child_indent:
+                    break
+                if nxt.lstrip().startswith("- "):
+                    print(strip_item(nxt.strip()[2:]))
+                m += 1
+        break
+    i += 1
+PY
+)"
+
+if [[ -z "$branches" ]]; then
+  echo "FAIL $WORKFLOW: no on.pull_request.branches filter found — cannot confirm milestone PRs are gated" >&2
+  exit 1
+fi
+
+if grep -qx 'milestone/\*' <<<"$branches"; then
+  echo "OK   $WORKFLOW: pull_request.branches includes 'milestone/*' — milestone PRs are gated"
+  exit 0
+fi
+
+echo "FAIL $WORKFLOW: pull_request.branches must include 'milestone/*' so milestone sub-issue PRs are gated (found: $(tr '\n' ' ' <<<"$branches"))" >&2
+exit 1

--- a/tests/scripts/milestone_branch_filter.bats
+++ b/tests/scripts/milestone_branch_filter.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-milestone-branch-filter.sh — Issue #393.
+#
+# Exercises the milestone branch-filter validator with synthetic workflow YAML
+# in temporary directories so behaviour (exit codes, reported failures) is
+# verified end-to-end without depending on the real workflow file's state.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-milestone-branch-filter.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical workflow whose pull_request filter gates milestone branches. Failure
+# tests mutate this fixture to drop or break the milestone glob.
+write_gated_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: Example
+
+on:
+  push:
+    branches:
+      - Develop
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - Develop
+      - milestone/*
+  workflow_dispatch:
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+}
+
+@test "passes when pull_request.branches includes milestone/*" {
+  write_gated_workflow "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"includes 'milestone/*'"* ]]
+}
+
+@test "fails when the milestone/* glob is absent" {
+  write_gated_workflow "$TMP_WF/example.yml"
+  sed -i.bak '/- milestone\/\*/d' "$TMP_WF/example.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must include 'milestone/*'"* ]]
+}
+
+@test "fails when there is no pull_request.branches filter at all" {
+  cat >"$TMP_WF/example.yml" <<'EOF'
+name: Example
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no on.pull_request.branches filter found"* ]]
+}
+
+@test "accepts the inline list form of branches" {
+  cat >"$TMP_WF/example.yml" <<'EOF'
+name: Example
+
+on:
+  pull_request:
+    branches: [Develop, "milestone/*"]
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/example.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"includes 'milestone/*'"* ]]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "the repository CI workflow gates milestone PRs" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# CI quality workflow now gates milestone PRs

## Summary

The CI quality workflow (`.github/workflows/ci.yml`) only fired on pull requests
targeting `Develop`, so its `pull_request.branches` filter matched none of the
`milestone/<slug>` feature branches. Milestone sub-issue PRs target a shared
`milestone/<slug>` branch, so the gate never ran on them and they merged into
the milestone branch unchecked — the gap surfaced only later at the single
rollup PR into the default branch.

This adds `milestone/*` to the workflow's `pull_request.branches` filter so the
gate runs on every intermediate sub-issue PR too. Milestone branch names are
`milestone/<slug>` with no nested slashes, so the single-level `milestone/*`
glob is sufficient.

A purpose-built validator (`scripts/check-milestone-branch-filter.sh`, invoked
from `quality.sh`) fails loudly unless the filter includes the `milestone/*`
glob, and `tests/scripts/milestone_branch_filter.bats` covers it end-to-end so
the gate cannot silently regress.

Closes #393.

## Evidence

Backend/CI change — no web interface to screenshot. Verified via the validator
and its bats suite.

```mermaid
flowchart LR
    subgraph before["Before"]
        a1[milestone sub-issue PR] -->|filter matches only Develop| a2[merged UNCHECKED]
    end
    subgraph after["After (milestone/* added)"]
        b1[milestone sub-issue PR] -->|filter matches milestone/*| b2[CI gate runs] --> b3[merged only if green]
    end
```

Validator against the fixed workflow:

```
$ ./scripts/check-milestone-branch-filter.sh
OK   .github/workflows/ci.yml: pull_request.branches includes 'milestone/*' — milestone PRs are gated
```

New bats suite (all pass):

```
1..7
ok 1 passes when pull_request.branches includes milestone/*
ok 2 fails when the milestone/* glob is absent
ok 3 fails when there is no pull_request.branches filter at all
ok 4 accepts the inline list form of branches
ok 5 reports an error when the workflow file does not exist
ok 6 unknown flag prints usage and exits non-zero
ok 7 the repository CI workflow gates milestone PRs
```

Full existing bats suite continues to pass (344 tests, 0 failures);
`shellcheck --severity=warning` and `codespell` are clean.

## Test Plan

- Added `scripts/check-milestone-branch-filter.sh` — parses
  `on.pull_request.branches` from `ci.yml` and fails unless `milestone/*` is
  present (both inline and block list forms).
- Added `tests/scripts/milestone_branch_filter.bats` — 7 cases covering the
  happy path, the absent-glob regression (fails against the pre-fix workflow),
  a missing branches filter, the inline list form, a missing file, an unknown
  flag, and the real repository `ci.yml`.
- Wired the validator into `quality.sh` alongside the other workflow checks.
- Updated `README.md` to reflect that `ci.yml` now also gates `milestone/*`
  PRs, with a pointer to the validator and its bats suite.
