### PR TITLE
Disable credential persistence for actionlint checkout (Issue #372)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -56,6 +56,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # This job only reads the tree to lint workflow YAML and never pushes
+          # back or fetches a private submodule, so the workflow GITHUB_TOKEN
+          # must not be written to .git/config where a later step could read it
+          # (Issue #372).
+          persist-credentials: false
 
       - name: Install actionlint
         run: |

--- a/docs/archive/pr-summaries/pr-summary-372.md
+++ b/docs/archive/pr-summaries/pr-summary-372.md
@@ -1,0 +1,45 @@
+# Harden `actionlint` checkout — disable credential persistence
+
+## Summary
+
+The `actionlint` workflow's `actions/checkout` step ran without
+`persist-credentials: false`, so `actions/checkout` wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job
+(including a compromised dependency or an injected script) could read it and act
+as the token. This job only reads the tree to lint workflow YAML — it never
+pushes back or fetches a private submodule — so the persisted credential is
+unnecessary and only widens the blast radius of a compromised step.
+
+Added `persist-credentials: false` to the checkout step, matching the
+established pattern already used across `ci.yml`, `security.yml`, `semgrep.yml`,
+`sbom.yml`, `markdown-lint.yml`, and `dependency-review.yml`.
+
+Closes #372.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified with the
+repository's own workflow validators:
+
+- `actionlint .github/workflows/actionlint.yml` — clean.
+- `scripts/check-persist-credentials.sh --workflow .github/workflows/actionlint.yml`
+  →
+  `OK   .github/workflows/actionlint.yml: checkout at line 58 sets persist-credentials: false`
+- `scripts/check-actionlint-workflow.sh` — all structural checks pass
+  (triggers, least-privilege permissions, SHA-pinned checkout, milestone branch
+  filter, no push-to-default-branch trigger).
+
+```mermaid
+flowchart LR
+    A[checkout] -->|persist-credentials: false| B[.git/config has no token]
+    B --> C[Install actionlint]
+    C --> D[Run actionlint]
+```
+
+## Test Plan
+
+- `scripts/check-persist-credentials.sh --workflow .github/workflows/actionlint.yml`
+  now reports the checkout step disables credential persistence (previously it
+  would fail this rule for the file).
+- `actionlint` and `scripts/check-actionlint-workflow.sh` confirm the workflow
+  remains structurally valid after the edit.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.21"
+version = "1.1.22"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."


### PR DESCRIPTION
# Harden `actionlint` checkout — disable credential persistence

## Summary

The `actionlint` workflow's `actions/checkout` step ran without
`persist-credentials: false`, so `actions/checkout` wrote the workflow
`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job
(including a compromised dependency or an injected script) could read it and act
as the token. This job only reads the tree to lint workflow YAML — it never
pushes back or fetches a private submodule — so the persisted credential is
unnecessary and only widens the blast radius of a compromised step.

Added `persist-credentials: false` to the checkout step, matching the
established pattern already used across `ci.yml`, `security.yml`, `semgrep.yml`,
`sbom.yml`, `markdown-lint.yml`, and `dependency-review.yml`.

Closes #372.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified with the
repository's own workflow validators:

- `actionlint .github/workflows/actionlint.yml` — clean.
- `scripts/check-persist-credentials.sh --workflow .github/workflows/actionlint.yml`
  →
  `OK   .github/workflows/actionlint.yml: checkout at line 58 sets persist-credentials: false`
- `scripts/check-actionlint-workflow.sh` — all structural checks pass
  (triggers, least-privilege permissions, SHA-pinned checkout, milestone branch
  filter, no push-to-default-branch trigger).

```mermaid
flowchart LR
    A[checkout] -->|persist-credentials: false| B[.git/config has no token]
    B --> C[Install actionlint]
    C --> D[Run actionlint]
```

## Test Plan

- `scripts/check-persist-credentials.sh --workflow .github/workflows/actionlint.yml`
  now reports the checkout step disables credential persistence (previously it
  would fail this rule for the file).
- `actionlint` and `scripts/check-actionlint-workflow.sh` confirm the workflow
  remains structurally valid after the edit.



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrwj88py-80f3e5`<!-- vibe-worker-issue-372 -->