### PR TITLE
Disable credential persistence for cargo-quality checkout (Issue #374)

### DIFF
--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # This job only runs fmt + clippy — it never pushes back to the repo
+          # nor fetches a private submodule, so the GITHUB_TOKEN must not be
+          # persisted to .git/config where a later step could read it (#374).
+          persist-credentials: false
 
       # NEAT-AI-core is a path dependency required for `cargo fmt --all` and
       # `cargo clippy` to resolve the workspace. The checkout + sibling symlink

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,9 +660,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.22"
+version = "1.1.23"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-374.md
+++ b/docs/archive/pr-summaries/pr-summary-374.md
@@ -1,0 +1,51 @@
+## Summary
+
+Job `quality` in `.github/workflows/cargo-quality.yml` checked out the repo with
+`actions/checkout` but did not disable credential persistence. By default
+`actions/checkout` writes the workflow's `GITHUB_TOKEN` into `.git/config` as an
+auth header, where any later step in the job — including a compromised
+dependency or an injected script — can read it and act as the token. This job
+only runs `cargo fmt --check` and `cargo clippy`; it never pushes back to the
+repository nor fetches a private submodule, so the persisted credential is pure
+blast radius.
+
+This PR adds `persist-credentials: false` to the checkout step and extends the
+`check-persist-credentials.sh` guarded-workflow list so `cargo-quality.yml` is
+now enforced alongside `security.yml` and `semgrep.yml`, preventing regression.
+
+Closes #374.
+
+## Change detail
+
+- `.github/workflows/cargo-quality.yml` — checkout step now sets
+  `persist-credentials: false` (with an explanatory comment).
+- `scripts/check-persist-credentials.sh` — `cargo-quality.yml` added to the
+  default guarded-workflow set (plus header/usage text).
+- `tests/scripts/persist_credentials.bats` — new real-repo assertion for
+  `cargo-quality.yml` and the default-run coverage test updated to expect it.
+
+```mermaid
+flowchart LR
+    A[actions/checkout] -->|persist-credentials: true default| B[GITHUB_TOKEN in .git/config]
+    B --> C[Later step reads token]
+    A -->|persist-credentials: false| D[No token on disk]
+    D --> E[fmt + clippy run — no push-back needed]
+```
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified via the
+credential-persistence validator and BATS suite:
+
+- `./scripts/check-persist-credentials.sh` now reports
+  `OK ... cargo-quality.yml: checkout at line 52 sets persist-credentials: false`.
+- `./scripts/check-cargo-quality-workflow.sh` still passes all rules.
+
+## Test Plan
+
+- Added `tests/scripts/persist_credentials.bats::real repository
+  cargo-quality.yml disables credential persistence (Issue #374)` — reproduces
+  the finding (fails before the fix, passes after).
+- Updated `tests/scripts/persist_credentials.bats::default run validates every
+  guarded workflow` to assert `cargo-quality.yml` is now covered.
+- Full `bats tests/scripts/persist_credentials.bats` suite passes (11 tests).

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.23"
+version = "1.1.24"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-persist-credentials.sh
+++ b/scripts/check-persist-credentials.sh
@@ -17,7 +17,8 @@
 #
 # The script takes an optional `--workflow PATH` argument so BATS tests can
 # exercise it against fixtures. With no argument it validates every guarded
-# workflow (`security.yml`, `semgrep.yml`) relative to the repo root.
+# workflow (`security.yml`, `semgrep.yml`, `cargo-quality.yml`) relative to the
+# repo root.
 set -euo pipefail
 
 usage() {
@@ -27,7 +28,8 @@ Usage: check-persist-credentials.sh [--workflow PATH]
 Options:
   --workflow PATH   Path to a single workflow YAML file to validate. When
                     omitted, every guarded workflow under
-                    .github/workflows/ (security.yml, semgrep.yml) is checked.
+                    .github/workflows/ (security.yml, semgrep.yml,
+                    cargo-quality.yml) is checked.
   -h, --help        Show this message.
 
 Exits 0 when every actions/checkout step disables credential persistence (or
@@ -70,6 +72,7 @@ else
   WORKFLOWS=(
     "$SCRIPT_DIR/../.github/workflows/security.yml"
     "$SCRIPT_DIR/../.github/workflows/semgrep.yml"
+    "$SCRIPT_DIR/../.github/workflows/cargo-quality.yml"
   )
 fi
 

--- a/tests/scripts/persist_credentials.bats
+++ b/tests/scripts/persist_credentials.bats
@@ -159,10 +159,17 @@ EOF
   [[ "$output" != *"FAIL"* ]]
 }
 
-@test "default run validates every guarded workflow (security.yml and semgrep.yml)" {
+@test "real repository cargo-quality.yml disables credential persistence (Issue #374)" {
+  run "$SCRIPT_UNDER_TEST" --workflow "${BATS_TEST_DIRNAME}/../../.github/workflows/cargo-quality.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "default run validates every guarded workflow (security.yml, semgrep.yml and cargo-quality.yml)" {
   run "$SCRIPT_UNDER_TEST"
   [ "$status" -eq 0 ]
   [[ "$output" != *"FAIL"* ]]
   [[ "$output" == *"security.yml"* ]]
   [[ "$output" == *"semgrep.yml"* ]]
+  [[ "$output" == *"cargo-quality.yml"* ]]
 }


### PR DESCRIPTION
## Summary

Job `quality` in `.github/workflows/cargo-quality.yml` checked out the repo with
`actions/checkout` but did not disable credential persistence. By default
`actions/checkout` writes the workflow's `GITHUB_TOKEN` into `.git/config` as an
auth header, where any later step in the job — including a compromised
dependency or an injected script — can read it and act as the token. This job
only runs `cargo fmt --check` and `cargo clippy`; it never pushes back to the
repository nor fetches a private submodule, so the persisted credential is pure
blast radius.

This PR adds `persist-credentials: false` to the checkout step and extends the
`check-persist-credentials.sh` guarded-workflow list so `cargo-quality.yml` is
now enforced alongside `security.yml` and `semgrep.yml`, preventing regression.

Closes #374.

## Change detail

- `.github/workflows/cargo-quality.yml` — checkout step now sets
  `persist-credentials: false` (with an explanatory comment).
- `scripts/check-persist-credentials.sh` — `cargo-quality.yml` added to the
  default guarded-workflow set (plus header/usage text).
- `tests/scripts/persist_credentials.bats` — new real-repo assertion for
  `cargo-quality.yml` and the default-run coverage test updated to expect it.

```mermaid
flowchart LR
    A[actions/checkout] -->|persist-credentials: true default| B[GITHUB_TOKEN in .git/config]
    B --> C[Later step reads token]
    A -->|persist-credentials: false| D[No token on disk]
    D --> E[fmt + clippy run — no push-back needed]
```

## Evidence

Backend/CI change — no web interface to screenshot. Verified via the
credential-persistence validator and BATS suite:

- `./scripts/check-persist-credentials.sh` now reports
  `OK ... cargo-quality.yml: checkout at line 52 sets persist-credentials: false`.
- `./scripts/check-cargo-quality-workflow.sh` still passes all rules.

## Test Plan

- Added `tests/scripts/persist_credentials.bats::real repository
  cargo-quality.yml disables credential persistence (Issue #374)` — reproduces
  the finding (fails before the fix, passes after).
- Updated `tests/scripts/persist_credentials.bats::default run validates every
  guarded workflow` to assert `cargo-quality.yml` is now covered.
- Full `bats tests/scripts/persist_credentials.bats` suite passes (11 tests).



## Milestone
This PR is part of the **Audit 21 July** milestone and targets the `milestone/audit-21-july` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrwj88py-80f3e5`<!-- vibe-worker-issue-374 -->