### PR TITLE
Drop push-to-Develop trigger from CI checker workflow (Issue #370)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,13 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - Develop
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
+  # No `push:` trigger (Issue #370). CI is a checker — the heavy test/lint/scan
+  # gate — so it should gate the pull request, not re-run post-merge. A
+  # push-to-`Develop` trigger duplicated the run that already gated the PR,
+  # wasting CI minutes and risking a red tick on the default branch for a check
+  # that already passed. Deploy/publish/release workflows differ (they must keep
+  # firing on push); this checker fires on `pull_request` and `workflow_dispatch`
+  # only. `scripts/check-ci-push-trigger.sh` guards against re-adding it.
   pull_request:
     types: [opened, synchronize, reopened]
     branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ section to the released version with its date.
 
 ### Changed
 
+- **Drop the push-to-`Develop` trigger from the CI checker workflow (Issue
+  #370).** `ci.yml` runs the heavy test/lint/scan gate; as a *checker* it should
+  gate the pull request, not re-run post-merge. The `push:` trigger targeting the
+  default branch `Develop` duplicated the run that already gated the PR — wasting
+  CI minutes and risking a red tick on `Develop` for a check that already passed.
+  The workflow now fires on `pull_request` and `workflow_dispatch` only.
+  Deploy/publish/release workflows are unaffected (they must keep firing on
+  push). A new guard (`scripts/check-ci-push-trigger.sh`, wired into
+  `quality.sh`, with BATS coverage in `tests/scripts/ci_push_trigger.bats`)
+  rejects any re-added push-to-`Develop` trigger while leaving the legitimate
+  `pull_request` filter on `Develop` untouched.
+
 - **Extract the NEAT-AI-core checkout + symlink block into a local composite
   action (Issue #401).** The "checkout `stSoftwareAU/NEAT-AI-core` + symlink the
   sibling path Cargo expects" pair was copy-pasted across seven call sites in

--- a/docs/archive/pr-summaries/pr-summary-370.md
+++ b/docs/archive/pr-summaries/pr-summary-370.md
@@ -1,0 +1,66 @@
+# Drop push-to-`Develop` trigger from the CI checker workflow (Issue #370)
+
+## Summary
+
+`.github/workflows/ci.yml` runs the heavy test/lint/scan gate. As a **checker**
+it should gate the pull request, not re-run post-merge. It still triggered on
+`push:` to the default branch `Develop`, so every merge into `Develop`
+re-ran the full build — a duplicate of the run that already gated the PR. That
+duplicate post-merge run wastes CI minutes and can leave a red tick on the
+default branch for a check that already passed on the PR.
+
+The fix removes the `push:` block from the workflow's `on:` trigger (it targeted
+only `Develop`), leaving `pull_request` and `workflow_dispatch`. The legitimate
+`pull_request` filter on `Develop`/`milestone/*` is untouched, so PRs into the
+default and milestone branches are still gated. Deploy/publish/release workflows
+are different and must keep firing on push — this change is scoped to the CI
+checker only.
+
+A purpose-built guard, `scripts/check-ci-push-trigger.sh` (wired into
+`quality.sh`), fails loudly if a push-to-`Develop` trigger is ever re-added,
+while deliberately ignoring the `pull_request` filter's legitimate `Develop`
+entry.
+
+Closes #370.
+
+## Change of behaviour
+
+```mermaid
+flowchart LR
+    subgraph Before
+        A1[PR into Develop] --> C1[CI runs]
+        B1[Merge/push to Develop] --> C2[CI runs again<br/>duplicate, wastes minutes]
+    end
+    subgraph After
+        A2[PR into Develop] --> C3[CI runs]
+        B2[Merge/push to Develop] --> C4[No CI re-run<br/>checker gated the PR]
+    end
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the new
+validator and BATS suite (TDD: the repo-workflow test failed before the fix and
+passes after).
+
+Validator against the fixed workflow:
+
+```
+OK   .github/workflows/ci.yml: no push trigger — the checker gates the PR, not push to Develop
+```
+
+## Test Plan
+
+- Added `scripts/check-ci-push-trigger.sh` — scopes strictly to the `on.push`
+  trigger and fails only when the push branch filter lists `Develop`.
+- Added `tests/scripts/ci_push_trigger.bats` covering:
+  - passes when there is no push trigger (checker gates the PR only);
+  - fails when the push trigger targets `Develop` (block form and inline-list
+    form);
+  - passes when push targets only non-default branches (`main`, `master`);
+  - does not confuse the legitimate `pull_request` `Develop` filter for a push
+    trigger;
+  - missing-file / unknown-flag error paths;
+  - the real repository `ci.yml` no longer re-triggers on push to `Develop`
+    (regression test — red before the fix, green after).
+- Wired the validator into `quality.sh` and added a `CHANGELOG.md` entry.

--- a/quality.sh
+++ b/quality.sh
@@ -96,6 +96,9 @@ echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 echo "🧭 Validating CI job dependency graph (Issue #23)..."
 ./scripts/check-ci-job-graph.sh
 
+echo "🚫 Validating CI checker does not re-trigger on push to Develop (Issue #370)..."
+./scripts/check-ci-push-trigger.sh
+
 echo "🎯 Validating CI gates milestone PRs (Issue #393)..."
 ./scripts/check-milestone-branch-filter.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.32"
+version = "1.1.33"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-ci-push-trigger.sh
+++ b/scripts/check-ci-push-trigger.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Validate that the CI checker workflow does not re-trigger on push to the
+# default branch `Develop` (Issue #370).
+#
+# `ci.yml` runs the heavy test/lint/scan gate. As a *checker* it should gate the
+# pull request, not re-run post-merge: a push-to-`Develop` trigger duplicates
+# the run that already gated the PR — wasting CI minutes and risking a red tick
+# on the default branch for a check that already passed. Deploy/publish/release
+# workflows are different (they must keep firing on push); this is a checker.
+#
+# The `pull_request` filter legitimately lists `Develop` (PRs into the default
+# branch must be gated), so this validator scopes strictly to the `on.push`
+# trigger: it fails only when the *push* branch filter lists `Develop`. A
+# workflow with no `push` trigger at all passes — a checker that gates only the
+# PR is exactly the desired end state.
+#
+# This validator is purpose-built: it scans the workflow with a minimal Python
+# scanner rather than pulling in a YAML parser. Designed for reuse from BATS
+# tests and `quality.sh`.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-ci-push-trigger.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Path to the CI workflow YAML file (default:
+                    .github/workflows/ci.yml relative to repo root).
+  -h, --help        Show this message.
+
+Exits 0 when the workflow's on.push trigger does not target the default branch
+`Develop` (or has no push trigger). Exits non-zero with a descriptive message
+when the push branch filter lists `Develop`.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
+fi
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "Workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+# Detect whether a `push:` trigger exists at all, and extract its `branches`
+# list (one entry per line) if present. The scanner walks the `on:` map,
+# descends into `push:`, then collects the `branches:` sequence in both inline
+# (`[a, b]`) and block (`- a`) forms. A leading "PUSH_PRESENT" marker line
+# distinguishes "no push trigger" from "push trigger with an empty filter".
+scan="$(
+  python3 - "$WORKFLOW" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def strip_item(raw: str) -> str:
+    raw = raw.strip()
+    if (raw.startswith('"') and raw.endswith('"')) or (
+        raw.startswith("'") and raw.endswith("'")
+    ):
+        raw = raw[1:-1]
+    return raw
+
+
+# Locate the top-level `on:` map (column 0). Accept only the literal `on:`.
+on_start = None
+for i, line in enumerate(lines):
+    if line.rstrip() == "on:":
+        on_start = i + 1
+        break
+
+if on_start is None:
+    sys.exit(0)
+
+# Walk children of `on:` to find `push:`.
+push_start = None
+push_indent = None
+child_indent = None
+i = on_start
+while i < len(lines):
+    line = lines[i]
+    if not line.strip() or line.lstrip().startswith("#"):
+        i += 1
+        continue
+    ind = indent_of(line)
+    if ind == 0:
+        break  # left the `on:` map
+    if child_indent is None:
+        child_indent = ind
+    if ind == child_indent and line.strip().rstrip(":") == "push":
+        push_start = i + 1
+        push_indent = ind
+        break
+    i += 1
+
+if push_start is None:
+    sys.exit(0)
+
+print("PUSH_PRESENT")
+
+# Walk children of `push:` to find `branches:`.
+i = push_start
+push_child_indent = None
+while i < len(lines):
+    line = lines[i]
+    if not line.strip() or line.lstrip().startswith("#"):
+        i += 1
+        continue
+    ind = indent_of(line)
+    if ind <= push_indent:
+        break  # left the push block
+    if push_child_indent is None:
+        push_child_indent = ind
+    if ind == push_child_indent and line.strip().startswith("branches:"):
+        tail = line.strip()[len("branches:"):].strip()
+        if tail:
+            # inline form: branches: [a, b] or branches: a
+            tail = tail.strip("[]")
+            for item in tail.split(","):
+                item = strip_item(item)
+                if item:
+                    print(item)
+        else:
+            # block sequence form
+            m = i + 1
+            while m < len(lines):
+                nxt = lines[m]
+                if not nxt.strip() or nxt.lstrip().startswith("#"):
+                    m += 1
+                    continue
+                ni = indent_of(nxt)
+                if ni <= push_child_indent:
+                    break
+                if nxt.lstrip().startswith("- "):
+                    print(strip_item(nxt.strip()[2:]))
+                m += 1
+        break
+    i += 1
+PY
+)"
+
+# No `push:` trigger at all — the checker gates only the PR, which is the goal.
+if ! grep -qx 'PUSH_PRESENT' <<<"$scan"; then
+  echo "OK   $WORKFLOW: no push trigger — the checker gates the PR, not push to Develop"
+  exit 0
+fi
+
+branches="$(grep -vx 'PUSH_PRESENT' <<<"$scan" || true)"
+
+if grep -qxE 'Develop' <<<"$branches"; then
+  echo "FAIL $WORKFLOW: on.push.branches lists the default branch Develop — a checker must not re-run on push to Develop (Issue #370)" >&2
+  exit 1
+fi
+
+echo "OK   $WORKFLOW: on.push.branches does not target the default branch Develop"
+exit 0

--- a/tests/scripts/ci_push_trigger.bats
+++ b/tests/scripts/ci_push_trigger.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-ci-push-trigger.sh — Issue #370.
+#
+# Exercises the push-trigger validator with synthetic workflow YAML in
+# temporary directories so behaviour (exit codes, reported failures) is
+# verified end-to-end without depending on the real workflow file's state.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-ci-push-trigger.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Canonical fixed workflow: a checker that gates the PR only, with no push
+# trigger. Failure tests mutate this fixture to reintroduce push-to-Develop.
+write_pr_only_workflow() {
+  local file="$1"
+  cat >"$file" <<'EOF'
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - Develop
+      - milestone/*
+  workflow_dispatch:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+}
+
+@test "passes when there is no push trigger (checker gates the PR only)" {
+  write_pr_only_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/ci.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no push trigger"* ]]
+}
+
+@test "fails when the push trigger targets the default branch Develop (block form)" {
+  cat >"$TMP_WF/ci.yml" <<'EOF'
+name: CI
+
+on:
+  push:
+    branches:
+      - Develop
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    branches:
+      - Develop
+  workflow_dispatch:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/ci.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must not re-run on push to Develop"* ]]
+}
+
+@test "fails when the push trigger targets Develop in inline-list form" {
+  cat >"$TMP_WF/ci.yml" <<'EOF'
+name: CI
+
+on:
+  push:
+    branches: [main, Develop]
+  pull_request:
+    branches: [Develop, "milestone/*"]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/ci.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Develop"* ]]
+}
+
+@test "passes when push targets only non-default branches" {
+  cat >"$TMP_WF/ci.yml" <<'EOF'
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches:
+      - Develop
+  workflow_dispatch:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/ci.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"does not target the default branch Develop"* ]]
+}
+
+@test "does not confuse the pull_request Develop filter for a push trigger" {
+  # pull_request legitimately lists Develop; only the push filter must not.
+  write_pr_only_workflow "$TMP_WF/ci.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/ci.yml"
+  [ "$status" -eq 0 ]
+}
+
+@test "reports an error when the workflow file does not exist" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "the repository CI workflow does not re-trigger on push to Develop" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# Drop push-to-`Develop` trigger from the CI checker workflow (Issue #370)

## Summary

`.github/workflows/ci.yml` runs the heavy test/lint/scan gate. As a **checker**
it should gate the pull request, not re-run post-merge. It still triggered on
`push:` to the default branch `Develop`, so every merge into `Develop`
re-ran the full build — a duplicate of the run that already gated the PR. That
duplicate post-merge run wastes CI minutes and can leave a red tick on the
default branch for a check that already passed on the PR.

The fix removes the `push:` block from the workflow's `on:` trigger (it targeted
only `Develop`), leaving `pull_request` and `workflow_dispatch`. The legitimate
`pull_request` filter on `Develop`/`milestone/*` is untouched, so PRs into the
default and milestone branches are still gated. Deploy/publish/release workflows
are different and must keep firing on push — this change is scoped to the CI
checker only.

A purpose-built guard, `scripts/check-ci-push-trigger.sh` (wired into
`quality.sh`), fails loudly if a push-to-`Develop` trigger is ever re-added,
while deliberately ignoring the `pull_request` filter's legitimate `Develop`
entry.

Closes #370.

## Change of behaviour

```mermaid
flowchart LR
    subgraph Before
        A1[PR into Develop] --> C1[CI runs]
        B1[Merge/push to Develop] --> C2[CI runs again<br/>duplicate, wastes minutes]
    end
    subgraph After
        A2[PR into Develop] --> C3[CI runs]
        B2[Merge/push to Develop] --> C4[No CI re-run<br/>checker gated the PR]
    end
```

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the new
validator and BATS suite (TDD: the repo-workflow test failed before the fix and
passes after).

Validator against the fixed workflow:

```
OK   .github/workflows/ci.yml: no push trigger — the checker gates the PR, not push to Develop
```

## Test Plan

- Added `scripts/check-ci-push-trigger.sh` — scopes strictly to the `on.push`
  trigger and fails only when the push branch filter lists `Develop`.
- Added `tests/scripts/ci_push_trigger.bats` covering:
  - passes when there is no push trigger (checker gates the PR only);
  - fails when the push trigger targets `Develop` (block form and inline-list
    form);
  - passes when push targets only non-default branches (`main`, `master`);
  - does not confuse the legitimate `pull_request` `Develop` filter for a push
    trigger;
  - missing-file / unknown-flag error paths;
  - the real repository `ci.yml` no longer re-triggers on push to `Develop`
    (regression test — red before the fix, green after).
- Wired the validator into `quality.sh` and added a `CHANGELOG.md` entry.
