### PR TITLE
Reword private GRQ/GRQ-cluster references in README.md to concept level (Issue #450)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.2.17"
+version = "0.2.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.28"
+version = "1.1.29"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ flag wins over the `NEAT_SCORER_GPU` environment variable.
 
 | Mode    | Behaviour                                                                                                       | `gpuBackend` value                                  |
 |---------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| `auto`  | **Default since Issue #83.** Use GPU on directory paths with **AllPrivate** topology (≤256 total neurons per creature); fall back to CPU for scratch/mixed GRQ-scale pools (#317), GPU-unsupported costs (any cost other than MSE/RMSE/MAE), missing adapters, or failed pre-flight. Prints one stderr note when declining GPU for topology. | `"metal"` / `"vulkan"` / `"dx12"` / `"gl"` / `"cpu-fallback"` |
+| `auto`  | **Default since Issue #83.** Use GPU on directory paths with **AllPrivate** topology (≤256 total neurons per creature); fall back to CPU for scratch/mixed production-scale pools (#317), GPU-unsupported costs (any cost other than MSE/RMSE/MAE), missing adapters, or failed pre-flight. Prints one stderr note when declining GPU for topology. | `"metal"` / `"vulkan"` / `"dx12"` / `"gl"` / `"cpu-fallback"` |
 | `on`    | Require a compatible GPU; exit non-zero with a clear message when none is found (no silent fallback). Forces the GPU path even where bench evidence does not support it. | `"metal"` / `"vulkan"` / `"dx12"` / `"gl"`          |
 | `off`   | Skip GPU detection entirely; run the CPU pipeline.                                                             | `"cpu-fallback"`                                    |
 
@@ -159,7 +159,7 @@ neuron count) routes straight to the CPU pipeline without ever spinning up —
 or tearing down — a GPU context, so the fallback always returns valid JSON
 and exits cleanly. Since Issue #182 the 256-neuron cap is no longer a reason
 to fall back (see below). Issue #317 adds a **topology probe** before GPU
-device creation: GRQ-scale creatures (total neurons >256, including inputs)
+device creation: production-scale creatures (total neurons >256, including inputs)
 classify as **ScratchOnly** and `Auto` stays on CPU — full-corpus M4 A/B
 showed CPU ~3× faster than scratch GPU even with dual-kernel dispatch and
 32 MiB read chunks. `--gpu on` still runs the scratch kernel for debug.
@@ -179,7 +179,7 @@ requires editing that function plus the matching row in the docs table
 |------------------------------------|-------------------------|----------------|--------------|
 | `score_from_json_fused` (single)   | GPU loses               | **CPU**        | Issue #81 (negative result) |
 | `score_from_creature_dir` (N=50, AllPrivate) | **GPU −32.4 %** (Metal) | **GPU**        | Issue #82 PR summary |
-| `score_from_creature_dir` (N=63, GRQ scratch) | **CPU ~3× faster** (full corpus) | **CPU** | Issue #317 |
+| `score_from_creature_dir` (N=63, production scratch) | **CPU ~3× faster** (full corpus) | **CPU** | Issue #317 |
 
 `Auto` selects per **path** (single vs directory), not per N — at N=10 the
 per-dispatch overhead dominates, but at the issue-target corpus the
@@ -252,7 +252,7 @@ selecting the positive or negative sum on the condition sign. This matches
 `neat_core::batch_scoring::neuron_activation_scalar` exactly, so `SynapseGpu`
 now carries a `synapse_type` field. **Constant neurons** are hosted too
 (flagged by `NeuronGpu.is_constant`): the kernel returns their clamped bias and
-ignores their synapses. Together these make the real GRQ-cluster creature
+ignores their synapses. Together these make the real production creature
 (aggregates + three constant neurons) fully GPU-hostable. The remaining three
 aggregates **HYPOT / HYPOTv2 / MEAN (35..=37)** are still unhosted and force a
 clean CPU fallback via `squash_supported`.
