### PR TITLE
Drop push→Develop trigger from Markdown Lint workflow (Issue #371)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,13 +18,14 @@ name: Markdown Lint
 #   * actions/setup-node — SHA-pinned to v6 (Node 24).
 
 on:
+  # Issue #371: this is a lint/checker workflow, so it gates the pull request
+  # only. It deliberately has no `push:` trigger — a post-merge push run to the
+  # default branch (`Develop`) would just duplicate the run that already gated
+  # the PR, wasting CI minutes and risking a red tick on the default branch for
+  # a check that already passed. (This reverses the Issue #207 push→Develop
+  # policy; deploy/publish workflows still fire on push, a checker does not.)
   pull_request:
     branches: ["*"]
-  push:
-    # Default branch is `Develop`; include legacy names for symmetry with
-    # actionlint.yml so markdown lint also runs on pushes to the real default
-    # branch (Issue #207).
-    branches: [main, master, Develop]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -978,9 +978,11 @@ covered end-to-end by `tests/scripts/semgrep_workflow.bats`.
 A standalone Markdown Lint workflow
 (`.github/workflows/markdown-lint.yml`, Issue #63) runs
 `markdownlint-cli2` against the existing `.markdownlint-cli2.yaml`
-config on every pull request and on pushes to `main`/`master`. The
-workflow keeps README/docs style regressions out of merged commits
-without depending on the full CI graph. It is validated by
+config on every pull request. As a lint/checker it gates the PR only
+and deliberately carries no `push:` trigger (Issue #371) — a post-merge
+push run to the default branch (`Develop`) would just duplicate the run
+that already gated the PR. The workflow keeps README/docs style
+regressions out of merged commits without depending on the full CI graph. It is validated by
 `scripts/check-markdown-lint-workflow.sh` (invoked from `quality.sh`)
 and covered end-to-end by `tests/scripts/markdown_lint_workflow.bats`.
 

--- a/docs/archive/pr-summaries/pr-summary-371.md
+++ b/docs/archive/pr-summaries/pr-summary-371.md
@@ -1,0 +1,62 @@
+# PR Summary — Issue #371
+
+## Summary
+
+The Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) is a
+lint/checker workflow, but it still triggered on `push` to the default branch
+`Develop` (via `branches: [main, master, Develop]`). Once it becomes a required
+status check, every merge into `Develop` re-ran a check that had already gated
+the pull request — wasting CI minutes and risking a red tick on the default
+branch for a check that already passed.
+
+This PR removes the `push:` trigger entirely so the workflow gates the pull
+request only, and updates the per-repo validator + tests + docs to enforce and
+describe the new policy. This deliberately reverses the Issue #207 push→Develop
+policy for this checker (deploy/publish workflows still fire on push; a checker
+does not). `Closes #371`.
+
+## Changes
+
+- **`.github/workflows/markdown-lint.yml`** — dropped the `push:` trigger,
+  keeping `pull_request`. Replaced the Issue #207 comment with an Issue #371
+  explanation of why a checker has no `push:` trigger.
+- **`scripts/check-markdown-lint-workflow.sh`** — inverted rule 6. It now
+  **fails** when a `push:` trigger reaches the default branch `Develop` (or is
+  unfiltered) and **passes** when there is no `push:` trigger or its branches
+  list excludes `Develop`.
+- **`tests/scripts/markdown_lint_workflow.bats`** — canonical fixture no longer
+  carries a `push:` trigger. Replaced the Issue #207 "must target Develop" test
+  with three Issue #371 tests: push→Develop fails, push excluding Develop
+  passes, and an unfiltered push fails. Documented the business-logic reversal
+  inline.
+- **`README.md`** — corrected the Markdown Lint description (PR-gated only, no
+  `push:` trigger).
+
+## Trigger policy
+
+```mermaid
+flowchart LR
+    PR[Pull request] -->|pull_request| MDL[Markdown Lint gate]
+    PUSH[Push to Develop] -.->|no push trigger #371| X[(no duplicate run)]
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+per-repo validator and the BATS suite:
+
+- `scripts/check-markdown-lint-workflow.sh` against the real workflow prints 7
+  `OK` markers and exits 0, including
+  `no push trigger — the lint workflow gates the PR only (Issue #371)`.
+- `bats tests/scripts/markdown_lint_workflow.bats` — 14/14 pass.
+- `shellcheck scripts/check-markdown-lint-workflow.sh` — clean.
+- `markdownlint-cli2` — 0 errors.
+
+## Test Plan
+
+- `tests/scripts/markdown_lint_workflow.bats`:
+  - `fails when the push trigger targets the default branch Develop (Issue #371)`
+  - `passes when a push trigger excludes the default branch Develop (Issue #371)`
+  - `fails when the push trigger has no branches filter (Issue #371)`
+  - `passes on the canonical fixture` (updated fixture, still 7 `OK` markers)
+  - all pre-existing rule tests continue to pass.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.21"
+version = "1.1.22"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-markdown-lint-workflow.sh
+++ b/scripts/check-markdown-lint-workflow.sh
@@ -118,10 +118,17 @@ else
   fail "markdownlint-cli2 is not invoked — no 'run: markdownlint-cli2' step found"
 fi
 
-# 6. push trigger targets the default branch (Develop). Issue #207 — the repo
-#    default is `Develop`, so a push trigger limited to main/master never fires.
-#    Capture the first `branches:` line inside the `push:` block and require it
-#    to list `Develop`.
+# 6. A lint/checker workflow must gate the PR only — it must NOT trigger on
+#    push to the default branch `Develop` (Issue #371, reversing Issue #207).
+#    Once this check is a required status, a post-merge push run only duplicates
+#    the run that already gated the PR: it wastes CI minutes and can leave a red
+#    tick on the default branch for a check that already passed. The PR gate
+#    (rule 1) is the sole gate a checker needs.
+#      * No `push:` trigger              -> pass (PR-gated only).
+#      * `push:` whose branches exclude   -> pass (non-default pushes are fine).
+#        the default branch `Develop`
+#      * `push:` reaching `Develop`, or   -> fail.
+#        an unfiltered `push:`
 if grep -qE '^[[:space:]]+push:' "$WORKFLOW"; then
   push_branches="$(awk '
     /^[[:space:]]+push:[[:space:]]*$/ { in_push = 1; next }
@@ -129,12 +136,14 @@ if grep -qE '^[[:space:]]+push:' "$WORKFLOW"; then
     in_push && /^[^[:space:]#]/ { exit }
   ' "$WORKFLOW")"
   if [[ -z "$push_branches" ]]; then
-    fail "push trigger has no branches list — cannot confirm Develop is covered"
+    fail "push trigger has an unfiltered branches list — a lint/checker workflow must not push to the default branch (Develop); remove push or exclude Develop (Issue #371)"
   elif echo "$push_branches" | grep -q 'Develop'; then
-    ok "push trigger targets the default branch (Develop)"
+    fail "push trigger targets the default branch (Develop) — a lint/checker workflow should gate the PR only (Issue #371)"
   else
-    fail "push trigger does not target Develop — pushes to the default branch are not linted"
+    ok "push trigger excludes the default branch (Develop)"
   fi
+else
+  ok "no push trigger — the lint workflow gates the PR only (Issue #371)"
 fi
 
 exit "$EXIT_CODE"

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -19,6 +19,11 @@ teardown() {
 
 # Canonical hardened workflow. Failure tests mutate this fixture to drop or
 # break one rule at a time.
+#
+# Issue #371: a lint/checker workflow must gate the PR only — it must NOT
+# trigger on push to the default branch `Develop`. The canonical fixture
+# therefore carries no `push:` trigger (this reverses the Issue #207 policy
+# that previously required push→Develop).
 write_markdown_lint_workflow() {
   local file="$1"
   cat >"$file" <<'EOF'
@@ -27,8 +32,6 @@ name: Markdown Lint
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [main, master, Develop]
 
 permissions:
   contents: read
@@ -57,13 +60,69 @@ EOF
   [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
 }
 
-@test "fails when the push trigger omits Develop (Issue #207)" {
+# Business-logic change (Issue #371 reverses Issue #207): a lint/checker
+# workflow must gate the PR only, so a `push:` trigger reaching the default
+# branch `Develop` is now a failure rather than a requirement.
+@test "fails when the push trigger targets the default branch Develop (Issue #371)" {
   write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
-  sed -i.bak 's|branches: \[main, master, Develop\]|branches: [main, master]|' \
-    "$TMP_WF/markdown-lint.yml"
+  # Re-introduce a push→Develop trigger to prove the checker rejects it.
+  python3 - "$TMP_WF/markdown-lint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "on:\n  pull_request:\n    branches: [\"*\"]\n",
+    "on:\n  pull_request:\n    branches: [\"*\"]\n  push:\n    branches: [main, master, Develop]\n",
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"push trigger does not target Develop"* ]]
+  [[ "$output" == *"push trigger targets the default branch (Develop)"* ]]
+}
+
+# A push trigger that excludes the default branch is acceptable — the workflow
+# may still lint pushes to non-default branches without duplicating the PR gate.
+@test "passes when a push trigger excludes the default branch Develop (Issue #371)" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  python3 - "$TMP_WF/markdown-lint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "on:\n  pull_request:\n    branches: [\"*\"]\n",
+    "on:\n  pull_request:\n    branches: [\"*\"]\n  push:\n    branches: [main, master]\n",
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"push trigger excludes the default branch (Develop)"* ]]
+}
+
+# An unfiltered push trigger (no branches list) reaches every branch, including
+# the default — the checker must reject it.
+@test "fails when the push trigger has no branches filter (Issue #371)" {
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  python3 - "$TMP_WF/markdown-lint.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "on:\n  pull_request:\n    branches: [\"*\"]\n",
+    "on:\n  pull_request:\n    branches: [\"*\"]\n  push:\n",
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unfiltered branches list"* ]]
 }
 
 @test "fails when the workflow is not triggered on pull_request" {


### PR DESCRIPTION
# PR Summary — Issue #371

## Summary

The Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) is a
lint/checker workflow, but it still triggered on `push` to the default branch
`Develop` (via `branches: [main, master, Develop]`). Once it becomes a required
status check, every merge into `Develop` re-ran a check that had already gated
the pull request — wasting CI minutes and risking a red tick on the default
branch for a check that already passed.

This PR removes the `push:` trigger entirely so the workflow gates the pull
request only, and updates the per-repo validator + tests + docs to enforce and
describe the new policy. This deliberately reverses the Issue #207 push→Develop
policy for this checker (deploy/publish workflows still fire on push; a checker
does not). `Closes #371`.

## Changes

- **`.github/workflows/markdown-lint.yml`** — dropped the `push:` trigger,
  keeping `pull_request`. Replaced the Issue #207 comment with an Issue #371
  explanation of why a checker has no `push:` trigger.
- **`scripts/check-markdown-lint-workflow.sh`** — inverted rule 6. It now
  **fails** when a `push:` trigger reaches the default branch `Develop` (or is
  unfiltered) and **passes** when there is no `push:` trigger or its branches
  list excludes `Develop`.
- **`tests/scripts/markdown_lint_workflow.bats`** — canonical fixture no longer
  carries a `push:` trigger. Replaced the Issue #207 "must target Develop" test
  with three Issue #371 tests: push→Develop fails, push excluding Develop
  passes, and an unfiltered push fails. Documented the business-logic reversal
  inline.
- **`README.md`** — corrected the Markdown Lint description (PR-gated only, no
  `push:` trigger).

## Trigger policy

```mermaid
flowchart LR
    PR[Pull request] -->|pull_request| MDL[Markdown Lint gate]
    PUSH[Push to Develop] -.->|no push trigger #371| X[(no duplicate run)]
```

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the
per-repo validator and the BATS suite:

- `scripts/check-markdown-lint-workflow.sh` against the real workflow prints 7
  `OK` markers and exits 0, including
  `no push trigger — the lint workflow gates the PR only (Issue #371)`.
- `bats tests/scripts/markdown_lint_workflow.bats` — 14/14 pass.
- `shellcheck scripts/check-markdown-lint-workflow.sh` — clean.
- `markdownlint-cli2` — 0 errors.

## Test Plan

- `tests/scripts/markdown_lint_workflow.bats`:
  - `fails when the push trigger targets the default branch Develop (Issue #371)`
  - `passes when a push trigger excludes the default branch Develop (Issue #371)`
  - `fails when the push trigger has no branches filter (Issue #371)`
  - `passes on the canonical fixture` (updated fixture, still 7 `OK` markers)
  - all pre-existing rule tests continue to pass.
