### PR TITLE
Gate milestone PRs in Gitleaks workflow (Issue #394)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,7 +16,11 @@ name: Gitleaks
 
 on:
   pull_request:
-    branches: ["*"]
+    # `*` matches only top-level branches (it does not span `/`), so
+    # `milestone/<slug>` PRs need an explicit `milestone/*` glob — otherwise the
+    # secret-scanning gate never runs on milestone sub-issue PRs and they merge
+    # into the milestone branch unscanned (Issue #394).
+    branches: ["*", "milestone/*"]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -918,8 +918,12 @@ targeting `Develop` and `milestone/*` (Issue #393) — milestone branch names ar
 `milestone/<slug>` with no nested slashes, so the single-level `milestone/*`
 glob gates every sub-issue PR rather than only the rollup PR into `Develop`.
 This dedicated workflow still gives other feature branches and stacked PRs the
-same fmt + clippy gate without spinning up the full CI graph. The milestone
-filter on `ci.yml` is validated by
+same fmt + clippy gate without spinning up the full CI graph. The Gitleaks
+secret-scanning workflow (`.github/workflows/gitleaks.yml`) carries the same
+`milestone/*` glob (Issue #394) — its previous `["*"]` filter matched only
+top-level branches (GitHub's `*` glob does not span `/`), so milestone
+sub-issue PRs merged into the milestone branch unscanned. The milestone
+filter on both `ci.yml` and `gitleaks.yml` is validated by
 `scripts/check-milestone-branch-filter.sh` (invoked from `quality.sh`) and
 covered end-to-end by `tests/scripts/milestone_branch_filter.bats`. The workflow is validated by
 `scripts/check-cargo-quality-workflow.sh` (invoked from `quality.sh`) and

--- a/docs/archive/pr-summaries/pr-summary-394.md
+++ b/docs/archive/pr-summaries/pr-summary-394.md
@@ -1,0 +1,56 @@
+## Summary
+
+The Gitleaks secret-scanning workflow (`.github/workflows/gitleaks.yml`) gated
+pull requests with `on.pull_request.branches: ["*"]`. GitHub's `*` glob does not
+span `/`, so it matched only top-level branches — `milestone/<slug>` sub-issue
+PRs never triggered the scan and merged into the milestone branch unscanned. The
+gap only surfaced later at the single rollup PR into the default branch.
+
+This PR adds the single-level `milestone/*` glob to the filter so the
+secret-scanning gate runs on every milestone sub-issue PR, matching the existing
+`ci.yml` treatment (Issue #393). The invariant is now enforced locally and in CI
+by reusing `scripts/check-milestone-branch-filter.sh` against `gitleaks.yml`.
+
+Closes #394.
+
+## Evidence
+
+This is a CI/workflow change with no web interface to screenshot. It is verified
+by the milestone branch-filter validator and its BATS suite.
+
+Before — the validator failed against `gitleaks.yml`:
+
+```text
+FAIL .github/workflows/gitleaks.yml: pull_request.branches must include 'milestone/*' ... (found: * )
+```
+
+After — the validator passes:
+
+```text
+OK   .github/workflows/gitleaks.yml: pull_request.branches includes 'milestone/*' — milestone PRs are gated
+```
+
+Branch-matching behaviour before and after the fix:
+
+```mermaid
+flowchart LR
+    subgraph before["Before: branches: [\"*\"]"]
+        A1[PR -> Develop] --> G1[Gitleaks runs]
+        A2[PR -> milestone/audit-21-july] -.skipped.-> X1[No scan]
+    end
+    subgraph after["After: branches: [\"*\", \"milestone/*\"]"]
+        B1[PR -> Develop] --> G2[Gitleaks runs]
+        B2[PR -> milestone/audit-21-july] --> G3[Gitleaks runs]
+    end
+```
+
+## Test Plan
+
+- Added `tests/scripts/milestone_branch_filter.bats::the repository Gitleaks
+  workflow gates milestone PRs` — runs the validator against the real
+  `.github/workflows/gitleaks.yml`; fails on the old `["*"]` filter and passes
+  after the `milestone/*` glob is added.
+- Existing `milestone_branch_filter.bats` and `gitleaks_workflow.bats` suites
+  continue to pass.
+- `quality.sh` now invokes the validator against `gitleaks.yml` so the gate is
+  enforced on every quality run and in CI.

--- a/quality.sh
+++ b/quality.sh
@@ -96,6 +96,9 @@ echo "🧭 Validating CI job dependency graph (Issue #23)..."
 echo "🎯 Validating CI gates milestone PRs (Issue #393)..."
 ./scripts/check-milestone-branch-filter.sh
 
+echo "🎯 Validating Gitleaks gates milestone PRs (Issue #394)..."
+./scripts/check-milestone-branch-filter.sh --workflow .github/workflows/gitleaks.yml
+
 echo "🔢 Validating workflow action versions for Node 24 compat (Issue #24)..."
 ./scripts/check-workflow-action-versions.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.23"
+version = "1.1.24"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/tests/scripts/milestone_branch_filter.bats
+++ b/tests/scripts/milestone_branch_filter.bats
@@ -114,3 +114,10 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" != *"FAIL"* ]]
 }
+
+# Issue #394 — the Gitleaks CI quality workflow must also gate milestone PRs.
+@test "the repository Gitleaks workflow gates milestone PRs" {
+  run "$SCRIPT_UNDER_TEST" --workflow "${BATS_TEST_DIRNAME}/../../.github/workflows/gitleaks.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary

The Gitleaks secret-scanning workflow (`.github/workflows/gitleaks.yml`) gated
pull requests with `on.pull_request.branches: ["*"]`. GitHub's `*` glob does not
span `/`, so it matched only top-level branches — `milestone/<slug>` sub-issue
PRs never triggered the scan and merged into the milestone branch unscanned. The
gap only surfaced later at the single rollup PR into the default branch.

This PR adds the single-level `milestone/*` glob to the filter so the
secret-scanning gate runs on every milestone sub-issue PR, matching the existing
`ci.yml` treatment (Issue #393). The invariant is now enforced locally and in CI
by reusing `scripts/check-milestone-branch-filter.sh` against `gitleaks.yml`.

Closes #394.

## Evidence

This is a CI/workflow change with no web interface to screenshot. It is verified
by the milestone branch-filter validator and its BATS suite.

Before — the validator failed against `gitleaks.yml`:

```text
FAIL .github/workflows/gitleaks.yml: pull_request.branches must include 'milestone/*' ... (found: * )
```

After — the validator passes:

```text
OK   .github/workflows/gitleaks.yml: pull_request.branches includes 'milestone/*' — milestone PRs are gated
```

Branch-matching behaviour before and after the fix:

```mermaid
flowchart LR
    subgraph before["Before: branches: [\"*\"]"]
        A1[PR -> Develop] --> G1[Gitleaks runs]
        A2[PR -> milestone/audit-21-july] -.skipped.-> X1[No scan]
    end
    subgraph after["After: branches: [\"*\", \"milestone/*\"]"]
        B1[PR -> Develop] --> G2[Gitleaks runs]
        B2[PR -> milestone/audit-21-july] --> G3[Gitleaks runs]
    end
```

## Test Plan

- Added `tests/scripts/milestone_branch_filter.bats::the repository Gitleaks
  workflow gates milestone PRs` — runs the validator against the real
  `.github/workflows/gitleaks.yml`; fails on the old `["*"]` filter and passes
  after the `milestone/*` glob is added.
- Existing `milestone_branch_filter.bats` and `gitleaks_workflow.bats` suites
  continue to pass.
- `quality.sh` now invokes the validator against `gitleaks.yml` so the gate is
  enforced on every quality run and in CI.