@@ -327,7 +327,7 @@ forward pass and then reduce a per-record loss selected by the shader's
   both are GPU-supported at identical speed.
 - `MAE` (Issue #316) accumulates the **absolute-error sum** on the same forward
   pass, so it is GPU-hosted on both kernels — including the > 256-neuron scratch
-  path used by production GRQ creatures — at MSE-class speed.
+  path used by production-scale creatures — at MSE-class speed.
 
 Every **other** (non-`MSE`, non-`RMSE`, non-`MAE`) `--cost` selection forces the
 CPU pipeline:
@@ -339,7 +339,7 @@ CPU pipeline:
   informational `[gpu] auto fallback ...` line to stderr naming the
   cost as the reason (Issue #205), so the CPU choice is not silent;
   MSE / RMSE / MAE (GPU-supported costs) print nothing extra. (An
-  `AllPrivate` pool runs on GPU; `Mixed`/`ScratchOnly` GRQ-scale pools still
+  `AllPrivate` pool runs on GPU; `Mixed`/`ScratchOnly` production-scale pools still
   fall back to CPU for **topology** reasons per Issue #317, independent of cost.)
 - Under `--gpu on` a GPU-unsupported cost is a hard error before any scoring
   runs (no silent downgrade — `--gpu on` is a strict requirement).
@@ -418,7 +418,7 @@ score stays stable:
 | `0.1`           | 150,000        | 0.021 s    | 5.67×    |
 
 > **Production gate (needs production data + a human).** Lighting this up on the
-> real GRQ corpus is gated on ≥ 5 % `evolveDir` wall-clock **and** rank
+> real production corpus is gated on ≥ 5 % `evolveDir` wall-clock **and** rank
 > correlation (Spearman/pairwise) of subsample vs full ≥ 0.95, published on
 > NEAT-AI#3256 / #3257. The scorer does **not** auto-release — the consumer bumps
 > to a released scorer through the normal dependency-bump flow once a human cuts
@@ -445,11 +445,11 @@ In directory mode, output is a top-level object keyed by creature filename stem,
 
 ```json
 {
-  "GRQ-10-1": {
+  "creature-10-1": {
     "score": 0.9999998,
     "error": 0.0
   },
-  "GRQ-12-1": {
+  "creature-12-1": {
     "score": 0.9999998,
     "error": 0.0
   }
@@ -544,7 +544,7 @@ warning.
 ### Large-record hosts: raise `NEAT_SCORER_READ_BYTES` (Issue #307)
 
 The default `NEAT_SCORER_READ_BYTES` (2 MiB) is tuned for the synthetic
-small-record fixtures. **Production GRQ-cluster records are 9848 bytes**
+small-record fixtures. **Production records are 9848 bytes**
 (2461 inputs + 1 output, `f32`), so a 2 MiB chunk holds only ~213 records —
 too few to amortise the per-chunk Rayon dispatch across the worker pool. A
 sweep on the #296 production fixture (see
@@ -565,7 +565,7 @@ back-to-back on one Apple Silicon host; absolute times are host-load
 sensitive, so the table reports the relative improvement each cell held across
 repeated interleaved runs.)
 
-On GRQ hosts with these large records, export a bigger chunk before scoring:
+On production hosts with these large records, export a bigger chunk before scoring:
 
 ```bash
 # ~24 % faster forward-only scoring on 9848-byte production records.
@@ -577,7 +577,7 @@ buffer. The read buffer is **per-scan, not per-worker** — directory mode runs
 a single shared scan and partitions the unpacked records across the worker
 pool — so a 32 MiB setting adds at most ~64 MiB of transient buffer (the
 pipelined path double-buffers), not 32 MiB × worker count. That stays well
-within GRQ host RAM headroom.
+within production host RAM headroom.
 
 The global default is intentionally **left at 2 MiB**: the gain is specific to
 large (> ~1 KiB) records, and raising it globally would enlarge the buffer for

--- a/docs/archive/pr-summaries/pr-summary-450.md
+++ b/docs/archive/pr-summaries/pr-summary-450.md
@@ -1,0 +1,64 @@
+## Summary
+
+`README.md` named the **private** `stSoftwareAU/GRQ` and `stSoftwareAU/GRQ-cluster`
+repositories in public documentation — check 3 of the private-repo-reference audit.
+Reworded all 12 mentions to concept-level phrasing ("production creature",
+"production-scale pools", "production hosts", record byte size) so the public README
+stays fully self-contained, and added a permanent guard so the references cannot
+creep back in. No code or runtime behaviour changed.
+
+Closes #450.
+
+Rewording (same style as the sibling `docs/performance-baseline.md` change, Issue #449):
+
+| Before | After |
+|---|---|
+| scratch/mixed **GRQ-scale** pools | scratch/mixed **production-scale** pools |
+| **GRQ-scale** creatures (total neurons >256) | **production-scale** creatures (total neurons >256) |
+| `score_from_creature_dir` (N=63, **GRQ** scratch) | `score_from_creature_dir` (N=63, **production** scratch) |
+| the real **GRQ-cluster** creature | the real **production** creature |
+| production **GRQ** creatures | **production-scale** creatures |
+| the real **GRQ** corpus | the real **production** corpus |
+| `"GRQ-10-1"` / `"GRQ-12-1"` JSON keys | `"creature-10-1"` / `"creature-12-1"` |
+| Production **GRQ-cluster** records are 9848 bytes | Production records are 9848 bytes |
+| On **GRQ** hosts / within **GRQ** host RAM headroom | On **production** hosts / within **production** host RAM headroom |
+
+The `NEAT-AI*` dependency-table rows (public repos) and the
+`stSoftwareAU/VibeCoding#1613` reference (tracked separately) are untouched, as the
+issue specifies.
+
+## Evidence
+
+Documentation-only change — there is no web interface to screenshot. Verified by the
+new regression guard and the full local gate:
+
+- `scripts/check-readme-private-repo-refs.sh` — exits 1 with every offending line when
+  the README names `GRQ` / `GRQ-cluster`, exits 0 on the current README. Fails loud on a
+  missing README (exit 1) and on an unknown argument (exit 2).
+- Wired into `quality.sh`; CI already runs `bats tests/scripts`, and the suite includes a
+  test asserting the **shipped** README passes the guard, so CI enforces it on every PR.
+- `./quality.sh < /dev/null` → `✅ All quality checks passed!` (shellcheck, bats, fmt,
+  clippy, tests, rustdoc, release build).
+
+```mermaid
+flowchart LR
+    A[README.md edit] --> B[scripts/check-readme-private-repo-refs.sh]
+    B -->|private name found| C[exit 1 — fail loud]
+    B -->|clean| D[exit 0]
+    B --- E[quality.sh + CI bats job]
+```
+
+## Test Plan
+
+Added `tests/scripts/readme_private_repo_refs.bats` (7 tests, all passing):
+
+- passes on a README with concept-level production wording
+- fails when the README names the private `GRQ` repo
+- fails when the README names the private `GRQ-cluster` repo
+- reports every offending line, not just the first
+- fails loudly when the README path does not exist
+- rejects an unknown argument with a usage error
+- the shipped `README.md` passes the guard (regression test for this issue — it fails
+  against the pre-fix README and passes after the rewording)
+
+No existing tests were modified or removed.

--- a/quality.sh
+++ b/quality.sh
@@ -132,6 +132,9 @@ echo "🛟 Validating risk-bearing multi-line run: blocks open with set -euo pip
 echo "📖 Validating README 'matches CI' block aligns with the CI quality job (Issue #212)..."
 ./scripts/check-readme-ci-alignment.sh
 
+echo "🕵️  Validating README names no private repository (Issue #450)..."
+./scripts/check-readme-private-repo-refs.sh
+
 echo "📝 Running codespell preflight (mirrors CI spell-check job)..."
 if ! ./scripts/spell-check.sh; then
   echo "spell-check: FAILED — fix the typos above or update .codespellrc (see README)."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.29"
+version = "1.1.30"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-readme-private-repo-refs.sh
+++ b/scripts/check-readme-private-repo-refs.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# check-readme-private-repo-refs.sh — Issue #450.
+#
+# Guards the public README against naming the private `stSoftwareAU/GRQ` and
+# `stSoftwareAU/GRQ-cluster` repositories. A public repo must be
+# self-contained: naming a private repo points every public reader at
+# something they cannot see. Production behaviour is documented at concept
+# level instead ("production creature", "production-scale pools", record byte
+# size), so no private repo name is needed.
+#
+# Usage:
+#   check-readme-private-repo-refs.sh [--readme PATH]
+#
+# Exit codes:
+#   0  no private repo name found
+#   1  at least one private repo name found
+#   2  usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+README="$REPO_ROOT/README.md"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --readme)
+      [ $# -ge 2 ] || { echo "Usage: $0 [--readme PATH]" >&2; exit 2; }
+      README="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--readme PATH]"
+      exit 0
+      ;;
+    *)
+      echo "Usage: $0 [--readme PATH]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "$README" ]; then
+  echo "❌ README not found: $README" >&2
+  exit 1
+fi
+
+# Private repo names, matched case-sensitively as whole words so ordinary
+# prose is unaffected.
+PRIVATE_PATTERN='\bGRQ(-cluster)?\b'
+
+if matches="$(grep -nE "$PRIVATE_PATTERN" "$README")"; then
+  echo "❌ README names a private repository (Issue #450):" >&2
+  echo "$matches" >&2
+  echo >&2
+  echo "   Reword to concept level — describe the production creature, corpus" >&2
+  echo "   record size and topology by their properties, without naming the" >&2
+  echo "   private stSoftwareAU/GRQ or stSoftwareAU/GRQ-cluster repos." >&2
+  exit 1
+fi
+
+echo "✅ README free of private GRQ / GRQ-cluster repo references"

--- a/tests/scripts/readme_private_repo_refs.bats
+++ b/tests/scripts/readme_private_repo_refs.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-readme-private-repo-refs.sh — Issue #450.
+#
+# Synthetic README fixtures in a temp directory exercise the pass/fail
+# behaviour (exit codes, reported output) so the real README is never mutated,
+# plus one test asserting the shipped README passes the guard.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-readme-private-repo-refs.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export REPO_ROOT
+
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+@test "passes on a README with concept-level production wording" {
+  cat >"$TMP_DIR/README.md" <<'EOF'
+# Title
+
+Scratch/mixed production-scale pools fall back to CPU. Production records are
+9848 bytes (2461 inputs + 1 output).
+EOF
+
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"free of private"* ]]
+}
+
+@test "fails when the README names the private GRQ repo" {
+  cat >"$TMP_DIR/README.md" <<'EOF'
+# Title
+
+Scratch/mixed GRQ-scale pools fall back to CPU.
+EOF
+
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"names a private repository"* ]]
+  [[ "$output" == *"GRQ-scale"* ]]
+}
+
+@test "fails when the README names the private GRQ-cluster repo" {
+  cat >"$TMP_DIR/README.md" <<'EOF'
+# Title
+
+Production GRQ-cluster records are 9848 bytes.
+EOF
+
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"GRQ-cluster"* ]]
+}
+
+@test "reports every offending line, not just the first" {
+  cat >"$TMP_DIR/README.md" <<'EOF'
+# Title
+
+Line one mentions GRQ.
+Line two is clean.
+Line three mentions GRQ-cluster.
+EOF
+
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"3:Line one mentions GRQ."* ]]
+  [[ "$output" == *"5:Line three mentions GRQ-cluster."* ]]
+}
+
+@test "fails loudly when the README path does not exist" {
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/missing.md"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"README not found"* ]]
+}
+
+@test "rejects an unknown argument with a usage error" {
+  run "$SCRIPT_UNDER_TEST" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "the shipped README passes the guard" {
+  run "$SCRIPT_UNDER_TEST" --readme "$REPO_ROOT/README.md"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`README.md` named the **private** `stSoftwareAU/GRQ` and `stSoftwareAU/GRQ-cluster`
repositories in public documentation — check 3 of the private-repo-reference audit.
Reworded all 12 mentions to concept-level phrasing ("production creature",
"production-scale pools", "production hosts", record byte size) so the public README
stays fully self-contained, and added a permanent guard so the references cannot
creep back in. No code or runtime behaviour changed.

Closes #450.

Rewording (same style as the sibling `docs/performance-baseline.md` change, Issue #449):

| Before | After |
|---|---|
| scratch/mixed **GRQ-scale** pools | scratch/mixed **production-scale** pools |
| **GRQ-scale** creatures (total neurons >256) | **production-scale** creatures (total neurons >256) |
| `score_from_creature_dir` (N=63, **GRQ** scratch) | `score_from_creature_dir` (N=63, **production** scratch) |
| the real **GRQ-cluster** creature | the real **production** creature |
| production **GRQ** creatures | **production-scale** creatures |
| the real **GRQ** corpus | the real **production** corpus |
| `"GRQ-10-1"` / `"GRQ-12-1"` JSON keys | `"creature-10-1"` / `"creature-12-1"` |
| Production **GRQ-cluster** records are 9848 bytes | Production records are 9848 bytes |
| On **GRQ** hosts / within **GRQ** host RAM headroom | On **production** hosts / within **production** host RAM headroom |

The `NEAT-AI*` dependency-table rows (public repos) and the
`stSoftwareAU/VibeCoding#1613` reference (tracked separately) are untouched, as the
issue specifies.

## Evidence

Documentation-only change — there is no web interface to screenshot. Verified by the
new regression guard and the full local gate:

- `scripts/check-readme-private-repo-refs.sh` — exits 1 with every offending line when
  the README names `GRQ` / `GRQ-cluster`, exits 0 on the current README. Fails loud on a
  missing README (exit 1) and on an unknown argument (exit 2).
- Wired into `quality.sh`; CI already runs `bats tests/scripts`, and the suite includes a
  test asserting the **shipped** README passes the guard, so CI enforces it on every PR.
- `./quality.sh < /dev/null` → `✅ All quality checks passed!` (shellcheck, bats, fmt,
  clippy, tests, rustdoc, release build).

```mermaid
flowchart LR
    A[README.md edit] --> B[scripts/check-readme-private-repo-refs.sh]
    B -->|private name found| C[exit 1 — fail loud]
    B -->|clean| D[exit 0]
    B --- E[quality.sh + CI bats job]
```

## Test Plan

Added `tests/scripts/readme_private_repo_refs.bats` (7 tests, all passing):

- passes on a README with concept-level production wording
- fails when the README names the private `GRQ` repo
- fails when the README names the private `GRQ-cluster` repo
- reports every offending line, not just the first
- fails loudly when the README path does not exist
- rejects an unknown argument with a usage error
- the shipped `README.md` passes the guard (regression test for this issue — it fails
  against the pre-fix README and passes after the rewording)

No existing tests were modified or removed.



## Milestone
This PR is part of the **Public only** milestone and targets the `milestone/public-only` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxfxtga-5551db`<!-- vibe-worker-issue-450 -->