### PR TITLE
Push auto-format/version bumps with ACTIONS_PUSH (Issue #435)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -35,8 +35,8 @@ jobs:
     name: Auto-format Code
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Skip forks — GITHUB_TOKEN cannot push to a fork's branch. Formatting
-    # on fork PRs is the author's responsibility.
+    # Skip forks — neither GITHUB_TOKEN nor ACTIONS_PUSH can push to a
+    # fork's branch. Formatting on fork PRs is the author's responsibility.
     if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
@@ -45,7 +45,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Keep the job token off disk; push auth is injected only below
+          # via ACTIONS_PUSH (Issue #435 / NEAT-AI ACTIONS_PUSH pattern).
+          persist-credentials: false
 
       # NEAT-AI-core is a path dependency required for `cargo fmt --all` to
       # resolve the workspace. The checkout + sibling symlink live in the
@@ -73,14 +75,24 @@ jobs:
             echo "changed=false" >>"$GITHUB_OUTPUT"
           fi
 
+      # Push with the org-level ACTIONS_PUSH PAT so the resulting
+      # `synchronize` event is attributed to a trusted identity and PR
+      # checks run without the "Awaiting approval / Approve and run" gate
+      # that GITHUB_TOKEN bot pushes create (Issue #435). Fall back to
+      # GITHUB_TOKEN only when the secret is unset. The PAT is passed via
+      # env + a per-command extraheader so it never lives in `.git/config`
+      # (mirrors NEAT-AI update-package-version.yml).
       - name: Commit and push rustfmt fixes
         if: steps.detect.outputs.changed == 'true'
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           msg="$(./scripts/auto-format.sh --commit-message)"
           git commit -am "$msg"
-          git push origin "HEAD:$PR_HEAD_REF"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PAT" | base64 -w0)"
+          git -c http.https://github.com/.extraheader="$AUTH_HEADER" \
+            push origin "HEAD:$PR_HEAD_REF"

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -37,8 +37,8 @@ jobs:
     name: Version Bump Guard
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Never attempt to push onto a fork's branch — the GITHUB_TOKEN cannot
-    # write there, and bump-on-fork is the PR author's responsibility.
+    # Never attempt to push onto a fork's branch — bump-on-fork is the
+    # PR author's responsibility.
     if: github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       should_bump: ${{ steps.check.outputs.should_bump }}
@@ -49,6 +49,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch base ref
         env:
@@ -91,7 +92,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Keep the job token off disk; push auth is injected only below
+          # via ACTIONS_PUSH (Issue #435 / NEAT-AI ACTIONS_PUSH pattern).
+          persist-credentials: false
 
       - name: Fetch base ref
         env:
@@ -118,11 +121,19 @@ jobs:
             echo "changed=true" >>"$GITHUB_OUTPUT"
           fi
 
+      # Push with the org-level ACTIONS_PUSH PAT so the resulting
+      # `synchronize` event is attributed to a trusted identity and PR
+      # checks run without the "Awaiting approval / Approve and run" gate
+      # that GITHUB_TOKEN bot pushes create (Issue #435). Fall back to
+      # GITHUB_TOKEN only when the secret is unset. The PAT is passed via
+      # env + a per-command extraheader so it never lives in `.git/config`
+      # (mirrors NEAT-AI update-package-version.yml).
       - name: Commit and push bump
         if: steps.bump.outputs.changed == 'true'
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           NEXT_VERSION: ${{ needs.guard.outputs.next_version }}
+          GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -131,4 +142,6 @@ jobs:
           git commit -m "chore: auto-bump rust_scorer version to ${NEXT_VERSION}
 
           Closes part of #20 — guarded auto-version increment."
-          git push origin "HEAD:$PR_HEAD_REF"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PAT" | base64 -w0)"
+          git -c http.https://github.com/.extraheader="$AUTH_HEADER" \
+            push origin "HEAD:$PR_HEAD_REF"

--- a/README.md
+++ b/README.md
@@ -854,7 +854,9 @@ the patch component once and pushes that commit back to the PR branch. A
 re-run of CI — or a human-authored bump on the same branch — short-circuits
 the job, so no duplicate bump commits are produced. The underlying logic
 lives in `scripts/version-increment.sh` and is covered by
-`tests/scripts/version_increment.bats`.
+`tests/scripts/version_increment.bats`. Bot pushes authenticate with the
+org-level `ACTIONS_PUSH` PAT (falling back to `GITHUB_TOKEN` when unset) so
+the follow-on PR checks run without an "Approve and run" gate (Issue #435).
 
 PRs also run an auto-format job (`.github/workflows/auto-format.yml`,
 Issue #19). The job runs `cargo fmt --all` on the PR branch; if the working
@@ -863,7 +865,8 @@ and pushed back. When there are no changes the commit step is skipped, so
 re-running on a clean branch is a no-op. Change detection and the commit
 message live in `scripts/auto-format.sh` and are covered by
 `tests/scripts/auto_format.bats`; the workflow itself is validated by
-`scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`).
+`scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`). The same
+`ACTIONS_PUSH` push token pattern applies here (Issue #435).
 
 A standalone Cargo Security Audit workflow (`.github/workflows/cargo-audit.yml`,
 Issue #64) runs a prebuilt `cargo audit` on every PR (against `*` and

--- a/quality.sh
+++ b/quality.sh
@@ -93,6 +93,9 @@ echo "🔒 Validating SECURITY.md vulnerability disclosure policy (Issue #177)..
 echo "🪄 Validating auto-format PR workflow (Issue #19)..."
 ./scripts/check-auto-format-workflow.sh
 
+echo "🔑 Validating bot-push workflows use ACTIONS_PUSH (Issue #435)..."
+./scripts/check-bot-push-token.sh
+
 echo "🧭 Validating CI job dependency graph (Issue #23)..."
 ./scripts/check-ci-job-graph.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.27"
+version = "1.1.28"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-auto-format-workflow.sh
+++ b/scripts/check-auto-format-workflow.sh
@@ -12,6 +12,9 @@
 #      job is idempotent — re-running on a clean branch is a no-op.
 #   5. Refuse to push onto a fork's PR branch (the GITHUB_TOKEN cannot
 #      write there anyway; skipping keeps failure messages tidy).
+#   6. Authenticate the push with the org-level ACTIONS_PUSH PAT (with
+#      GITHUB_TOKEN fallback) so bot `synchronize` events re-trigger PR
+#      checks without the "Approve and run" gate (Issue #435).
 set -euo pipefail
 
 usage() {
@@ -119,6 +122,17 @@ if grep -qE 'set[[:space:]]+-euo[[:space:]]+pipefail' "$WORKFLOW"; then
   ok "strict bash (set -euo pipefail) present"
 else
   fail "no 'set -euo pipefail' in run: blocks — failures may be swallowed"
+fi
+
+# 7. Bot push must use ACTIONS_PUSH (org PAT) with GITHUB_TOKEN fallback.
+#    A bare GITHUB_TOKEN push attributes the synchronize event to
+#    github-actions[bot] and leaves required checks "awaiting approval"
+#    (Issue #435). Accept either the expression form or a GH_PAT env that
+#    references ACTIONS_PUSH.
+if grep -qE 'secrets\.ACTIONS_PUSH[[:space:]]*\|\|[[:space:]]*secrets\.GITHUB_TOKEN' "$WORKFLOW"; then
+  ok "push authenticates with ACTIONS_PUSH (GITHUB_TOKEN fallback)"
+else
+  fail "no 'secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN' — bot pushes will gate PR checks behind Approve and run (Issue #435)"
 fi
 
 exit "$EXIT_CODE"

--- a/scripts/check-bot-push-token.sh
+++ b/scripts/check-bot-push-token.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Validate that bot-push PR workflows authenticate with ACTIONS_PUSH
+# (Issue #435).
+#
+# Auto Format and Version Increment commit back to the PR branch. A push
+# authenticated only with GITHUB_TOKEN attributes the resulting
+# `synchronize` event to github-actions[bot], and GitHub holds the
+# follow-on required checks behind "N checks awaiting approval /
+# Approve and run". NEAT-AI avoids this by pushing with the org-level
+# ACTIONS_PUSH PAT (GITHUB_TOKEN fallback when unset).
+#
+# Rule: each guarded workflow must reference
+# `secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN`.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-bot-push-token.sh [--workflow PATH]
+
+Options:
+  --workflow PATH   Validate a single workflow YAML file. When omitted,
+                    both auto-format.yml and version-increment.yml under
+                    .github/workflows/ are checked.
+  -h, --help        Show this message.
+
+Exits 0 when every target workflow authenticates bot pushes with
+ACTIONS_PUSH (GITHUB_TOKEN fallback). Exits non-zero otherwise.
+EOF
+}
+
+WORKFLOW=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflow)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --workflow" >&2
+        usage >&2
+        exit 2
+      fi
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+WORKFLOWS=()
+if [[ -n "$WORKFLOW" ]]; then
+  WORKFLOWS=("$WORKFLOW")
+else
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  WORKFLOWS=(
+    "$SCRIPT_DIR/../.github/workflows/auto-format.yml"
+    "$SCRIPT_DIR/../.github/workflows/version-increment.yml"
+  )
+fi
+
+EXIT_CODE=0
+
+validate_workflow() {
+  local wf="$1"
+
+  if [[ ! -f "$wf" ]]; then
+    echo "Workflow file not found: $wf" >&2
+    EXIT_CODE=2
+    return
+  fi
+
+  if grep -qE 'secrets\.ACTIONS_PUSH[[:space:]]*\|\|[[:space:]]*secrets\.GITHUB_TOKEN' "$wf"; then
+    echo "OK   $wf: push authenticates with ACTIONS_PUSH (GITHUB_TOKEN fallback)"
+  else
+    echo "FAIL $wf: no 'secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN' — bot pushes will gate PR checks behind Approve and run (Issue #435)" >&2
+    EXIT_CODE=1
+  fi
+}
+
+for wf in "${WORKFLOWS[@]}"; do
+  validate_workflow "$wf"
+done
+
+exit "$EXIT_CODE"

--- a/tests/scripts/auto_format.bats
+++ b/tests/scripts/auto_format.bats
@@ -118,7 +118,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -138,13 +138,17 @@ jobs:
           fi
       - name: Commit and push rustfmt fixes
         if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           msg="$(./scripts/auto-format.sh --commit-message)"
           git commit -am "$msg"
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PAT" | base64 -w0)"
+          git -c http.https://github.com/.extraheader="$AUTH_HEADER" \
+            push origin "HEAD:${{ github.event.pull_request.head.ref }}"
 EOF
 }
 
@@ -267,6 +271,43 @@ EOF
   run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"fork"* || "$output" == *"head.repo"* ]]
