### PR TITLE
Disable credential persistence for quality checkout (Issue #376)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 0
+          # Read-only job (fmt/clippy/build/test/doc/release); never pushes
+          # back, so keep the GITHUB_TOKEN off disk (Issue #376).
+          persist-credentials: false
 
       # Checkout + sibling symlink for the NEAT-AI-core path dependency
       # (Issue #18) live in one local composite action (Issue #401) so the

--- a/docs/archive/pr-summaries/pr-summary-376.md
+++ b/docs/archive/pr-summaries/pr-summary-376.md
@@ -1,0 +1,73 @@
+# Disable credential persistence for the `quality` checkout (Issue #376)
+
+## Summary
+
+The `quality` job in `.github/workflows/ci.yml` checked out with
+`actions/checkout` (`fetch-depth: 0`) but did **not** set
+`persist-credentials: false`. By default `actions/checkout` writes the
+workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
+step in the job — a compromised dependency or an injected script — can read it
+and act as the token. The `quality` job only reads the tree (fmt / clippy /
+build / test / doc / release) and never pushes back or fetches a private
+submodule, so the persisted credential is pure blast radius.
+
+The fix adds `persist-credentials: false` to the `quality` job's "Checkout
+code" step so the token is never written to disk, matching the already-hardened
+`validation` and `spell-check` checkouts in the same workflow.
+
+Closes #376
+
+## Evidence
+
+This is a CI-workflow / shell change with no web interface, so evidence is the
+regression test plus the workflow validators.
+
+Before the fix, the credential-persistence check reported the `quality`
+checkout as unprotected:
+
+```
+FAIL .github/workflows/ci.yml: checkout at line 77 must set 'persist-credentials: false' ...
+```
+
+After the fix, the new BATS regression test passes and `actionlint` is clean:
+
+```
+ok 18 quality self checkout sets persist-credentials: false
+ok 19 parser reports 'no' when the disable flag is absent (guards the assertion)
+actionlint OK
+```
+
+### Token blast-radius before vs after
+
+```mermaid
+flowchart LR
+    subgraph Before[Before]
+        A[actions/checkout] -->|writes GITHUB_TOKEN| B[.git/config]
+        B --> C[Any later step can read token]
+    end
+    subgraph After[After: persist-credentials false]
+        D[actions/checkout] -->|token NOT written| E[.git/config clean]
+        E --> F[Later steps have no token to steal]
+    end
+```
+
+## Test Plan
+
+- Added `tests/scripts/persist_credentials_quality.bats`, which parses the
+  shipped `.github/workflows/ci.yml`, isolates the `quality:` job's self
+  checkout (the `actions/checkout` step with no `repository:` override), and
+  asserts it sets `persist-credentials: false`. The test fails against the
+  unfixed workflow and passes after the fix; a second guard case confirms the
+  parser reports `no` when the flag is absent, so the assertion cannot silently
+  pass.
+- Full `./quality.sh` shell/workflow gate passes: shellcheck,
+  `check-persist-credentials.sh` (default guarded set unchanged),
+  `check-ci-permissions.sh`, workflow timeout / concurrency / job-graph
+  validators, README-CI alignment, codespell, and all BATS suites (382 tests),
+  plus `actionlint .github/workflows/ci.yml`.
+
+## Scope note
+
+Only the `quality` job's checkout was changed. The `shell-checks` self checkout
+(ci.yml:255) is a separate finding tracked under its own issue and is
+intentionally left untouched here.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.22"
+version = "1.1.23"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/tests/scripts/persist_credentials_quality.bats
+++ b/tests/scripts/persist_credentials_quality.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Regression test for Issue #376 — the `quality` job's primary "Checkout code"
+# step must not persist the workflow GITHUB_TOKEN on disk.
+#
+# `actions/checkout` writes the token into `.git/config` by default. The
+# `quality` job only reads the tree (fmt / clippy / build / test / doc /
+# release), never pushes back and never fetches a private submodule through the
+# self checkout, so the credential must be disabled with
+# `persist-credentials: false`.
+#
+# Parses the real ci.yml: isolates the `quality:` job, finds the self checkout
+# step (the one with no `repository:` override), and asserts that same step sets
+# `persist-credentials: false`. Behaviour is asserted against the shipped
+# workflow so the fix and the file cannot drift apart.
+
+setup() {
+  CI_WF="${BATS_TEST_DIRNAME}/../../.github/workflows/ci.yml"
+  export CI_WF
+}
+
+# Emit "yes" iff, inside the `quality` job, the self checkout step (an
+# actions/checkout with no `repository:` override) also sets
+# persist-credentials: false.
+self_checkout_disables_persist() {
+  local file="$1"
+  awk '
+    # Evaluate the just-finished step before opening a new scope.
+    function close_step() {
+      if (is_checkout && is_self && has_disable) found = 1
+    }
+
+    # Track entry/exit of the quality job (2-space indented job key).
+    /^  quality:[[:space:]]*$/ { in_job = 1; next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { if (in_job) { close_step() }; in_job = 0 }
+    in_job == 0 { next }
+
+    # A new step (6-space "- ...") closes the previous step scope.
+    /^      - / {
+      close_step()
+      is_checkout = ($0 ~ /uses:[[:space:]]*actions\/checkout/) ? 1 : 0
+      is_self = 1            # assume self-checkout until a repository: appears
+      has_disable = 0
+    }
+    /uses:[[:space:]]*actions\/checkout/ { is_checkout = 1 }
+    is_checkout && /repository:[[:space:]]/ { is_self = 0 }
+    is_checkout && /persist-credentials:[[:space:]]*false/ { has_disable = 1 }
+
+    END { close_step(); print (found ? "yes" : "no") }
+  ' "$file"
+}
+
+@test "quality self checkout sets persist-credentials: false" {
+  [ -f "$CI_WF" ]
+  run self_checkout_disables_persist "$CI_WF"
+  [ "$status" -eq 0 ]
+  [ "$output" = "yes" ]
+}
+
+@test "parser reports 'no' when the disable flag is absent (guards the assertion)" {
+  local tmp
+  tmp="$(mktemp)"
+  cat >"$tmp" <<'EOF'
+jobs:
+  quality:
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@sha
+      - name: Checkout NEAT-AI-core
+        uses: actions/checkout@sha
+        with:
+          repository: stSoftwareAU/NEAT-AI-core
+          persist-credentials: false
+  security:
+    steps:
+      - run: echo ok
+EOF
+  run self_checkout_disables_persist "$tmp"
+  rm -f "$tmp"
+  [ "$output" = "no" ]
+}


### PR DESCRIPTION
# Disable credential persistence for the `quality` checkout (Issue #376)

## Summary

The `quality` job in `.github/workflows/ci.yml` checked out with
`actions/checkout` (`fetch-depth: 0`) but did **not** set
`persist-credentials: false`. By default `actions/checkout` writes the
workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
step in the job — a compromised dependency or an injected script — can read it
and act as the token. The `quality` job only reads the tree (fmt / clippy /
build / test / doc / release) and never pushes back or fetches a private
submodule, so the persisted credential is pure blast radius.

The fix adds `persist-credentials: false` to the `quality` job's "Checkout
code" step so the token is never written to disk, matching the already-hardened
`validation` and `spell-check` checkouts in the same workflow.

Closes #376

## Evidence

This is a CI-workflow / shell change with no web interface, so evidence is the
regression test plus the workflow validators.

Before the fix, the credential-persistence check reported the `quality`
checkout as unprotected:

```
FAIL .github/workflows/ci.yml: checkout at line 77 must set 'persist-credentials: false' ...
```

After the fix, the new BATS regression test passes and `actionlint` is clean:

```
ok 18 quality self checkout sets persist-credentials: false
ok 19 parser reports 'no' when the disable flag is absent (guards the assertion)
actionlint OK
```

### Token blast-radius before vs after

```mermaid
flowchart LR
    subgraph Before[Before]
        A[actions/checkout] -->|writes GITHUB_TOKEN| B[.git/config]
        B --> C[Any later step can read token]
    end
    subgraph After[After: persist-credentials false]
        D[actions/checkout] -->|token NOT written| E[.git/config clean]
        E --> F[Later steps have no token to steal]
    end
```

## Test Plan

- Added `tests/scripts/persist_credentials_quality.bats`, which parses the
  shipped `.github/workflows/ci.yml`, isolates the `quality:` job's self
  checkout (the `actions/checkout` step with no `repository:` override), and
  asserts it sets `persist-credentials: false`. The test fails against the
  unfixed workflow and passes after the fix; a second guard case confirms the
  parser reports `no` when the flag is absent, so the assertion cannot silently
  pass.
- Full `./quality.sh` shell/workflow gate passes: shellcheck,
  `check-persist-credentials.sh` (default guarded set unchanged),
  `check-ci-permissions.sh`, workflow timeout / concurrency / job-graph
  validators, README-CI alignment, codespell, and all BATS suites (382 tests),
  plus `actionlint .github/workflows/ci.yml`.

## Scope note

Only the `quality` job's checkout was changed. The `shell-checks` self checkout
(ci.yml:255) is a separate finding tracked under its own issue and is
intentionally left untouched here.
