### PR TITLE
Drop push-to-Develop trigger from Actionlint lint gate (Issue #369)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -27,7 +27,12 @@ on:
     # PRs would skip this gate; "milestone/**" restores coverage (Issue #390).
     branches: ["*", "milestone/**"]
   push:
-    branches: [main, master, Develop]
+    # Lint gates belong on the PR, not on push to the default branch `Develop`
+    # (Issue #369): a post-merge re-run duplicates the check that already gated
+    # the PR, wasting CI minutes and risking a red tick on `Develop` for a
+    # check that already passed. Keep push coverage for non-default branches
+    # only; deploy/release workflows are different and must keep firing on push.
+    branches: [main, master]
   workflow_dispatch:
 
 # Least-privilege default token scope — actionlint only reads the checked-out

--- a/docs/archive/pr-summaries/pr-summary-369.md
+++ b/docs/archive/pr-summaries/pr-summary-369.md
@@ -1,0 +1,72 @@
+# PR Summary — Issue #369
+
+## Summary
+
+The standalone **Actionlint** lint gate (`.github/workflows/actionlint.yml`)
+still triggered on `push` to the default branch `Develop`. actionlint is a
+checker — it should gate the pull request, not re-run post-merge. The
+push-to-`Develop` trigger duplicated the run that already gated the PR, wasting
+CI minutes and risking a stray red tick on `Develop` for a check that already
+passed.
+
+This PR narrows the `push:` branch filter to non-default branches
+(`[main, master]`), dropping `Develop`, and keeps the `pull_request` and
+`workflow_dispatch` triggers intact so every change is still linted before
+merge. A new validation rule in `scripts/check-actionlint-workflow.sh` (rule 7)
+enforces the invariant so the regression cannot silently return.
+
+Closes #369.
+
+## Change type
+
+Backend/CI configuration — no web interface to screenshot. Verified via the
+shell validator and its BATS suite (see Test Plan).
+
+## What changed
+
+- `.github/workflows/actionlint.yml` — `push.branches` narrowed from
+  `[main, master, Develop]` to `[main, master]`; added a comment explaining why
+  a lint gate must not re-run on push to the default branch.
+- `scripts/check-actionlint-workflow.sh` — added **rule 7**: fail if any
+  `branches:` filter lists the default branch `Develop` (only the push filter
+  ever does).
+- `tests/scripts/actionlint_workflow.bats` — updated the canonical fixture to
+  the fixed push filter, bumped the `OK` marker count to 7, and added a
+  regression test that re-introduces the push-to-`Develop` trigger and asserts
+  the validator fails.
+
+## Trigger behaviour — before vs after
+
+```mermaid
+flowchart LR
+    subgraph Before
+        A1[push to Develop] --> A2[Actionlint re-runs post-merge]
+        A3[pull_request] --> A4[Actionlint gates PR]
+    end
+    subgraph After
+        B1[push to Develop] -. no trigger .-> B2[skipped]
+        B3[pull_request] --> B4[Actionlint gates PR]
+        B5[push to main/master] --> B6[Actionlint runs]
+    end
+```
+
+## Evidence
+
+Validator against the real workflow — rule 7 now reported:
+
+```
+OK   .../actionlint.yml: does not re-trigger on push to the default branch Develop
+```
+
+`actionlint` and `shellcheck` both pass on the modified files.
+
+## Test Plan
+
+- `tests/scripts/actionlint_workflow.bats` — all 12 tests pass, including the
+  new `fails when the push trigger re-runs on the default branch Develop`
+  regression test (fails against the pre-fix filter, passes after the fix).
+- `scripts/check-actionlint-workflow.sh` exits 0 against the real workflow with
+  7 `OK` markers.
+- `shellcheck scripts/check-actionlint-workflow.sh` — clean.
+- `actionlint .github/workflows/actionlint.yml` — clean.
+- `./quality.sh` — full local gate.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.31"
+version = "1.1.32"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-actionlint-workflow.sh
+++ b/scripts/check-actionlint-workflow.sh
@@ -14,6 +14,10 @@
 #   6. Cover milestone/<slug> branches in the pull_request filter so the gate
 #      runs on milestone sub-issue PRs, not only top-level base branches
 #      (Issue #390). A bare "*" glob does not match refs containing a slash.
+#   7. Not re-trigger on push to the default branch `Develop` (Issue #369). A
+#      lint gate belongs on the PR; a post-merge push run duplicates the check
+#      that already gated the PR, wasting CI minutes and risking a stray red
+#      tick on the default branch.
 #
 # The script takes a single optional `--workflow PATH` argument so BATS tests
 # can exercise it against fixtures. When called with no argument it validates
@@ -126,6 +130,20 @@ if grep -qE 'milestone/\*' "$WORKFLOW"; then
   ok "pull_request branch filter covers milestone/* branches"
 else
   fail "pull_request branch filter omits milestone/* — milestone PRs skip the gate"
+fi
+
+# 7. The lint gate must not re-trigger on push to the default branch `Develop`
+#    (Issue #369). actionlint is a checker: it should gate the PR, not re-run
+#    post-merge. A push-to-`Develop` trigger duplicates the run that already
+#    gated the PR — wasting CI minutes and risking a red tick on the default
+#    branch for a check that already passed. Deploy/release workflows differ
+#    (they must keep firing on push); this is a lint gate. Any `branches:`
+#    filter listing `Develop` (only the push filter ever does) fails this rule.
+if grep -E '^[[:space:]]+branches:' "$WORKFLOW" \
+  | grep -qE '(^|[^[:alnum:]_])Develop([^[:alnum:]_]|$)'; then
+  fail "branch filter lists the default branch Develop — a lint gate must not re-run on push to Develop (Issue #369)"
+else
+  ok "does not re-trigger on push to the default branch Develop"
 fi
 
 exit "$EXIT_CODE"

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -28,7 +28,7 @@ on:
   pull_request:
     branches: ["*", "milestone/**"]
   push:
-    branches: [main, master, Develop]
+    branches: [main, master]
 
 permissions:
   contents: read
@@ -62,7 +62,7 @@ EOF
   [ "$status" -eq 0 ]
   # Issue #360: prove every rule was individually evaluated and passed via the
   # machine-checkable "OK   " marker rather than pinning informational wording.
-  [ "$(grep -c '^OK   ' <<<"$output")" -eq 6 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {
@@ -146,6 +146,16 @@ PY
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"milestone"* ]]
+}
+
+@test "fails when the push trigger re-runs on the default branch Develop" {
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  # Re-introduce the pre-fix push-to-Develop trigger (Issue #369): a lint gate
+  # must not re-run on push to the default branch.
+  sed -i.bak 's|branches: \[main, master\]|branches: [main, master, Develop]|' "$TMP_WF/actionlint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Develop"* ]]
 }
 
 @test "reports an error when the workflow file does not exist" {


### PR DESCRIPTION
# PR Summary — Issue #369

## Summary

The standalone **Actionlint** lint gate (`.github/workflows/actionlint.yml`)
still triggered on `push` to the default branch `Develop`. actionlint is a
checker — it should gate the pull request, not re-run post-merge. The
push-to-`Develop` trigger duplicated the run that already gated the PR, wasting
CI minutes and risking a stray red tick on `Develop` for a check that already
passed.

This PR narrows the `push:` branch filter to non-default branches
(`[main, master]`), dropping `Develop`, and keeps the `pull_request` and
`workflow_dispatch` triggers intact so every change is still linted before
merge. A new validation rule in `scripts/check-actionlint-workflow.sh` (rule 7)
enforces the invariant so the regression cannot silently return.

Closes #369.

## Change type

Backend/CI configuration — no web interface to screenshot. Verified via the
shell validator and its BATS suite (see Test Plan).

## What changed

- `.github/workflows/actionlint.yml` — `push.branches` narrowed from
  `[main, master, Develop]` to `[main, master]`; added a comment explaining why
  a lint gate must not re-run on push to the default branch.
- `scripts/check-actionlint-workflow.sh` — added **rule 7**: fail if any
  `branches:` filter lists the default branch `Develop` (only the push filter
  ever does).
- `tests/scripts/actionlint_workflow.bats` — updated the canonical fixture to
  the fixed push filter, bumped the `OK` marker count to 7, and added a
  regression test that re-introduces the push-to-`Develop` trigger and asserts
  the validator fails.

## Trigger behaviour — before vs after

```mermaid
flowchart LR
    subgraph Before
        A1[push to Develop] --> A2[Actionlint re-runs post-merge]
        A3[pull_request] --> A4[Actionlint gates PR]
    end
    subgraph After
        B1[push to Develop] -. no trigger .-> B2[skipped]
        B3[pull_request] --> B4[Actionlint gates PR]
        B5[push to main/master] --> B6[Actionlint runs]
    end
```

## Evidence

Validator against the real workflow — rule 7 now reported:

```
OK   .../actionlint.yml: does not re-trigger on push to the default branch Develop
```

`actionlint` and `shellcheck` both pass on the modified files.

## Test Plan

- `tests/scripts/actionlint_workflow.bats` — all 12 tests pass, including the
  new `fails when the push trigger re-runs on the default branch Develop`
  regression test (fails against the pre-fix filter, passes after the fix).
- `scripts/check-actionlint-workflow.sh` exits 0 against the real workflow with
  7 `OK` markers.
- `shellcheck scripts/check-actionlint-workflow.sh` — clean.
- `actionlint .github/workflows/actionlint.yml` — clean.
- `./quality.sh` — full local gate.
