### PR TITLE
Fix security.yml permissions: swap unused issues:write for pull-requests:write (Issue #398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,16 +170,18 @@ jobs:
     # Fan-in after `validation` keeps security audits aligned with the rest
     # of the graph — no advisory scan runs against a broken repo layout.
     needs: [validation]
-    # The reusable security.yml writes check-run annotations and PR/issue
-    # comments, so the calling job must grant those scopes explicitly: a
-    # called workflow's token can only be narrowed, never elevated, along the
-    # caller chain. With the read-only workflow default above, omitting this
-    # block would clamp security.yml's own `checks: write` / `issues: write`
-    # away. Mirrors the permissions declared in security.yml.
+    # The reusable security.yml writes check-run annotations and the
+    # dependency-review PR summary comment, so the calling job must grant those
+    # scopes explicitly: a called workflow's token can only be narrowed, never
+    # elevated, along the caller chain. With the read-only workflow default
+    # above, omitting this block would clamp security.yml's own `checks: write`
+    # / `pull-requests: write` away. `issues: write` is intentionally omitted —
+    # audit-check only files issues on non-PR events and this caller is PR-gated
+    # (Issue #398). Mirrors the permissions declared in security.yml.
     permissions:
       contents: read
       checks: write
-      issues: write
+      pull-requests: write
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'
     with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,10 +9,18 @@ on:
         type: boolean
         default: true
 
+# Least-privilege token scope, derived from the steps below (Issue #398):
+#   * checks: write        — rustsec/audit-check annotates the check run.
+#   * pull-requests: write — dependency-review posts its `comment-summary-in-pr`
+#                            summary comment.
+# `issues: write` is deliberately NOT granted: audit-check only files issues on
+# non-PR events (push/schedule) and this workflow's sole caller is PR-gated, so
+# the scope would be dead weight widening the blast radius. A schedule-triggered
+# caller that wants issue filing can grant `issues: write` itself.
 permissions:
   contents: read
   checks: write
-  issues: write
+  pull-requests: write
 
 jobs:
   security:

--- a/docs/archive/pr-summaries/pr-summary-398.md
+++ b/docs/archive/pr-summaries/pr-summary-398.md
@@ -1,0 +1,61 @@
+# Fix security.yml permissions mismatch (Issue #398)
+
+## Summary
+
+The reusable `.github/workflows/security.yml` and its sole caller (the `security`
+job in `.github/workflows/ci.yml`) both granted `permissions: issues: write`,
+but the block was never derived from the steps — it had two defects:
+
+1. **`issues: write` was dead weight.** `security.yml` is invoked only from the
+   `security` job in `ci.yml`, which is gated `if: github.event_name ==
+   'pull_request'`. `rustsec/audit-check` only files repository issues on
+   non-PR events (`push`/`schedule`); on `pull_request` it reports via check
+   runs. So the write scope could never be exercised, needlessly widening the
+   blast radius of every step in the job.
+2. **`pull-requests: write` was missing.** The dependency-review step sets
+   `comment-summary-in-pr: always`, and `actions/dependency-review-action`
+   requires `pull-requests: write` to post that summary comment. Without it the
+   configured comment silently never posted.
+
+Fix: swap `issues: write` → `pull-requests: write` in **both** mirrored
+permission blocks (a called workflow's token is only ever narrowed along the
+caller chain, so both the caller job and the reusable workflow must grant the
+scope). `scripts/check-ci-permissions.sh` now asserts the corrected
+`checks: write` + `pull-requests: write` pairing, with its bats tests updated to
+match. A `schedule`-triggered caller that ever wants issue filing can grant
+`issues: write` itself.
+
+Closes #398.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the
+least-privilege validator and its test suite.
+
+`scripts/check-ci-permissions.sh` against the real `ci.yml`:
+
+```
+OK   …/ci.yml: security job grants checks: write
+OK   …/ci.yml: security job grants pull-requests: write
+OK   …/ci.yml: security job grants contents: read
+```
+
+Token-scope narrowing along the caller chain:
+
+```mermaid
+flowchart LR
+    A["ci.yml security job<br/>contents: read<br/>checks: write<br/>pull-requests: write"] -->|token narrowed only| B["security.yml<br/>contents: read<br/>checks: write<br/>pull-requests: write"]
+    B --> C["rustsec/audit-check<br/>→ check-run annotations"]
+    B --> D["dependency-review<br/>comment-summary-in-pr: always<br/>→ needs pull-requests: write"]
+```
+
+## Test Plan
+
+- Updated `tests/scripts/ci_permissions.bats`:
+  - Canonical + failure fixtures now grant `pull-requests: write` (not
+    `issues: write`).
+  - Renamed `fails when the security job omits pull-requests: write` to assert
+    the validator rejects a security job missing that scope.
+- All 10 bats cases pass, including `real repository ci.yml satisfies every
+  least-privilege rule`.
+- `scripts/check-ci-permissions.sh` and `shellcheck` pass clean.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.24"
+version = "1.1.25"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-ci-permissions.sh
+++ b/scripts/check-ci-permissions.sh
@@ -14,12 +14,16 @@
 #      `*: write` scope at the workflow level.
 #   3. The `security` job — which calls the reusable `security.yml` — declares
 #      its own job-level `permissions:` granting the scopes the reusable
-#      workflow needs (`checks: write`, `issues: write`, and `contents: read`).
-#      This is required because a called workflow's token can only be narrowed,
-#      never elevated, along the caller chain — without the job-level grant the
-#      reusable workflow's own `checks: write` / `issues: write` would be
-#      clamped away by the read-only workflow default and the security
-#      annotations would silently fail.
+#      workflow needs (`checks: write`, `pull-requests: write`, and
+#      `contents: read`). This is required because a called workflow's token can
+#      only be narrowed, never elevated, along the caller chain — without the
+#      job-level grant the reusable workflow's own `checks: write` /
+#      `pull-requests: write` would be clamped away by the read-only workflow
+#      default and the security annotations / dependency-review PR comment would
+#      silently fail. `pull-requests: write` (not `issues: write`) is the scope
+#      the dependency-review action needs to post its `comment-summary-in-pr`
+#      summary; the audit-check action only files issues on non-PR events, which
+#      this PR-gated caller never triggers (Issue #398).
 #
 # The script takes a single optional `--workflow PATH` argument so BATS tests
 # can exercise it against fixtures. With no argument it validates
@@ -246,7 +250,7 @@ if [[ "$(field SECURITY_JOB)" == "1" ]]; then
     fail "security job must declare job-level 'permissions:' — the reusable security.yml needs checks/issues write, and a read-only default would clamp them away"
   fi
 
-  for scope in checks issues; do
+  for scope in checks pull-requests; do
     if [[ "$(scope_value SEC "$scope")" == "write" ]]; then
       ok "security job grants $scope: write"
     else

--- a/tests/scripts/ci_permissions.bats
+++ b/tests/scripts/ci_permissions.bats
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
       checks: write
-      issues: write
+      pull-requests: write
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'
     with:
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: read
       checks: write
-      issues: write
+      pull-requests: write
     uses: ./.github/workflows/security.yml
 EOF
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
@@ -114,7 +114,7 @@ jobs:
     permissions:
       contents: read
       checks: write
-      issues: write
+      pull-requests: write
     uses: ./.github/workflows/security.yml
 EOF
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
@@ -150,13 +150,13 @@ EOF
   [[ "$output" == *"security job must grant 'checks: write'"* ]]
 }
 
