### PR TITLE
Add set -euo pipefail to risk-bearing multi-line run: blocks (Issue #400)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,14 @@ jobs:
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |
+          set -euo pipefail
           if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
             ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
           fi
 
       - name: Free up runner disk space
         run: |
+          set -euo pipefail
           df -h /
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
@@ -225,6 +227,7 @@ jobs:
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |
+          set -euo pipefail
           if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
             ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
           fi
@@ -299,12 +302,14 @@ jobs:
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |
+          set -euo pipefail
           if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
             ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
           fi
 
       - name: Check bash script syntax
         run: |
+          set -euo pipefail
           EXIT_CODE=0
           while IFS= read -r script; do
             if bash -n "$script"; then
@@ -328,6 +333,7 @@ jobs:
         env:
           SHELLCHECK_OPTS: -s bash
         run: |
+          set -euo pipefail
           shellcheck --version
           scripts=()
           while IFS= read -r script; do

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |
+          set -euo pipefail
           if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
             ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Link NEAT-AI-core sibling path expected by Cargo
         run: |
+          set -euo pipefail
           if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
             ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
           fi

--- a/docs/archive/pr-summaries/pr-summary-400.md
+++ b/docs/archive/pr-summaries/pr-summary-400.md
@@ -1,0 +1,67 @@
+# Harden multi-line `run:` blocks with `set -euo pipefail`
+
+## Summary
+
+Several multi-line `run:` blocks in the workflow YAML did not begin with
+`set -euo pipefail`, so a failing intermediate command could be swallowed and
+the step still report success — a "false green" on gating checks and a
+never-fail-silently hazard. This change adds `set -euo pipefail` as the first
+line of each flagged block and adds a regression guard so the drift cannot
+return. Closes #400.
+
+Blocks fixed (matching the audit finding `BP-abcb2822fb7b`):
+
+- `.github/workflows/ci.yml` — the "Link NEAT-AI-core sibling path expected by
+  Cargo" symlink step (three copies), "Free up runner disk space"
+  (`sudo rm -rf`), "Check bash script syntax" (`find … | while`), and
+  "Run ShellCheck" (`find`-driven).
+- `.github/workflows/security.yml` and `.github/workflows/sbom.yml` — two more
+  copies of the symlink step.
+
+This is drift between copies of the same blocks, not a missing convention:
+`auto-format.yml`, `cargo-quality.yml`, `gitleaks.yml` and
+`version-increment.yml` already open their multi-line scripts with
+`set -euo pipefail`.
+
+## Regression guard
+
+Added `scripts/check-run-block-safety.sh` (wired into `quality.sh` and exercised
+by `tests/scripts/run_block_safety.bats`). It scans every workflow for
+*risk-bearing* multi-line `run: |` blocks — the NEAT-AI-core symlink
+(`ln -s`), `find … -name "*.sh"` shell discovery, and privileged deletion
+(`sudo rm -rf`) — and fails (listing each offender as `file:line`) if any does
+not open with `set -euo pipefail`. Benign single-command line-continuation
+blocks (e.g. a wrapped `cargo clippy` invocation) are deliberately not flagged.
+
+```mermaid
+flowchart LR
+    A[workflow *.yml] --> B{multi-line run: block?}
+    B -- no --> Z[skip]
+    B -- yes --> C{risk pattern?<br/>ln -s / find *.sh / sudo rm -rf}
+    C -- no --> Z
+    C -- yes --> D{first line ==<br/>set -euo pipefail?}
+    D -- yes --> OK[pass]
+    D -- no --> FAIL[fail: file:line]
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via:
+
+- `./scripts/check-run-block-safety.sh` → passes against the real repo after the
+  fix; reproduces the failure (`exit 1`, offender listed) against a reverted
+  fixture.
+- `bats tests/scripts` → all 358 tests pass, including the 9 new
+  `run_block_safety.bats` cases.
+- `shellcheck --severity=warning` and `bash -n` clean on the new script.
+- `actionlint` clean on `ci.yml`, `security.yml`, `sbom.yml`.
+
+## Test Plan
+
+- Added `tests/scripts/run_block_safety.bats`:
+  - passes when the symlink block opens with `set -euo pipefail`;
+  - fails when the symlink / `find`-`*.sh` / `sudo rm -rf` blocks omit it;
+  - reports every offending block across multiple files;
+  - ignores a benign single-command continuation block;
+  - errors on a missing workflows directory and on an unknown flag;
+  - asserts the real repository keeps every risk-bearing block safe.

--- a/quality.sh
+++ b/quality.sh
@@ -117,6 +117,9 @@ echo "🔁 Validating concurrency groups on pile-up-prone workflows (Issue #156)
 echo "🔒 Validating credential-free checkouts set persist-credentials: false (Issue #380)..."
 ./scripts/check-persist-credentials.sh
 
+echo "🛟 Validating risk-bearing multi-line run: blocks open with set -euo pipefail (Issue #400)..."
+./scripts/check-run-block-safety.sh
+
 echo "📖 Validating README 'matches CI' block aligns with the CI quality job (Issue #212)..."
 ./scripts/check-readme-ci-alignment.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.29"
+version = "1.1.30"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-run-block-safety.sh
+++ b/scripts/check-run-block-safety.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Guard: risk-bearing multi-line `run:` blocks must open with `set -euo pipefail`
+# (Issue #400).
+#
+# A multi-line `run: |` block without `set -euo pipefail` lets a failing
+# intermediate command be swallowed: the step reports success while doing less
+# than it claims. For gating jobs (e.g. `shell-checks`) that turns a broken lint
+# invocation into a false green on a required check — the exact
+# "never fail silently" hazard the house style guards against.
+#
+# The repository already opens its multi-line scripts with `set -euo pipefail`
+# (auto-format.yml, cargo-quality.yml, gitleaks.yml, version-increment.yml). This
+# guard asserts that convention for the *risk-bearing* block shapes the audit
+# flagged, so a copy-pasted block cannot drift back to the unsafe form:
+#
+#   * the NEAT-AI-core sibling symlink block (`ln -s … NEAT-AI-core`) — five
+#     copies across ci.yml, security.yml and sbom.yml;
+#   * shell-script discovery driven by `find … -name "*.sh"` (bash-syntax and
+#     ShellCheck steps) — a failing `find` must not yield an empty loop and a
+#     green step;
+#   * privileged deletion (`sudo rm -rf`) — the "Free up runner disk space"
+#     step.
+#
+# The script takes an optional `--workflows DIR` argument so BATS tests can
+# exercise it against fixtures. With no argument it scans `.github/workflows`
+# relative to the repo root.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-run-block-safety.sh [--workflows DIR]
+
+Options:
+  --workflows DIR   Directory containing workflow YAML files (default:
+                    .github/workflows relative to the repo root).
+  -h, --help        Show this message.
+
+Exits 0 when every risk-bearing multi-line `run:` block (NEAT-AI-core symlink,
+find-driven shell discovery, or `sudo rm -rf`) opens with `set -euo pipefail`.
+Exits 1 (listing each offender as `file:line`) when any such block does not.
+EOF
+}
+
+WORKFLOWS_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflows)
+      WORKFLOWS_DIR="${2:-}"
+      [[ -n "$WORKFLOWS_DIR" ]] || { echo "--workflows requires a directory argument" >&2; exit 2; }
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOWS_DIR" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
+fi
+
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
+  exit 2
+fi
+
+# Collect offenders as "file:line" strings. A block is examined only when it is
+# a `run: |` (literal block scalar); folded/inline `run:` forms are ignored.
+offenders=()
+
+scan_workflow() {
+  local file="$1"
+  awk '
+    # Detect the start of a literal block scalar `run: |`.
+    /^[[:space:]]*run:[[:space:]]*\|[[:space:]]*$/ {
+      # Indentation of the `run:` key; block body is more indented than this.
+      match($0, /^[[:space:]]*/)
+      key_indent = RLENGTH
+      start_line = NR
+      first_stmt = ""
+      body = ""
+      # Consume the block body: lines indented deeper than the key, or blank.
+      # A dedent (indent <= key) ends the block. The dedented line cannot begin
+      # a deeper `run:` block, so it is safe not to re-evaluate it.
+      while ((getline line) > 0) {
+        if (line ~ /^[[:space:]]*$/) { body = body "\n" line; continue }
+        match(line, /^[[:space:]]*/)
+        if (RLENGTH <= key_indent) break
+        if (first_stmt == "") { first_stmt = line }
+        body = body "\n" line
+      }
+      # Is this a risk-bearing block? (symlink / find-*.sh / sudo rm -rf)
+      risky = 0
+      if (body ~ /ln[[:space:]]+-s/) risky = 1
+      if (body ~ /find[^\n]*-name[[:space:]]*"\*\.sh"/) risky = 1
+      if (body ~ /sudo[[:space:]]+rm[[:space:]]+-rf/) risky = 1
+      if (risky && first_stmt !~ /^[[:space:]]*set[[:space:]]+-euo[[:space:]]+pipefail[[:space:]]*$/) {
+        printf "%s:%d\n", FILENAME, start_line
+      }
+      next
+    }
+  ' "$file"
+}
+
+while IFS= read -r workflow; do
+  [[ -f "$workflow" ]] || continue
+  while IFS= read -r hit; do
+    [[ -n "$hit" ]] && offenders+=("$hit")
+  done < <(scan_workflow "$workflow")
+done < <(find "$WORKFLOWS_DIR" -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) -type f | sort)
+
+if [[ ${#offenders[@]} -eq 0 ]]; then
+  echo "OK   every risk-bearing multi-line run: block opens with 'set -euo pipefail'"
+  exit 0
+fi
+
+echo "FAIL risk-bearing multi-line run: block missing 'set -euo pipefail' (Issue #400):" >&2
+printf '  - %s\n' "${offenders[@]}" >&2
+exit 1

--- a/tests/scripts/run_block_safety.bats
+++ b/tests/scripts/run_block_safety.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-run-block-safety.sh — Issue #400.
+#
+# Exercises the run-block safety guard with synthetic workflow YAML in temporary
+# directories so behaviour (exit codes, reported offenders) is verified
+# end-to-end without mutating the real workflow files. Also asserts the real
+# repository keeps every risk-bearing multi-line run: block under
+# `set -euo pipefail`.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-run-block-safety.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# A symlink block WITHOUT the safety prefix (the drift the audit flagged).
+write_unsafe_symlink_workflow() {
+  cat >"$1" <<'EOF'
+name: Unsafe
+jobs:
+  x:
+    steps:
+      - name: Link NEAT-AI-core sibling path expected by Cargo
+        run: |
+          if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
+            ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
+          fi
+EOF
+}
+
+# The same symlink block WITH the safety prefix.
+write_safe_symlink_workflow() {
+  cat >"$1" <<'EOF'
+name: Safe
+jobs:
+  x:
+    steps:
+      - name: Link NEAT-AI-core sibling path expected by Cargo
+        run: |
+          set -euo pipefail
+          if [ ! -e "$GITHUB_WORKSPACE/../NEAT-AI-core" ]; then
+            ln -s "$GITHUB_WORKSPACE/NEAT-AI-core" "$GITHUB_WORKSPACE/../NEAT-AI-core"
+          fi
+EOF
+}
+
+# A find-*.sh driven block without the prefix (bash-syntax / ShellCheck shape).
+write_unsafe_find_workflow() {
+  cat >"$1" <<'EOF'
+name: Find
+jobs:
+  x:
+    steps:
+      - name: Check bash script syntax
+        run: |
+          EXIT_CODE=0
+          while IFS= read -r script; do
+            bash -n "$script" || EXIT_CODE=1
+          done < <(find . -name "*.sh" -not -path "./target/*")
+          exit $EXIT_CODE
+EOF
+}
+
+# A `sudo rm -rf` block without the prefix (free-disk-space shape).
+write_unsafe_sudo_rm_workflow() {
+  cat >"$1" <<'EOF'
+name: FreeDisk
+jobs:
+  x:
+    steps:
+      - name: Free up runner disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet
+          df -h /
+EOF
+}
+
+# A non-risky multi-line block: a single command spread over line continuations.
+write_benign_continuation_workflow() {
+  cat >"$1" <<'EOF'
+name: Benign
+jobs:
+  x:
+    steps:
+      - name: Run linter
+        run: |
+          cargo clippy --all-targets --all-features -- \
+            -D warnings
+EOF
+}
+
+@test "passes when the symlink block opens with set -euo pipefail" {
+  write_safe_symlink_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "fails when the symlink block omits set -euo pipefail" {
+  write_unsafe_symlink_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"ci.yml"* ]]
+}
+
+@test "fails when a find-*.sh block omits set -euo pipefail" {
+  write_unsafe_find_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+}
+
+@test "fails when a sudo rm -rf block omits set -euo pipefail" {
+  write_unsafe_sudo_rm_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+}
+
+@test "reports every offending block across multiple files" {
+  write_unsafe_symlink_workflow "$TMP_WF/security.yml"
+  write_unsafe_sudo_rm_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"security.yml"* ]]
+  [[ "$output" == *"ci.yml"* ]]
+}
+
+@test "ignores a benign single-command continuation block" {
+  write_benign_continuation_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "reports an error when the workflows directory does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/missing"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "real repository keeps every risk-bearing run: block safe" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Harden multi-line `run:` blocks with `set -euo pipefail`

## Summary

Several multi-line `run:` blocks in the workflow YAML did not begin with
`set -euo pipefail`, so a failing intermediate command could be swallowed and
the step still report success — a "false green" on gating checks and a
never-fail-silently hazard. This change adds `set -euo pipefail` as the first
line of each flagged block and adds a regression guard so the drift cannot
return. Closes #400.

Blocks fixed (matching the audit finding `BP-abcb2822fb7b`):

- `.github/workflows/ci.yml` — the "Link NEAT-AI-core sibling path expected by
  Cargo" symlink step (three copies), "Free up runner disk space"
  (`sudo rm -rf`), "Check bash script syntax" (`find … | while`), and
  "Run ShellCheck" (`find`-driven).
- `.github/workflows/security.yml` and `.github/workflows/sbom.yml` — two more
  copies of the symlink step.

This is drift between copies of the same blocks, not a missing convention:
`auto-format.yml`, `cargo-quality.yml`, `gitleaks.yml` and
`version-increment.yml` already open their multi-line scripts with
`set -euo pipefail`.

## Regression guard

Added `scripts/check-run-block-safety.sh` (wired into `quality.sh` and exercised
by `tests/scripts/run_block_safety.bats`). It scans every workflow for
*risk-bearing* multi-line `run: |` blocks — the NEAT-AI-core symlink
(`ln -s`), `find … -name "*.sh"` shell discovery, and privileged deletion
(`sudo rm -rf`) — and fails (listing each offender as `file:line`) if any does
not open with `set -euo pipefail`. Benign single-command line-continuation
blocks (e.g. a wrapped `cargo clippy` invocation) are deliberately not flagged.

```mermaid
flowchart LR
    A[workflow *.yml] --> B{multi-line run: block?}
    B -- no --> Z[skip]
    B -- yes --> C{risk pattern?<br/>ln -s / find *.sh / sudo rm -rf}
    C -- no --> Z
    C -- yes --> D{first line ==<br/>set -euo pipefail?}
    D -- yes --> OK[pass]
    D -- no --> FAIL[fail: file:line]
```

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via:

- `./scripts/check-run-block-safety.sh` → passes against the real repo after the
  fix; reproduces the failure (`exit 1`, offender listed) against a reverted
  fixture.
- `bats tests/scripts` → all 358 tests pass, including the 9 new
  `run_block_safety.bats` cases.
- `shellcheck --severity=warning` and `bash -n` clean on the new script.
- `actionlint` clean on `ci.yml`, `security.yml`, `sbom.yml`.

## Test Plan

- Added `tests/scripts/run_block_safety.bats`:
  - passes when the symlink block opens with `set -euo pipefail`;
  - fails when the symlink / `find`-`*.sh` / `sudo rm -rf` blocks omit it;
  - reports every offending block across multiple files;
  - ignores a benign single-command continuation block;
  - errors on a missing workflows directory and on an unknown flag;
  - asserts the real repository keeps every risk-bearing block safe.
