### PR TITLE
Disable credential persistence for audit checkout (Issue #373)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -46,6 +46,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # Read-only audit job: never pushes back nor fetches private
+          # submodules, so the GITHUB_TOKEN must not be persisted to
+          # `.git/config` where a later step could read it (Issue #373).
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable, frozen 2026-05-18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.21"
+version = "1.1.22"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-369.md
+++ b/docs/archive/pr-summaries/pr-summary-369.md
@@ -54,7 +54,7 @@ flowchart LR
 
 Validator against the real workflow — rule 7 now reported:
 
-```
+```text
 OK   .../actionlint.yml: does not re-trigger on push to the default branch Develop
 ```
 

--- a/docs/archive/pr-summaries/pr-summary-370.md
+++ b/docs/archive/pr-summaries/pr-summary-370.md
@@ -45,7 +45,7 @@ passes after).
 
 Validator against the fixed workflow:
 
-```
+```text
 OK   .github/workflows/ci.yml: no push trigger — the checker gates the PR, not push to Develop
 ```
 

--- a/docs/archive/pr-summaries/pr-summary-373.md
+++ b/docs/archive/pr-summaries/pr-summary-373.md
@@ -1,0 +1,34 @@
+## Summary
+
+The `audit` job in `.github/workflows/cargo-audit.yml` ran `actions/checkout`
+with credential persistence left on (the default). By default checkout writes
+the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where any
+later step in the job — including a compromised dependency — can read it. The
+`audit` job is read-only: it only runs `cargo audit` and never pushes back to
+the repository nor fetches private submodules, so it does not need the persisted
+credential.
+
+This PR adds `persist-credentials: false` to the checkout step so the token is
+no longer written to disk, narrowing the blast radius of a compromised step.
+Mirrors the identical fix applied to the actionlint workflow in Issue #372.
+
+Closes #373.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified with:
+
+- `actionlint .github/workflows/cargo-audit.yml` — passes cleanly.
+- YAML parse check (`yaml.safe_load`) — valid.
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|GITHUB_TOKEN written to .git/config| B[later step can read token]
+    C[persist-credentials: false] -->|token not written to disk| D[reduced blast radius]
+```
+
+## Test Plan
+
+- `actionlint` on the modified workflow to confirm the step remains valid.
+- No Rust code changed, so no new unit tests are applicable; the change is a
+  GitHub Actions security hardening on the checkout step.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.22"
+version = "1.1.23"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."


### PR DESCRIPTION
## Summary

The `audit` job in `.github/workflows/cargo-audit.yml` ran `actions/checkout`
with credential persistence left on (the default). By default checkout writes
the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where any
later step in the job — including a compromised dependency — can read it. The
`audit` job is read-only: it only runs `cargo audit` and never pushes back to
the repository nor fetches private submodules, so it does not need the persisted
credential.

This PR adds `persist-credentials: false` to the checkout step so the token is
no longer written to disk, narrowing the blast radius of a compromised step.
Mirrors the identical fix applied to the actionlint workflow in Issue #372.

Closes #373.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified with:

- `actionlint .github/workflows/cargo-audit.yml` — passes cleanly.
- YAML parse check (`yaml.safe_load`) — valid.

```mermaid
flowchart LR
    A[checkout default] -->|GITHUB_TOKEN written to .git/config| B[later step can read token]
    C[persist-credentials: false] -->|token not written to disk| D[reduced blast radius]
```

## Test Plan

- `actionlint` on the modified workflow to confirm the step remains valid.
- No Rust code changed, so no new unit tests are applicable; the change is a
  GitHub Actions security hardening on the checkout step.