+}
+
+@test "workflow validator fails when ACTIONS_PUSH push token is missing" {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+name: Auto Format
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: write
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+      - name: Apply cargo fmt
+        run: |
+          set -euo pipefail
+          cargo fmt --all
+      - name: Detect formatting changes
+        id: detect
+        run: |
+          set -euo pipefail
+          echo "changed=true" >>"$GITHUB_OUTPUT"
+      - name: Commit and push
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git commit -am "fmt"
+          git push
+EOF
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ACTIONS_PUSH"* || "$output" == *"Approve and run"* ]]
 }
 
 @test "real repository auto-format workflow validates cleanly" {

--- a/tests/scripts/bot_push_token.bats
+++ b/tests/scripts/bot_push_token.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-bot-push-token.sh (Issue #435).
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-bot-push-token.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+  TMP_WF="$(mktemp -d)"
+  export TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+@test "passes when workflow uses ACTIONS_PUSH with GITHUB_TOKEN fallback" {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+jobs:
+  push:
+    steps:
+      - name: Push
+        env:
+          GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
+        run: git push
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "fails when workflow only uses GITHUB_TOKEN" {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+jobs:
+  push:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push
+        run: git push
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ACTIONS_PUSH"* ]]
+}
+
+@test "shipped auto-format and version-increment workflows validate cleanly" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"auto-format.yml"* ]]
+  [[ "$output" == *"version-increment.yml"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
## Summary
- Root cause of the "N checks awaiting approval / Approve and run" banner was **not** the fork-contributor Actions setting (it already matches NEAT-AI). Auto Format and Version Increment were pushing with `GITHUB_TOKEN`, so follow-on `synchronize` checks were attributed to `github-actions[bot]` and held for approval (89 historical `action_required` runs).
- Authenticate those pushes with the org-level `ACTIONS_PUSH` PAT (GITHUB_TOKEN fallback), injected only at push time via `http.extraheader` so the PAT never lands in `.git/config` — same pattern as [NEAT-AI `update-package-version.yml`](https://github.com/stSoftwareAU/NEAT-AI).
- Add `scripts/check-bot-push-token.sh` (+ bats) and extend the auto-format validator so the pattern cannot regress.

## Test plan
- [x] `./scripts/check-auto-format-workflow.sh`
- [x] `./scripts/check-bot-push-token.sh`
- [x] `bats tests/scripts/auto_format.bats tests/scripts/bot_push_token.bats`
- [x] `actionlint` on the two workflows
- [ ] Confirm org secret `ACTIONS_PUSH` is available to **NEAT-AI-scorer** (Settings → Secrets → Actions, or org secret "Repository access"). If unset, the `|| GITHUB_TOKEN` fallback keeps today's behaviour.
- [ ] On this PR: after Auto Format / Version Increment push, checks should start without an Approve-and-run click.

Closes #435


Made with [Cursor](https://cursor.com)