-@test "fails when the security job omits issues: write" {
+@test "fails when the security job omits pull-requests: write" {
   write_good_workflow "$TMP_WF"
-  grep -v 'issues: write' "$TMP_WF" >"$TMP_WF.stripped"
+  grep -v 'pull-requests: write' "$TMP_WF" >"$TMP_WF.stripped"
   mv "$TMP_WF.stripped" "$TMP_WF"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"security job must grant 'issues: write'"* ]]
+  [[ "$output" == *"security job must grant 'pull-requests: write'"* ]]
 }
 
 @test "reports an error when the workflow file does not exist" {


### PR DESCRIPTION
# Fix security.yml permissions mismatch (Issue #398)

## Summary

The reusable `.github/workflows/security.yml` and its sole caller (the `security`
job in `.github/workflows/ci.yml`) both granted `permissions: issues: write`,
but the block was never derived from the steps — it had two defects:

1. **`issues: write` was dead weight.** `security.yml` is invoked only from the
   `security` job in `ci.yml`, which is gated `if: github.event_name ==
   'pull_request'`. `rustsec/audit-check` only files repository issues on
   non-PR events (`push`/`schedule`); on `pull_request` it reports via check
   runs. So the write scope could never be exercised, needlessly widening the
   blast radius of every step in the job.
2. **`pull-requests: write` was missing.** The dependency-review step sets
   `comment-summary-in-pr: always`, and `actions/dependency-review-action`
   requires `pull-requests: write` to post that summary comment. Without it the
   configured comment silently never posted.

Fix: swap `issues: write` → `pull-requests: write` in **both** mirrored
permission blocks (a called workflow's token is only ever narrowed along the
caller chain, so both the caller job and the reusable workflow must grant the
scope). `scripts/check-ci-permissions.sh` now asserts the corrected
`checks: write` + `pull-requests: write` pairing, with its bats tests updated to
match. A `schedule`-triggered caller that ever wants issue filing can grant
`issues: write` itself.

Closes #398.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the
least-privilege validator and its test suite.

`scripts/check-ci-permissions.sh` against the real `ci.yml`:

```text
OK   …/ci.yml: security job grants checks: write
OK   …/ci.yml: security job grants pull-requests: write
OK   …/ci.yml: security job grants contents: read
```

Token-scope narrowing along the caller chain:

```mermaid
flowchart LR
    A["ci.yml security job<br/>contents: read<br/>checks: write<br/>pull-requests: write"] -->|token narrowed only| B["security.yml<br/>contents: read<br/>checks: write<br/>pull-requests: write"]
    B --> C["rustsec/audit-check<br/>→ check-run annotations"]
    B --> D["dependency-review<br/>comment-summary-in-pr: always<br/>→ needs pull-requests: write"]
```

## Test Plan

- Updated `tests/scripts/ci_permissions.bats`:
  - Canonical + failure fixtures now grant `pull-requests: write` (not
    `issues: write`).
  - Renamed `fails when the security job omits pull-requests: write` to assert
    the validator rejects a security job missing that scope.
- All 10 bats cases pass, including `real repository ci.yml satisfies every
  least-privilege rule`.
- `scripts/check-ci-permissions.sh` and `shellcheck` pass clean.



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrvizzun-151df3`<!-- vibe-worker-issue-398 -->