### PR TITLE
Disable credential persistence for shell-checks checkout (Issue #378)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # shell-checks only reads the tree (bash -n / ShellCheck / bats) and
+          # never pushes back or fetches a private submodule, so the workflow
+          # GITHUB_TOKEN must not be written to .git/config where a later step
+          # could read it (Issue #378).
+          persist-credentials: false
 
       # NEAT-AI-core checkout + sibling symlink via the shared composite action
       # (Issue #401) so `cargo metadata` (invoked by cargo_metadata.bats)

--- a/docs/archive/pr-summaries/pr-summary-378.md
+++ b/docs/archive/pr-summaries/pr-summary-378.md
@@ -1,0 +1,69 @@
+# Disable credential persistence for the `shell-checks` checkout
+
+## Summary
+
+The `shell-checks` job in `.github/workflows/ci.yml` ran its main repository
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job — a compromised dependency or an injected script — can
+read it and act as the token. The job only reads the tree (`bash -n`,
+ShellCheck, bats) and never pushes back or fetches a private submodule, so the
+persisted credential is pure blast radius.
+
+This mirrors the fix already applied to the sibling `build`, `validation` and
+`spell-check` jobs (Issues #376, #381, #380). `Closes #378.`
+
+Changes:
+
+- **`.github/workflows/ci.yml`** — add `persist-credentials: false` to the
+  `shell-checks` checkout step, keeping the token off disk for this read-only job.
+- **`scripts/check-persist-credentials.sh`** — add `ci.yml` to the default
+  guarded-workflow set so the local gate (`quality.sh`) and CI enforce that
+  every `ci.yml` checkout disables credential persistence, preventing regression.
+- **`tests/scripts/persist_credentials.bats`** — regression tests.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+Validator now passes against `ci.yml` (previously failed at line 258):
+
+```
+OK   .github/workflows/ci.yml: checkout at line 77 sets persist-credentials: false
+OK   .github/workflows/ci.yml: checkout at line 193 sets persist-credentials: false
+OK   .github/workflows/ci.yml: checkout at line 258 sets persist-credentials: false
+OK   .github/workflows/ci.yml: checkout at line 327 sets persist-credentials: false
+```
+
+Blast-radius reduction:
+
+```mermaid
+flowchart LR
+    subgraph before["Before"]
+        C1[actions/checkout] -->|writes GITHUB_TOKEN| G1[.git/config]
+        G1 -.->|readable| S1[later job step]
+    end
+    subgraph after["After · persist-credentials: false"]
+        C2[actions/checkout] -->|no token written| G2[.git/config clean]
+        S2[later job step] -.->|no token to read| G2
+    end
+```
+
+## Test Plan
+
+Added to `tests/scripts/persist_credentials.bats`:
+
+- `real repository ci.yml disables credential persistence everywhere (Issue #378)`
+  — asserts the validator passes against the shipped `ci.yml`.
+- Extended `default run validates every guarded workflow ...` to require the
+  `ci.yml` line in the default-set output.
+
+Verified TDD RED→GREEN: before the fix the validator failed at `ci.yml:258`;
+after the fix all four checkouts report `persist-credentials: false`. Full
+`bats tests/scripts` suite passes for the changed suites (16/16 across
+`persist_credentials.bats` and `persist_credentials_shell_checks.bats`).
+
+Note: an unrelated, pre-existing flaky test
+(`markdown_lint_workflow.bats` — "gates milestone PRs") intermittently fails in
+full-suite runs on the base branch and passes in isolation; it is untouched by
+this change.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.23"
+version = "1.1.24"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-persist-credentials.sh
+++ b/scripts/check-persist-credentials.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Validate that every `actions/checkout` step in the guarded workflows
-# disables credential persistence (Issues #388, #389).
+# disables credential persistence (Issues #388, #389, #378).
 #
 # Background: by default `actions/checkout` writes the workflow's GITHUB_TOKEN
 # into `.git/config` as an auth header. Any later step in the same job — a
@@ -28,7 +28,7 @@ Usage: check-persist-credentials.sh [--workflow PATH]
 Options:
   --workflow PATH   Path to a single workflow YAML file to validate. When
                     omitted, every guarded workflow under
-                    .github/workflows/ (security.yml, semgrep.yml,
+                    .github/workflows/ (ci.yml, security.yml, semgrep.yml,
                     cargo-quality.yml) is checked.
   -h, --help        Show this message.
 
@@ -63,13 +63,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Build the list of workflows to validate. An explicit --workflow overrides the
-# default set; otherwise every guarded workflow is checked in one run.
+# default set; otherwise every guarded workflow is checked in one run
+# (ci.yml is guarded per Issue #378).
 WORKFLOWS=()
 if [[ -n "$WORKFLOW" ]]; then
   WORKFLOWS=("$WORKFLOW")
 else
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOWS=(
+    "$SCRIPT_DIR/../.github/workflows/ci.yml"
     "$SCRIPT_DIR/../.github/workflows/security.yml"
     "$SCRIPT_DIR/../.github/workflows/semgrep.yml"
     "$SCRIPT_DIR/../.github/workflows/cargo-quality.yml"

--- a/tests/scripts/persist_credentials.bats
+++ b/tests/scripts/persist_credentials.bats
@@ -147,6 +147,12 @@ EOF
   [[ "$output" == *"Usage"* ]]
 }
 
+@test "real repository ci.yml disables credential persistence everywhere (Issue #378)" {
+  run "$SCRIPT_UNDER_TEST" --workflow "${BATS_TEST_DIRNAME}/../../.github/workflows/ci.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
 @test "real repository security.yml disables credential persistence everywhere" {
   run "$SCRIPT_UNDER_TEST" --workflow "${BATS_TEST_DIRNAME}/../../.github/workflows/security.yml"
   [ "$status" -eq 0 ]
@@ -165,10 +171,11 @@ EOF
   [[ "$output" != *"FAIL"* ]]
 }
 
-@test "default run validates every guarded workflow (security.yml, semgrep.yml and cargo-quality.yml)" {
+@test "default run validates every guarded workflow (ci.yml, security.yml, semgrep.yml and cargo-quality.yml)" {
   run "$SCRIPT_UNDER_TEST"
   [ "$status" -eq 0 ]
   [[ "$output" != *"FAIL"* ]]
+  [[ "$output" == *"ci.yml"* ]]
   [[ "$output" == *"security.yml"* ]]
   [[ "$output" == *"semgrep.yml"* ]]
   [[ "$output" == *"cargo-quality.yml"* ]]


### PR DESCRIPTION
# Disable credential persistence for the `shell-checks` checkout

## Summary

The `shell-checks` job in `.github/workflows/ci.yml` ran its main repository
`actions/checkout` without `persist-credentials: false`. By default checkout
writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job — a compromised dependency or an injected script — can
read it and act as the token. The job only reads the tree (`bash -n`,
ShellCheck, bats) and never pushes back or fetches a private submodule, so the
persisted credential is pure blast radius.

This mirrors the fix already applied to the sibling `build`, `validation` and
`spell-check` jobs (Issues #376, #381, #380). `Closes #378.`

Changes:

- **`.github/workflows/ci.yml`** — add `persist-credentials: false` to the
  `shell-checks` checkout step, keeping the token off disk for this read-only job.
- **`scripts/check-persist-credentials.sh`** — add `ci.yml` to the default
  guarded-workflow set so the local gate (`quality.sh`) and CI enforce that
  every `ci.yml` checkout disables credential persistence, preventing regression.
- **`tests/scripts/persist_credentials.bats`** — regression tests.

## Evidence

Backend/CI-only change — no web interface to screenshot.

Validator now passes against `ci.yml` (previously failed at line 258):

```
OK   .github/workflows/ci.yml: checkout at line 77 sets persist-credentials: false
OK   .github/workflows/ci.yml: checkout at line 193 sets persist-credentials: false
OK   .github/workflows/ci.yml: checkout at line 258 sets persist-credentials: false
OK   .github/workflows/ci.yml: checkout at line 327 sets persist-credentials: false
```

Blast-radius reduction:

```mermaid
flowchart LR
    subgraph before["Before"]
        C1[actions/checkout] -->|writes GITHUB_TOKEN| G1[.git/config]
        G1 -.->|readable| S1[later job step]
    end
    subgraph after["After · persist-credentials: false"]
        C2[actions/checkout] -->|no token written| G2[.git/config clean]
        S2[later job step] -.->|no token to read| G2
    end
```

## Test Plan

Added to `tests/scripts/persist_credentials.bats`:

- `real repository ci.yml disables credential persistence everywhere (Issue #378)`
  — asserts the validator passes against the shipped `ci.yml`.
- Extended `default run validates every guarded workflow ...` to require the
  `ci.yml` line in the default-set output.

Verified TDD RED→GREEN: before the fix the validator failed at `ci.yml:258`;
after the fix all four checkouts report `persist-credentials: false`. Full
`bats tests/scripts` suite passes for the changed suites (16/16 across
`persist_credentials.bats` and `persist_credentials_shell_checks.bats`).

Note: an unrelated, pre-existing flaky test
(`markdown_lint_workflow.bats` — "gates milestone PRs") intermittently fails in
full-suite runs on the base branch and passes in isolation; it is untouched by
this change.
