### PR TITLE
De-duplicate cargo-audit and dependency-review on Develop PRs (Issue #399)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,12 @@ jobs:
     uses: ./.github/workflows/security.yml
     if: github.event_name == 'pull_request'
     with:
-      include-dependency-review: true
+      # Opt out of the reusable workflow's dependency-review step (Issue #399).
+      # The standalone `dependency-review.yml` runs the same action on every PR
+      # — including PRs into `Develop` and `milestone/**` — so enabling it here
+      # too only produced a duplicate verdict on the dominant path. The
+      # standalone workflow is now the single dependency-review gate.
+      include-dependency-review: false
 
   validation:
     name: Project Validation

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,12 +2,13 @@ name: Dependency Review
 
 # Standalone Dependency Review workflow (Issue #62).
 #
-# Why a dedicated workflow? The reusable `security.yml` workflow already
-# invokes `actions/dependency-review-action` on PR events as part of CI.
-# This file mirrors that coverage as a self-contained, single-purpose
-# workflow so the dependency-review check is discoverable on its own and
-# runs even on PRs targeting branches that bypass the full CI graph
-# (`ci.yml` only fires for PRs into `Develop`).
+# Why a dedicated workflow? This is now the single dependency-review gate for
+# the repo (Issue #399). It is self-contained and discoverable on its own, and
+# runs on PRs targeting every branch — including those that bypass the full CI
+# graph (`ci.yml` only fires for PRs into `Develop` and `milestone/*`). The
+# reusable `security.yml` used to run the same action inside CI as well, but
+# that duplicated the verdict on the dominant Develop / milestone path, so its
+# caller (`ci.yml`) now passes `include-dependency-review: false`.
 #
 # What it does: `actions/dependency-review-action` diffs the PR's manifest
 # (Cargo.toml / Cargo.lock here) against the base branch and fails the run
@@ -15,7 +16,11 @@ name: Dependency Review
 # disallowed licence — surfacing supply-chain risk before merge.
 #
 # Trigger: pull_request only. The action requires the diff between base and
-# head, which only makes sense on PR events.
+# head, which only makes sense on PR events. The filter includes `milestone/**`
+# so the gate also runs on milestone/<slug> sub-issue PRs — a bare "*" glob does
+# not match refs containing a slash (Issue #391), which would otherwise leave
+# milestone PRs with no dependency-review coverage once the reusable path is
+# disabled.
 #
 # Action versions follow `scripts/check-workflow-action-versions.sh`:
 # `actions/checkout@v5` (Node 24 policy) and
@@ -25,7 +30,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["*", "milestone/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,19 +83,21 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Belt-and-braces: run cargo-audit directly so the job fails hard on
-      # advisories even if the action's annotation path is disabled.
-      # Fetch a prebuilt cargo-audit binary instead of compiling from source
-      # on every run (Issue #208). taiki-e/install-action resolves a released
-      # binary in seconds, matching the prior unversioned `cargo install`.
-      - name: Install cargo-audit (prebuilt binary)
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
-        with:
-          tool: cargo-audit
+      # A second, direct `cargo audit` run used to follow the action here as
+      # "belt-and-braces". It was pure duplication (Issue #399): `rustsec/audit-check`
+      # already fails the check on any advisory, so a follow-up run against the
+      # identical `Cargo.lock` in the same job cannot catch anything the action
+      # missed. The standalone `cargo-audit.yml` still runs a prebuilt
+      # `cargo audit` on every PR (and on its weekly cron) for branches that
+      # bypass this reusable workflow, so no coverage is lost.
 
-      - name: Run cargo audit
-        run: cargo audit
-
+      # Optional dependency review, gated behind the `include-dependency-review`
+      # input so a caller can opt out. The sole caller (`ci.yml`) now passes
+      # `false` (Issue #399): the standalone `dependency-review.yml` is the
+      # single universal dependency-review gate on every PR — running it here
+      # too only duplicated the verdict on the Develop / milestone path. The
+      # capability (and the `pull-requests: write` scope it needs to post its
+      # comment summary) is retained for any future caller that opts back in.
       - name: Dependency review
         if: ${{ inputs.include-dependency-review && github.event_name == 'pull_request' }}
         # Bumped to v5.0.0 in Issue #136 — upstream shipped Node 24 on

--- a/README.md
+++ b/README.md
@@ -866,13 +866,17 @@ message live in `scripts/auto-format.sh` and are covered by
 `scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`).
 
 A standalone Cargo Security Audit workflow (`.github/workflows/cargo-audit.yml`,
-Issue #64) mirrors the `cargo audit` step in the reusable `security.yml` but
-adds a weekly cron schedule (`0 6 * * 1`) plus `workflow_dispatch`. The
-schedule catches advisories published *after* the last PR — the lockfile
-does not change but the RustSec advisory database does. The workflow is
-validated by `scripts/check-cargo-audit-workflow.sh` (invoked from
-`quality.sh`) and covered end-to-end by
-`tests/scripts/cargo_audit_workflow.bats`.
+Issue #64) runs a prebuilt `cargo audit` on every PR (against `*` and
+`milestone/**`) and adds a weekly cron schedule (`0 6 * * 1`) plus
+`workflow_dispatch`. The schedule catches advisories published *after* the last
+PR — the lockfile does not change but the RustSec advisory database does. The
+reusable `security.yml` scans the same `Cargo.lock` via the `rustsec/audit-check`
+action (which annotates the PR check run). A second, direct `cargo audit` run
+in `security.yml` was removed as pure duplication (Issue #399): the action
+already fails the check on any advisory, so a follow-up run in the same job
+could not catch anything it missed. The workflow is validated by
+`scripts/check-cargo-audit-workflow.sh` (invoked from `quality.sh`) and covered
+end-to-end by `tests/scripts/cargo_audit_workflow.bats`.
 
 A standalone SBOM workflow (`.github/workflows/sbom.yml`, Issue #172) exports
 the dependency inventory as a CycloneDX Software Bill of Materials and uploads
@@ -898,7 +902,7 @@ flowchart LR
 ```
 
 CI installs its cargo CLI tools from **prebuilt binaries**, not from source
-(Issue #208). `cargo-audit` (`cargo-audit.yml`, `security.yml`),
+(Issue #208). `cargo-audit` (`cargo-audit.yml`),
 `cargo-cyclonedx` (`sbom.yml`), and `cargo-deny` (`ci.yml`) are fetched via
 `taiki-e/install-action` — a released binary downloads in seconds, where
 `cargo install <tool> --locked` recompiled the tool from source on every run
@@ -941,16 +945,19 @@ re-introduces the duplicate ShellCheck step.
 
 A standalone Dependency Review workflow
 (`.github/workflows/dependency-review.yml`, Issue #62) runs
-`actions/dependency-review-action@v4` on every pull request against any
-branch. The action diffs the PR's manifest against the base branch and
-fails the run if any newly introduced dependency carries a known
-vulnerability or disallowed licence — catching supply-chain regressions
-before merge. The reusable `security.yml` workflow runs the same action
-inside the full CI graph; this dedicated workflow gives feature branches
-and stacked PRs the same gate without spinning up CI. The workflow is
-validated by `scripts/check-dependency-review-workflow.sh` (invoked from
-`quality.sh`) and covered end-to-end by
-`tests/scripts/dependency_review_workflow.bats`.
+`actions/dependency-review-action@v5` on every pull request against any branch
+(`branches: ["*", "milestone/**"]`). The action diffs the PR's manifest against
+the base branch and fails the run if any newly introduced dependency carries a
+known vulnerability or disallowed licence — catching supply-chain regressions
+before merge. This is now the **single** dependency-review gate (Issue #399):
+the reusable `security.yml` used to run the same action inside CI too, but that
+duplicated the verdict on the dominant `Develop` / `milestone/*` path, so its
+caller (`ci.yml`) now passes `include-dependency-review: false`. Because the
+standalone workflow is the sole gate, its `pull_request` filter includes
+`milestone/**` so milestone sub-issue PRs are not silently skipped (a bare `*`
+glob does not span `/`). The workflow is validated by
+`scripts/check-dependency-review-workflow.sh` (invoked from `quality.sh`) and
+covered end-to-end by `tests/scripts/dependency_review_workflow.bats`.
 
 A standalone Actionlint workflow (`.github/workflows/actionlint.yml`,
 Issue #195) runs [actionlint](https://github.com/rhysd/actionlint) — the

--- a/docs/archive/pr-summaries/pr-summary-399.md
+++ b/docs/archive/pr-summaries/pr-summary-399.md
@@ -1,0 +1,88 @@
+# De-duplicate cargo-audit and dependency-review on Develop PRs (Issue #399)
+
+## Summary
+
+On every PR into `Develop`, `cargo audit` ran **3×** and `dependency-review`
+ran **2×** across three workflow files. This PR removes the pure duplication on
+the dominant path without losing coverage on any branch. **Closes #399.**
+
+- **cargo-audit (3 → 2):** removed the redundant second, direct `cargo audit`
+  run from the reusable `security.yml` job. `rustsec/audit-check` already fails
+  the check on any advisory, so a follow-up run against the identical
+  `Cargo.lock` in the same job could not catch anything it missed. The
+  standalone `cargo-audit.yml` still runs a prebuilt `cargo audit` on every PR
+  (and on its weekly cron), so the belt-and-braces coverage of branches that
+  bypass CI is unchanged.
+- **dependency-review (2 → 1):** the reusable `security.yml` no longer runs the
+  action — `ci.yml` now passes `include-dependency-review: false`. The
+  standalone `dependency-review.yml` becomes the single universal gate. To keep
+  it truly universal its `pull_request` filter was extended to
+  `["*", "milestone/**"]`, so milestone `<slug>` sub-issue PRs (which a bare
+  `*` glob does not match) keep dependency-review coverage now that the reusable
+  path is off.
+
+The reusable workflow retains the optional dependency-review capability (and the
+`pull-requests: write` scope) behind its input, so a future caller can opt back
+in.
+
+### Coverage matrix (executions per PR)
+
+| Target branch        | cargo-audit before | cargo-audit after | dep-review before | dep-review after |
+|----------------------|:------------------:|:-----------------:|:-----------------:|:----------------:|
+| `Develop`            | 3                  | 2                 | 2                 | 1                |
+| `milestone/<slug>`   | 3                  | 2                 | 1                 | 1                |
+| other single-level   | 1                  | 1                 | 1                 | 1                |
+
+No cell decreases below 1 — every PR is still gated by both checks.
+
+## Evidence
+
+CI/workflow change only — no web interface to screenshot. Verified via the
+repo's workflow validators and the bats helper suite (all run under
+`quality.sh`):
+
+- `scripts/check-prebuilt-tool-install.sh` — passes; `security.yml` dropped from
+  the canonical cargo-audit pairs.
+- `scripts/check-dependency-review-workflow.sh` — passes, including the new
+  milestone-coverage rule.
+- `scripts/check-ci-permissions.sh`, `check-cargo-audit-workflow.sh`,
+  `check-workflow-action-versions.sh`, `check-persist-credentials.sh`,
+  `check-readme-ci-alignment.sh` — all pass.
+- `actionlint` — clean on the three edited workflows.
+- Full `bats tests/scripts` — 349 tests pass, 0 failures.
+
+```mermaid
+flowchart TB
+    subgraph Before["Develop PR — before"]
+      ca1["cargo-audit.yml: cargo audit"]
+      s1["security.yml: rustsec/audit-check"]
+      s2["security.yml: direct cargo audit"]
+      dr1["dependency-review.yml"]
+      s3["security.yml: dependency-review"]
+    end
+    subgraph After["Develop PR — after"]
+      ca2["cargo-audit.yml: cargo audit"]
+      s4["security.yml: rustsec/audit-check"]
+      dr2["dependency-review.yml (sole gate)"]
+    end
+    s2 -. removed .-> After
+    s3 -. disabled via include-dependency-review: false .-> After
+```
+
+## Test Plan
+
+- `tests/scripts/prebuilt_tool_install.bats`
+  - Updated the canonical-directory test to the three remaining pairs.
+  - Added `security.yml is not a canonical cargo-audit pair (Issue #399)` —
+    proves the validator passes when `security.yml` has no prebuilt cargo-audit
+    install.
+- `tests/scripts/dependency_review_workflow.bats`
+  - Updated the canonical fixture to `["*", "milestone/**"]` and the OK-marker
+    count 4 → 5.
+  - Added `fails when the pull_request filter omits milestone branches (Issue
+    #399)` — a regression guard so the sole dependency-review gate cannot
+    silently drop milestone coverage.
+- Existing `ci_permissions`, `cargo_audit_workflow`, `workflow_action_versions`
+  and `persist_credentials` suites continue to pass unchanged.
+
+No Rust source changed, so the cargo build/test/clippy/doc gates are unaffected.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.28"
+version = "1.1.29"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-dependency-review-workflow.sh
+++ b/scripts/check-dependency-review-workflow.sh
@@ -15,6 +15,13 @@
 #      major (the version policy in
 #      `scripts/check-workflow-action-versions.sh` tracks the current
 #      Node 20 exception at @v4).
+#   5. Cover milestone/<slug> branches in the pull_request filter. Since
+#      Issue #399 this standalone workflow is the *sole* dependency-review gate
+#      (the reusable `security.yml` no longer runs the action), so a bare "*"
+#      glob — which does not match refs containing a slash — would leave
+#      milestone sub-issue PRs with no dependency-review coverage at all. The
+#      `milestone/*` token also matches the wider `milestone/**` glob
+#      (Issue #391).
 #
 # The script takes a single optional `--workflow PATH` argument so BATS tests
 # can exercise it against fixtures. When called with no argument it validates
@@ -112,6 +119,15 @@ elif echo "$dr_line" | grep -qE 'actions/dependency-review-action@(v[0-9]+|[0-9a
   ok "actions/dependency-review-action present and pinned to a numeric major or 40-char SHA"
 else
   fail "actions/dependency-review-action is not pinned — branch refs disallowed"
+fi
+
+# 5. pull_request branch filter must include milestone branches. As the sole
+#    dependency-review gate (Issue #399), a bare "*" glob would silently skip
+#    milestone/<slug> sub-issue PRs (GitHub's "*" does not span "/").
+if grep -qE 'milestone/\*' "$WORKFLOW"; then
+  ok "pull_request branch filter covers milestone/* branches"
+else
+  fail "pull_request branch filter omits milestone/* — milestone PRs skip the dependency-review gate (Issue #399)"
 fi
 
 exit "$EXIT_CODE"

--- a/scripts/check-prebuilt-tool-install.sh
+++ b/scripts/check-prebuilt-tool-install.sh
@@ -3,11 +3,13 @@
 # compiled from source on every CI run (Issue #208, part of #198).
 #
 # Why this exists:
-#   Four workflows install a cargo CLI tool before using it:
+#   Three workflows install a cargo CLI tool before using it:
 #     * cargo-audit.yml — cargo-audit
-#     * security.yml    — cargo-audit
 #     * sbom.yml        — cargo-cyclonedx
 #     * ci.yml          — cargo-deny
+#   (security.yml no longer installs cargo-audit standalone: its redundant
+#    in-job `cargo audit` run was removed in Issue #399, leaving the
+#    `rustsec/audit-check` action as its sole advisory scan.)
 #   `cargo install <tool> --locked` recompiles the tool from source on every
 #   run, costing minutes of wasted CI wall-clock with no behaviour change.
 #   `taiki-e/install-action` downloads a prebuilt release binary instead, so
@@ -37,7 +39,8 @@ Options:
   --tool NAME       Cargo tool name expected to be installed as a prebuilt
                     binary (e.g. cargo-audit). Only valid with --workflow.
   --workflows DIR   Directory holding the canonical workflows (default:
-                    .github/workflows relative to the repo root).
+                    .github/workflows relative to the repo root). The three
+                    canonical pairs are cargo-audit.yml, sbom.yml and ci.yml.
   -h, --help        Show this message.
 
 Exits 0 when every checked (workflow, tool) pair installs the tool from a
@@ -133,7 +136,6 @@ fi
 # parallel-indexed pair list is used.
 PAIRS=(
   "cargo-audit.yml:cargo-audit"
-  "security.yml:cargo-audit"
   "sbom.yml:cargo-cyclonedx"
   "ci.yml:cargo-deny"
 )

--- a/tests/scripts/dependency_review_workflow.bats
+++ b/tests/scripts/dependency_review_workflow.bats
@@ -28,7 +28,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["*", "milestone/**"]
 
 permissions:
   contents: read
@@ -48,7 +48,15 @@ EOF
   [ "$status" -eq 0 ]
   # Issue #360: prove every rule was individually evaluated and passed via the
   # machine-checkable "OK   " marker rather than pinning informational wording.
-  [ "$(grep -c '^OK   ' <<<"$output")" -eq 4 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 5 ]
+}
+
+@test "fails when the pull_request filter omits milestone branches (Issue #399)" {
+  write_dependency_review_workflow "$TMP_WF/dependency-review.yml"
+  sed -i.bak 's|branches: \["\*", "milestone/\*\*"\]|branches: ["*"]|' "$TMP_WF/dependency-review.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/dependency-review.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"omits milestone/*"* ]]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {
@@ -58,7 +66,7 @@ import sys
 path = sys.argv[1]
 with open(path) as fh:
     text = fh.read()
-text = text.replace("on:\n  pull_request:\n    branches: [\"*\"]\n", "on:\n  workflow_dispatch:\n")
+text = text.replace("on:\n  pull_request:\n    branches: [\"*\", \"milestone/**\"]\n", "on:\n  workflow_dispatch:\n")
 with open(path, "w") as fh:
     fh.write(text)
 PY

--- a/tests/scripts/prebuilt_tool_install.bats
+++ b/tests/scripts/prebuilt_tool_install.bats
@@ -105,14 +105,41 @@ EOF
 }
 
 @test "validates a directory of canonical workflows" {
+  # Issue #399: security.yml no longer installs cargo-audit standalone, so it
+  # is not a canonical pair. The three remaining pairs are cargo-audit.yml,
+  # sbom.yml and ci.yml.
   mkdir -p "$TMP_WF/wf"
   write_prebuilt_workflow "$TMP_WF/wf/cargo-audit.yml" "cargo-audit"
-  write_prebuilt_workflow "$TMP_WF/wf/security.yml" "cargo-audit"
   write_prebuilt_workflow "$TMP_WF/wf/sbom.yml" "cargo-cyclonedx"
   write_prebuilt_workflow "$TMP_WF/wf/ci.yml" "cargo-deny"
   run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/wf"
   [ "$status" -eq 0 ]
   [[ "$output" != *"FAIL"* ]]
+}
+
+@test "security.yml is not a canonical cargo-audit pair (Issue #399)" {
+  # A directory containing only the three canonical workflows must pass even
+  # when security.yml has no prebuilt cargo-audit install — the validator must
+  # not require one there. A security.yml that only runs rustsec/audit-check
+  # (no taiki-e install) is present but deliberately not checked.
+  mkdir -p "$TMP_WF/wf"
+  write_prebuilt_workflow "$TMP_WF/wf/cargo-audit.yml" "cargo-audit"
+  write_prebuilt_workflow "$TMP_WF/wf/sbom.yml" "cargo-cyclonedx"
+  write_prebuilt_workflow "$TMP_WF/wf/ci.yml" "cargo-deny"
+  cat >"$TMP_WF/wf/security.yml" <<'EOF'
+name: Security Reusable Workflow
+on: [workflow_call]
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432  # v2
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/wf"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+  [[ "$output" != *"security.yml"* ]]
 }
 
 @test "real repository workflows install tools from prebuilt binaries" {


### PR DESCRIPTION
# De-duplicate cargo-audit and dependency-review on Develop PRs (Issue #399)

## Summary

On every PR into `Develop`, `cargo audit` ran **3×** and `dependency-review`
ran **2×** across three workflow files. This PR removes the pure duplication on
the dominant path without losing coverage on any branch. **Closes #399.**

- **cargo-audit (3 → 2):** removed the redundant second, direct `cargo audit`
  run from the reusable `security.yml` job. `rustsec/audit-check` already fails
  the check on any advisory, so a follow-up run against the identical
  `Cargo.lock` in the same job could not catch anything it missed. The
  standalone `cargo-audit.yml` still runs a prebuilt `cargo audit` on every PR
  (and on its weekly cron), so the belt-and-braces coverage of branches that
  bypass CI is unchanged.
- **dependency-review (2 → 1):** the reusable `security.yml` no longer runs the
  action — `ci.yml` now passes `include-dependency-review: false`. The
  standalone `dependency-review.yml` becomes the single universal gate. To keep
  it truly universal its `pull_request` filter was extended to
  `["*", "milestone/**"]`, so milestone `<slug>` sub-issue PRs (which a bare
  `*` glob does not match) keep dependency-review coverage now that the reusable
  path is off.

The reusable workflow retains the optional dependency-review capability (and the
`pull-requests: write` scope) behind its input, so a future caller can opt back
in.

### Coverage matrix (executions per PR)

| Target branch        | cargo-audit before | cargo-audit after | dep-review before | dep-review after |
|----------------------|:------------------:|:-----------------:|:-----------------:|:----------------:|
| `Develop`            | 3                  | 2                 | 2                 | 1                |
| `milestone/<slug>`   | 3                  | 2                 | 1                 | 1                |
| other single-level   | 1                  | 1                 | 1                 | 1                |

No cell decreases below 1 — every PR is still gated by both checks.

## Evidence

CI/workflow change only — no web interface to screenshot. Verified via the
repo's workflow validators and the bats helper suite (all run under
`quality.sh`):

- `scripts/check-prebuilt-tool-install.sh` — passes; `security.yml` dropped from
  the canonical cargo-audit pairs.
- `scripts/check-dependency-review-workflow.sh` — passes, including the new
  milestone-coverage rule.
- `scripts/check-ci-permissions.sh`, `check-cargo-audit-workflow.sh`,
  `check-workflow-action-versions.sh`, `check-persist-credentials.sh`,
  `check-readme-ci-alignment.sh` — all pass.
- `actionlint` — clean on the three edited workflows.
- Full `bats tests/scripts` — 349 tests pass, 0 failures.

```mermaid
flowchart TB
    subgraph Before["Develop PR — before"]
      ca1["cargo-audit.yml: cargo audit"]
      s1["security.yml: rustsec/audit-check"]
      s2["security.yml: direct cargo audit"]
      dr1["dependency-review.yml"]
      s3["security.yml: dependency-review"]
    end
    subgraph After["Develop PR — after"]
      ca2["cargo-audit.yml: cargo audit"]
      s4["security.yml: rustsec/audit-check"]
      dr2["dependency-review.yml (sole gate)"]
    end
    s2 -. removed .-> After
    s3 -. disabled via include-dependency-review: false .-> After
```

## Test Plan

- `tests/scripts/prebuilt_tool_install.bats`
  - Updated the canonical-directory test to the three remaining pairs.
  - Added `security.yml is not a canonical cargo-audit pair (Issue #399)` —
    proves the validator passes when `security.yml` has no prebuilt cargo-audit
    install.
- `tests/scripts/dependency_review_workflow.bats`
  - Updated the canonical fixture to `["*", "milestone/**"]` and the OK-marker
    count 4 → 5.
  - Added `fails when the pull_request filter omits milestone branches (Issue
    #399)` — a regression guard so the sole dependency-review gate cannot
    silently drop milestone coverage.
- Existing `ci_permissions`, `cargo_audit_workflow`, `workflow_action_versions`
  and `persist_credentials` suites continue to pass unchanged.

No Rust source changed, so the cargo build/test/clippy/doc gates are unaffected.
