### PR TITLE
Reword private repo mentions in CHANGELOG and archived PR summaries to concept level (Issue #453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ section to the released version with its date.
   Constant neurons are also rejected by the pre-flight
   (`GpuPrepareError::ConstantNeuron`) — the CPU returns a clamped bias and
   ignores their synapses, which the kernel cannot reproduce, so a creature
-  carrying one (the GRQ creature has 3) falls back to CPU rather than being
+  carrying one (the production creature has 3) falls back to CPU rather than being
   silently mis-scored. CPU↔GPU parity across all 32 point-wise squashes is asserted on Apple M4 /
   Metal by `cpu_vs_gpu_pointwise_squash_coverage`. The CPU path and the
   `auto_should_use_gpu` per-path default are unchanged; a new optional
@@ -67,6 +67,16 @@ section to the released version with its date.
   production squash mix.
 
 ### Changed
+
+- **Reword private-repo mentions in the changelog and archived PR summaries to
+  concept level (Issue #453).** Historical documentation named a private
+  `stSoftwareAU` repository; a public repo must be self-contained, so those
+  incidental mentions now describe the production creature, corpus and hosts by
+  their properties instead. A new guard
+  (`scripts/check-docs-private-repo-refs.sh`, wired into `quality.sh`, with BATS
+  coverage in `tests/scripts/docs_private_repo_refs.bats`) keeps `CHANGELOG.md`
+  and everything under `docs/` clean, completing the README (#450), source
+  (#452) and automation (#451) guards. Documentation only — no code change.
 
 - **Drop the push-to-`Develop` trigger from the CI checker workflow (Issue
   #370).** `ci.yml` runs the heavy test/lint/scan gate; as a *checker* it should
@@ -101,7 +111,7 @@ section to the released version with its date.
   alignment guard (`scripts/check-readme-ci-alignment.sh`), and `AGENTS.md` are
   updated to match; the guard now rejects a re-introduced standalone
   `cargo check`.
-- **Document the recommended `NEAT_SCORER_READ_BYTES` for large-record GRQ
+- **Document the recommended `NEAT_SCORER_READ_BYTES` for large-record production
   hosts (Issue #307).** Swept `NEAT_SCORER_READ_BYTES` ∈ {2, 8, 16, 32, 64} MiB
   on the #296 production fixture (9848-byte records). Larger aligned reads
   recover ~20–24 % on the single-creature and multi-creature production groups
@@ -110,7 +120,7 @@ section to the released version with its date.
   The global default stays **2 MiB** (the gain is record-size specific and the
   sweep host was contended, not the quiet host the merge gate requires); the
   README now documents exporting `NEAT_SCORER_READ_BYTES=33554432` (32 MiB) on
-  GRQ hosts, and `docs/performance-baseline.md` records the sweep table. No code
+  production hosts, and `docs/performance-baseline.md` records the sweep table. No code
   or default change.
 - **Acknowledge the neat-core 0.1 -> 0.2 breaking bump in the version-baseline
   gate (Issue #252).** `neat-core.expected-version` recorded `0.1.46` while the

--- a/docs/archive/pr-summaries/pr-summary-296.md
+++ b/docs/archive/pr-summaries/pr-summary-296.md
@@ -3,11 +3,11 @@
 ## Summary
 
 Adds a **production-scale benchmark fixture** that gates candidate optimisations
-against the real GRQ-cluster creature instead of the synthetic 8→8→2 fixture, and
+against the real production creature instead of the synthetic 8→8→2 fixture, and
 re-baselines the scorer from it. Closes #296.
 
 - New library module [`rust_scorer/src/prod_fixture.rs`](../../../rust_scorer/src/prod_fixture.rs)
-  loads the GRQ-cluster production `network.json` **fail-loud**: it parses,
+  loads the production `network.json` **fail-loud**: it parses,
   topology-checks against production ranges, and returns a hard error (which the
   bench turns into a panic) if the fixture is empty, fails to deserialize, or is
   not production-sized. It **never falls back** to the synthetic fixture, which

--- a/docs/archive/pr-summaries/pr-summary-305.md
+++ b/docs/archive/pr-summaries/pr-summary-305.md
@@ -1,9 +1,9 @@
-# [perf] Expand GPU squash coverage so the production GRQ creature can run on Metal/Vulkan
+# [perf] Expand GPU squash coverage so the production creature can run on Metal/Vulkan
 
 ## Summary
 
 The GPU `forward_mse_batched` / `forward_mse_scratch` WGSL kernels only inlined
-four activations (IDENTITY / RELU / LOGISTIC / TANH), so the production GRQ
+four activations (IDENTITY / RELU / LOGISTIC / TANH), so the production
 creature — spanning ~34 squash types — fell back to CPU on **~95.8 %** of its
 neurons and could not use the GPU path at all (Scorer#299, negative).
 
@@ -20,16 +20,16 @@ from `{0,1,6,7}` to `0..=31`, and the pre-flight now reports a point-wise
 production creature as GPU-hostable. The pre-flight also now **rejects constant
 neurons** (`GpuPrepareError::ConstantNeuron`): the CPU returns a clamped bias for
 them and ignores their synapses, which the sum-then-squash kernel cannot
-reproduce — so a creature carrying one (the real GRQ creature has 3) falls back
+reproduce — so a creature carrying one (the real production creature has 3) falls back
 to CPU rather than being silently mis-scored.
 
-Whether directory-mode GPU should *default* on for the real GRQ creature is a
+Whether directory-mode GPU should *default* on for the real production creature is a
 separate, benchmark-gated decision. The pre-existing per-path
 `auto_should_use_gpu` logic (#82/#83) is unchanged and the CPU path does not
 regress, so this coverage work stands on its own regardless of that decision
-(exactly as the issue frames it). The production A/B gate needs the GRQ
+(exactly as the issue frames it). The production A/B gate needs the production
 `network.json` + a multi-GiB corpus, which were **not reachable in this
-environment** (the `GRQ-cluster/main/network.json` URL returned `404`); that
+environment** (the production `network.json` URL returned `404`); that
 final default decision is left for a host with production data — see the
 "production GPU" note in `docs/performance-baseline.md`.
 
@@ -59,7 +59,7 @@ test result: ok. 7 passed; 0 failed
 
 ### GPU-vs-CPU A/B — synthetic mixed-squash creature
 
-The real GRQ creature was unreachable, so the A/B uses a synthetic
+The real production creature was unreachable, so the A/B uses a synthetic
 directory-mode creature whose hidden layer cycles the production squash mix
 (`BENCH_SCORING_HIDDEN_SQUASH=MIXED`: GELU/SELU/SINE/ABSOLUTE/BENT_IDENTITY/
 Cube/HARD_TANH/…). This exercises exactly the coverage the shader now hosts and
@@ -77,8 +77,8 @@ transcendental-heavy, so scalar CPU libm dominates per-neuron cost while the GPU
 evaluates activations in parallel. (Before this PR the `gpu_score_from_creature_dir`
 bench could not even run the mixed creature — `BatchedRunner::new` rejected the
 unsupported squashes.) These synthetic numbers do **not** replace the production
-GRQ A/B (issue benchmark gate), which needs the real `network.json` + multi-GiB
-corpus on a host with GRQ-cluster access; they confirm the coverage unblocks the
+production A/B (issue benchmark gate), which needs the real `network.json` + multi-GiB
+corpus on a host with production corpus access; they confirm the coverage unblocks the
 GPU path and does not regress CPU.
 
 ### Data flow
@@ -107,7 +107,7 @@ flowchart LR
     `32..=37` aggregate still yields `UnsupportedSquash`.
   - `build_batched_network_data_rejects_constant_neuron` (new) — a constant
     neuron yields `GpuPrepareError::ConstantNeuron` (CPU fallback), guarding
-    against silently mis-scoring the 3 constant neurons in the GRQ creature.
+    against silently mis-scoring the 3 constant neurons in the production creature.
 - **`rust_scorer/tests/gpu_preflight_tdd.rs`**
   - `preflight_returns_typed_error_for_unsupported_squash` — updated from
     GAUSSIAN (now hostable) to MEAN (an aggregate, still unsupported). Business

--- a/docs/archive/pr-summaries/pr-summary-307.md
+++ b/docs/archive/pr-summaries/pr-summary-307.md
@@ -1,7 +1,7 @@
 ## Summary
 
 Swept `NEAT_SCORER_READ_BYTES` ∈ {2, 8, 16, 32, 64} MiB against the #296
-**production** GRQ-cluster creature (9848-byte records: 2461 inputs + 1 output,
+**production** creature (9848-byte records: 2461 inputs + 1 output,
 `f32`) to answer whether larger aligned read chunks beat the 2 MiB default. They
 do — larger reads recover **~20–24 %** on the single- and multi-creature
 production scoring paths, with the sweet spot at **16–32 MiB**. This is a
@@ -13,7 +13,7 @@ no auto-tuner ships: the optimum is narrow and record-size specific, and the
 sweep ran on a **contended** worker host rather than the quiet Apple Silicon
 host the merge gate requires — not a sound basis for fixing a global constant.
 Instead this PR takes the issue's explicitly-sanctioned outcome: **document the
-recommended env for GRQ hosts**. It is not a negative result — there is a
+recommended env for production hosts**. It is not a negative result — there is a
 measurable, repeatable gain; we simply choose the documentation route over a
 default flip.
 
@@ -29,7 +29,7 @@ sweep below (Criterion, `bench` profile: release + LTO + `codegen-units = 1`),
 captured with the production fixture:
 
 ```bash
-export BENCH_PROD_CREATURE=/path/to/GRQ-cluster/network.json
+export BENCH_PROD_CREATURE=/path/to/production/network.json
 export BENCH_PROD_BYTES=134217728   # 128 MiB → 13 628 records (a few × the 64 MiB read cap)
 export BENCH_PROD_CREATURES=4
 for b in 2097152 8388608 16777216 33554432 67108864; do
@@ -81,7 +81,7 @@ large-record production hosts and the default is unchanged.
 The read buffer is **per-scan, not per-worker** (single shared scan; workers get
 partitioned slices of the unpacked records). A 32 MiB setting therefore adds
 ≤ ~64 MiB transient buffer (the pipelined path double-buffers), **not** 32 MiB ×
-worker count — well within GRQ host RAM headroom.
+worker count — well within production host RAM headroom.
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-312.md
+++ b/docs/archive/pr-summaries/pr-summary-312.md
@@ -1,11 +1,11 @@
 ## Summary
 
 GPU-host the aggregate squash neurons **MINIMUM (32) / MAXIMUM (33) / IF (34)**
-and **constant neurons** in both WGSL kernels so the real GRQ-cluster creature
+and **constant neurons** in both WGSL kernels so the real production creature
 runs on Metal/Vulkan. **Closes #312.**
 
-Before this change `--gpu auto` kept the real GRQ creature on CPU: hosting is
-gated per-creature (`build_batched_network_data`), and the GRQ creature contains
+Before this change `--gpu auto` kept the real production creature on CPU: hosting is
+gated per-creature (`build_batched_network_data`), and the production creature contains
 neuron forms the kernel's sum-then-squash path could not express — `IF` (×6,
 aggregates by synapse *type*), `MINIMUM` (×4) / `MAXIMUM` (×2) (min/max of
 `w·act`, not a sum), and 3 **constant** neurons (clamped bias, synapses ignored).
@@ -67,15 +67,15 @@ rather than skip).
 - `cpu_vs_gpu_minimum_aggregate`, `cpu_vs_gpu_maximum_aggregate`,
   `cpu_vs_gpu_if_aggregate` — one aggregate per creature.
 - `cpu_vs_gpu_mixed_aggregates_and_constant_neuron` — MIN + MAX + IF + constant
-  in one creature (the GRQ mix).
-- `cpu_vs_gpu_real_prod_creature_when_available` — scores the **actual** GRQ
+  in one creature (the production mix).
+- `cpu_vs_gpu_real_prod_creature_when_available` — scores the **actual** production
   `network.json` (1666 neurons, IF ×6 / MIN ×4 / MAX ×2, 3 constant neurons)
   when `BENCH_PROD_CREATURE` is set. Ran green against the local creature.
 
 All 11 GPU parity tests + 16 host unit tests pass; `./quality.sh` passes clean
 (shellcheck, fmt, clippy, check, build, test, rustdoc, release build).
 
-**Production GRQ A/B (`production_gpu_vs_cpu`, 16 MiB corpus / 1703 records):**
+**Production A/B (`production_gpu_vs_cpu`, 16 MiB corpus / 1703 records):**
 
 | Pool `N` | CPU median | GPU median | GPU vs CPU |
 |---|---|---|---|
@@ -86,7 +86,7 @@ The GPU amortises across the creature pool (one dispatch scores every
 `(creature, record)` pair): it loses by 1.7× at a small pool but pulls ahead by
 ~9 % at a realistic evolution population (`N=50`), with a break-even in between.
 
-**Default decision:** the hosting work merges on its own merits (real GRQ
+**Default decision:** the hosting work merges on its own merits (real production
 creature now hostable with verified parity, CPU path untouched). The A/B is a
 **crossover**, not a clean win, so the `--gpu auto` default is *not* flipped
 here — a population-size-aware `auto_should_use_gpu` threshold is left to the
@@ -100,8 +100,8 @@ Added / modified in `rust_scorer/tests/gpu_multi_score_parity.rs`:
 
 - `cpu_vs_gpu_minimum_aggregate`, `cpu_vs_gpu_maximum_aggregate`,
   `cpu_vs_gpu_if_aggregate` — aggregate parity on a real adapter.
-- `cpu_vs_gpu_mixed_aggregates_and_constant_neuron` — combined GRQ mix.
-- `cpu_vs_gpu_real_prod_creature_when_available` — real GRQ `network.json`
+- `cpu_vs_gpu_mixed_aggregates_and_constant_neuron` — combined production mix.
+- `cpu_vs_gpu_real_prod_creature_when_available` — real production `network.json`
   parity, gated on `BENCH_PROD_CREATURE`.
 
 Added / modified host unit tests in `rust_scorer/src/gpu/forward_mse_batched.rs`:
@@ -121,4 +121,4 @@ Added / modified host unit tests in `rust_scorer/src/gpu/forward_mse_batched.rs`
   (37) since MINIMUM (32) is now hosted.
 
 Added `rust_scorer/benches/scoring.rs::bench_production_gpu_vs_cpu` — the real
-GRQ CPU↔GPU A/B used for the numbers above.
+production CPU↔GPU A/B used for the numbers above.

--- a/docs/archive/pr-summaries/pr-summary-316.md
+++ b/docs/archive/pr-summaries/pr-summary-316.md
@@ -14,7 +14,7 @@ kernels now select the reduction from a new `cost_kind` header field:
   host-side `sqrt` at finalisation).
 - `MAE` (this change) accumulates **absolute** error on the identical forward
   pass — GPU-hosted on both the private-array and the >256-neuron scratch
-  kernels used by production GRQ creatures.
+  kernels used by production creatures.
 
 The `cost_kind` value comes from a new `CostKind::gpu_error_code()` (0 = squared,
 1 = absolute) written into the previously-unused header padding slot, so no new

--- a/docs/archive/pr-summaries/pr-summary-322.md
+++ b/docs/archive/pr-summaries/pr-summary-322.md
@@ -15,13 +15,13 @@ signature change, tracked by a monotonic reallocation-generation counter per
 growable buffer plus the bound scratch size.
 
 This is a correctness-preserving dispatch-overhead reduction. It does **not**
-flip `--gpu auto` routing — production GRQ topology is `ScratchOnly`, which still
+flip `--gpu auto` routing — production topology is `ScratchOnly`, which still
 selects CPU per #317/#319 — it lowers the fixed cost of every GPU dispatch on the
 `--gpu on` and all-private `auto` paths.
 
 The three remaining #322 experiments (64 MiB read default; async readback beyond
 `inflight=2`, blocked by the #319 Metal SIGSEGV; Metal-native micro-benchmark)
-need the proprietary full 521-bin GRQ corpus or are non-shipping spikes, and are
+need the proprietary full 521-bin production corpus or are non-shipping spikes, and are
 tracked in follow-up **#333**.
 
 ### Reuse decision
@@ -58,7 +58,7 @@ wall-time impact scales with dispatch count. Recorded in
 [`docs/performance-baseline.md`](../../performance-baseline.md) under
 "Production GPU dispatch overhead — 12 July 2026".
 
-**Ship-gate note.** #322's full ship gate (≥3 % CPU win on the full 521-bin GRQ
+**Ship-gate note.** #322's full ship gate (≥3 % CPU win on the full 521-bin production
 corpus, combined with #319 + kernel work) governs flipping the production default
 to GPU and needs proprietary data unavailable to the worker. This PR delivers the
 self-contained, measurable dispatch-overhead reduction and tracks the residual

--- a/docs/archive/pr-summaries/pr-summary-340.md
+++ b/docs/archive/pr-summaries/pr-summary-340.md
@@ -14,7 +14,7 @@ The work spans two repos, per the issue scope:
    upstream config validation accepts `costName: "RMSE"` and passes it through
    `NeatOptions.costName` unchanged.
 2. **This repo (scorer):** the sync-verification test + comment updates below.
-3. **End-to-end release + GRQ bump (human-gated):** tracked in
+3. **End-to-end release + production consumer bump (human-gated):** tracked in
    `stSoftwareAU/NEAT-AI#3342`. Per the release-gating rule the NEAT-AI release
    and the downstream bump are a human action — this PR does **not** auto-merge
    or publish anything.
@@ -53,7 +53,7 @@ and the upstream Deno suite.
 
 ```mermaid
 flowchart LR
-    A["GRQ<br/>costName: RMSE"] --> B["NEAT-AI TS<br/>BUILT_IN_COST_NAMES<br/>(NEAT-AI#3341)"]
+    A["Production consumer<br/>costName: RMSE"] --> B["NEAT-AI TS<br/>BUILT_IN_COST_NAMES<br/>(NEAT-AI#3341)"]
     B --> C["rust_scorer<br/>--cost RMSE"]
     C --> D["MSE kernel + host sqrt<br/>(#339)"]
     B -. "drift-detecting mirror" .- E["cost.rs sync test<br/>(this PR, #340)"]

--- a/docs/archive/pr-summaries/pr-summary-341.md
+++ b/docs/archive/pr-summaries/pr-summary-341.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Documents the new `RMSE` cost so users and GRQ operators can discover and request
+Documents the new `RMSE` cost so users and production operators can discover and request
 it, and records the change. The `RMSE` variant, its CPU dispatch (#338) and its
 GPU support via the shared MSE kernel (#339) already landed on the milestone
 branch; this PR consolidates the **hand-written** documentation those sub-issues

--- a/docs/archive/pr-summaries/pr-summary-430.md
+++ b/docs/archive/pr-summaries/pr-summary-430.md
@@ -9,7 +9,7 @@ module tree), the compiler's `dead_code` lint never analysed its `pub` items, so
 the unreferenced export sat undetected. Closes #430.
 
 The constant recorded production-corpus provenance (`training_data_files = 520`
-from GRQ-cluster `performance.csv`). That figure is **already** documented in
+from the production `performance.csv`). That figure is **already** documented in
 `docs/performance-baseline.md` (Corpus sizing section, line 692), so deleting the
 code loses no information — no doc move was required. This mirrors the #429
 removal of the adjacent `PRODUCTION_CORPUS_BYTES` constant.

--- a/docs/archive/pr-summaries/pr-summary-453.md
+++ b/docs/archive/pr-summaries/pr-summary-453.md
@@ -1,0 +1,76 @@
+# Reword private-repo mentions in the changelog and archived PR summaries
+
+## Summary
+
+The public repo's historical documentation — `CHANGELOG.md`, `docs/pr-summary-11.md`
+and nine archived PR summaries — still named a **private** `stSoftwareAU`
+repository. This is check 3 of the private-repo-reference audit (incidental,
+archival name mentions): archived summaries and the changelog are public
+documentation, and naming a private repo points public readers at content they
+cannot see.
+
+Per the check-3 remediation tier the mentions are reworded to **concept level**,
+preserving the historical narrative:
+
+| Before (private name) | After (concept level) |
+| --- | --- |
+| the real *private-repo* creature | the real **production** creature |
+| *private-repo* hosts / host RAM headroom | **production** hosts / host RAM headroom |
+| large-record *private-repo* corpora | large-record **production** corpora |
+| full 521-bin *private-repo* corpus | full 521-bin **production** corpus |
+| `/path/to/<private-repo>/network.json` | `/path/to/production/network.json` |
+| *private-repo* operators | **production** operators |
+
+A new per-repo gate, `scripts/check-docs-private-repo-refs.sh`, keeps them clean:
+it scans `CHANGELOG.md` and everything under `docs/` (any depth) for the private
+repo names as whole words and **fails loud** with every offending file:line. The
+three PR summaries that document the audit itself (#448, #449, #450) necessarily
+quote the names they removed and are the only allowlisted files. The guard is
+wired into `quality.sh` and covered by BATS, which CI runs.
+
+This completes the guard set alongside `check-readme-private-repo-refs.sh`
+(#450, README), `check-source-private-repo-refs.sh` (#452, sources/scripts/
+`AGENTS.md`) and `check-private-automation-repo-refs.sh` (#451). The #452 guard's
+"historical records are deliberately out of scope" comment now points at the new
+docs guard.
+
+Closes #453.
+
+```mermaid
+flowchart LR
+    Q[quality.sh / CI bats] --> R[check-readme-private-repo-refs.sh<br/>README #450]
+    Q --> S[check-source-private-repo-refs.sh<br/>*.rs, scripts, AGENTS.md #452]
+    Q --> A[check-private-automation-repo-refs.sh<br/>automation repo #451]
+    Q --> D[check-docs-private-repo-refs.sh<br/>CHANGELOG + docs/ #453]
+```
+
+## Evidence
+
+Documentation/CLI-only change — there is no web interface to screenshot. Evidence
+is the guard's own behaviour:
+
+- Before the reword, `./scripts/check-docs-private-repo-refs.sh` exited **1** and
+  listed 38 offending lines across 11 files.
+- After the reword it exits **0**:
+  `✅ CHANGELOG and docs free of private repo references`.
+- `./quality.sh` passes end to end (shellcheck, cargo-deny, fmt, clippy, build,
+  test, rustdoc, release build, all guards, 424 BATS tests).
+
+## Test Plan
+
+New BATS suite `tests/scripts/docs_private_repo_refs.bats` (9 tests) — each runs
+the real script against synthetic fixtures and asserts exit codes and output:
+
+- passes on a changelog with concept-level production wording
+- fails when the changelog names the private repo (exit 1, offending file
+  reported)
+- fails when an archived PR summary names the private cluster repo
+- reports **every** offending file, not just the first
+- ignores markdown outside `CHANGELOG.md` and `docs/`
+- allows the allowlisted remediation summaries
+- fails loudly when the root does not exist (exit 1)
+- rejects an unknown argument with a usage error (exit 2)
+- **regression test:** the shipped `CHANGELOG.md` and `docs/` tree pass the guard
+  — this test fails against the unfixed tree and passes after the reword
+
+Existing suites are unchanged and all 424 BATS tests pass.

--- a/docs/pr-summary-11.md
+++ b/docs/pr-summary-11.md
@@ -1,5 +1,5 @@
 ## Summary
-Unblocks the `rust_scorer` build against the current `NEAT-AI-core` `Develop` branch (post commit `62a5c92`) and adds a pre-flight binary smoke test that catches API drift between `rust_scorer` and the `neat-core` path dependency at PR time — rather than only when GRQ `option=learn` fails downstream. Closes #11.
+Unblocks the `rust_scorer` build against the current `NEAT-AI-core` `Develop` branch (post commit `62a5c92`) and adds a pre-flight binary smoke test that catches API drift between `rust_scorer` and the `neat-core` path dependency at PR time — rather than only when the production trainer's `option=learn` fails downstream. Closes #11.
 
 Two upstream breakages resolved in the scorer:
 

--- a/quality.sh
+++ b/quality.sh
@@ -138,6 +138,9 @@ echo "🕵️  Validating README names no private repository (Issue #450)..."
 echo "🕵️  Validating sources/scripts/AGENTS.md name no private repository (Issue #452)..."
 ./scripts/check-source-private-repo-refs.sh
 
+echo "🕵️  Validating CHANGELOG and docs name no private repository (Issue #453)..."
+./scripts/check-docs-private-repo-refs.sh
+
 echo "🕵️  Validating the tree names no private automation repository (Issue #451)..."
 ./scripts/check-private-automation-repo-refs.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.32"
+version = "1.1.33"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-docs-private-repo-refs.sh
+++ b/scripts/check-docs-private-repo-refs.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# check-docs-private-repo-refs.sh — Issue #453.
+#
+# Guards the historical documentation — `CHANGELOG.md` and everything under
+# `docs/` (including the archived PR summaries) — against naming the private
+# `stSoftwareAU/GRQ` / `stSoftwareAU/GRQ-cluster` repositories. A public repo
+# must be self-contained: an archival name mention is still public
+# documentation pointing readers at content they cannot see. Production
+# behaviour is described at concept level instead ("production creature",
+# "production-scale pools", "~9848 B/record").
+#
+# Companion to `check-readme-private-repo-refs.sh` (Issue #450, README),
+# `check-source-private-repo-refs.sh` (Issue #452, sources/scripts/AGENTS.md)
+# and `check-private-automation-repo-refs.sh` (Issue #451, automation repo).
+#
+# Usage:
+#   check-docs-private-repo-refs.sh [--root PATH]
+#
+# Exit codes:
+#   0  no private repo name found
+#   1  at least one private repo name found (or the root is missing)
+#   2  usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ $# -ge 2 ] || { echo "Usage: $0 [--root PATH]" >&2; exit 2; }
+      ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--root PATH]"
+      exit 0
+      ;;
+    *)
+      echo "Usage: $0 [--root PATH]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -d "$ROOT" ]; then
+  echo "❌ root not found: $ROOT" >&2
+  exit 1
+fi
+
+# Private repo names, matched case-sensitively as whole words so ordinary
+# prose is unaffected.
+PRIVATE_PATTERN='\bGRQ(-cluster)?\b'
+
+# The PR summaries that document the private-repo-reference audit itself
+# necessarily quote the names they removed; everything else must stay clean.
+in_scope() {
+  case "$1" in
+    docs/archive/pr-summaries/pr-summary-448.md \
+      | docs/archive/pr-summaries/pr-summary-449.md \
+      | docs/archive/pr-summaries/pr-summary-450.md) return 1 ;;
+    # `*` spans `/` in a case pattern, so this covers docs/ at any depth.
+    CHANGELOG.md | docs/*.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Prefer the git index (skips `target/`, build artefacts and untracked noise);
+# fall back to a plain find for synthetic test trees that are not work trees.
+list_candidates() {
+  local top=""
+  top="$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null || true)"
+
+  if [ -n "$top" ] && [ "$top" -ef "$ROOT" ]; then
+    git -C "$ROOT" ls-files
+    return
+  fi
+
+  (cd "$ROOT" && find . \
+    -path ./.git -prune -o -path ./target -prune -o \
+    -type f -print | sed 's|^\./||')
+}
+
+scan_matches() {
+  local files=() file=""
+
+  while IFS= read -r file; do
+    in_scope "$file" && files+=("$file")
+  done < <(list_candidates)
+
+  [ ${#files[@]} -eq 0 ] && return 0
+  # `|| true`: grep exits 1 when nothing matches, which is the clean case.
+  # -H so a single-file match still reports its path.
+  (cd "$ROOT" && grep -HInE "$PRIVATE_PATTERN" -- "${files[@]}") || true
+}
+
+matches="$(scan_matches)"
+
+if [ -n "$matches" ]; then
+  echo "❌ Documentation names a private repository (Issue #453):" >&2
+  echo "$matches" >&2
+  echo >&2
+  echo "   Reword to concept level — describe the production creature, corpus" >&2
+  echo "   record size and topology by their properties (e.g. \"production-scale\"," >&2
+  echo "   \">256-neuron scratch topology\", \"~9848 B/record\") without naming" >&2
+  echo "   the private repositories." >&2
+  exit 1
+fi
+
+echo "✅ CHANGELOG and docs free of private repo references"

--- a/scripts/check-source-private-repo-refs.sh
+++ b/scripts/check-source-private-repo-refs.sh
@@ -52,17 +52,19 @@ fi
 # prose is unaffected.
 PRIVATE_PATTERN='\bGRQ(-cluster)?\b'
 
-# This guard — and its README-scoped sibling from Issue #450 — necessarily
-# spell the names they forbid; everything else in scope must stay clean.
+# This guard — and its README-scoped (#450) and docs-scoped (#453) siblings —
+# necessarily spell the names they forbid; everything else in scope must stay
+# clean.
 SELF="$(basename "${BASH_SOURCE[0]}")"
 SIBLING_GUARD="scripts/check-readme-private-repo-refs.sh"
+DOCS_GUARD="scripts/check-docs-private-repo-refs.sh"
 
 # In-scope files: Rust sources, shell scripts and the agent guidance file.
-# Historical records (CHANGELOG, archived PR summaries) are deliberately out
-# of scope — they document what was said at the time.
+# Historical records (CHANGELOG, archived PR summaries) are covered by
+# `check-docs-private-repo-refs.sh` (Issue #453).
 in_scope() {
   case "$1" in
-    "scripts/$SELF" | "$SIBLING_GUARD") return 1 ;;
+    "scripts/$SELF" | "$SIBLING_GUARD" | "$DOCS_GUARD") return 1 ;;
     *.rs | scripts/*.sh | AGENTS.md) return 0 ;;
     *) return 1 ;;
   esac

--- a/tests/scripts/docs_private_repo_refs.bats
+++ b/tests/scripts/docs_private_repo_refs.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-docs-private-repo-refs.sh — Issue #453.
+#
+# Synthetic doc trees in a temp directory exercise the pass/fail behaviour
+# (exit codes, reported output) so the real docs are never mutated, plus one
+# test asserting the shipped CHANGELOG and docs pass the guard.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-docs-private-repo-refs.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export REPO_ROOT
+
+  TMP_DIR="$(mktemp -d)"
+  mkdir -p "$TMP_DIR/docs/archive/pr-summaries"
+  export TMP_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+@test "passes on a changelog with concept-level production wording" {
+  cat >"$TMP_DIR/CHANGELOG.md" <<'EOF'
+# Changelog
+
+Documented the recommended read size for the large-record production corpus.
+EOF
+
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"free of private"* ]]
+}
+
+@test "fails when the changelog names the private GRQ repo" {
+  cat >"$TMP_DIR/CHANGELOG.md" <<'EOF'
+# Changelog
+
+Documented the recommended read size for large-record GRQ corpora.
+EOF
+
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_DIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"names a private repository"* ]]
+  [[ "$output" == *"CHANGELOG.md"* ]]
+}
+
+@test "fails when an archived PR summary names the private GRQ-cluster repo" {
+  cat >"$TMP_DIR/docs/archive/pr-summaries/pr-summary-99.md" <<'EOF'
+# Summary
+
+Scored against the real GRQ-cluster creature.
+EOF
+
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_DIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"pr-summary-99.md"* ]]
+  [[ "$output" == *"GRQ-cluster"* ]]
+}
+
+@test "reports every offending file, not just the first" {
+  printf '# Changelog\n\nMentions GRQ.\n' >"$TMP_DIR/CHANGELOG.md"
+  printf '# Summary\n\nMentions GRQ-cluster.\n' \
+    >"$TMP_DIR/docs/pr-summary-7.md"
+
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_DIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CHANGELOG.md:3"* ]]
+  [[ "$output" == *"docs/pr-summary-7.md:3"* ]]
+}
+
+@test "ignores markdown outside the changelog and docs tree" {
+  printf '# Readme\n\nMentions GRQ.\n' >"$TMP_DIR/README.md"
+
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows the remediation PR summaries that document the audit itself" {
+  printf '# Summary\n\nRemoved the private GRQ-cluster name.\n' \
+    >"$TMP_DIR/docs/archive/pr-summaries/pr-summary-449.md"
+
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails loudly when the root does not exist" {
+  run "$SCRIPT_UNDER_TEST" --root "$TMP_DIR/missing"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"root not found"* ]]
+}
+
+@test "rejects an unknown argument with a usage error" {
+  run "$SCRIPT_UNDER_TEST" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "the shipped CHANGELOG and docs pass the guard" {
+  run "$SCRIPT_UNDER_TEST" --root "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Reword private-repo mentions in the changelog and archived PR summaries

## Summary

The public repo's historical documentation — `CHANGELOG.md`, `docs/pr-summary-11.md`
and nine archived PR summaries — still named a **private** `stSoftwareAU`
repository. This is check 3 of the private-repo-reference audit (incidental,
archival name mentions): archived summaries and the changelog are public
documentation, and naming a private repo points public readers at content they
cannot see.

Per the check-3 remediation tier the mentions are reworded to **concept level**,
preserving the historical narrative:

| Before (private name) | After (concept level) |
| --- | --- |
| the real *private-repo* creature | the real **production** creature |
| *private-repo* hosts / host RAM headroom | **production** hosts / host RAM headroom |
| large-record *private-repo* corpora | large-record **production** corpora |
| full 521-bin *private-repo* corpus | full 521-bin **production** corpus |
| `/path/to/<private-repo>/network.json` | `/path/to/production/network.json` |
| *private-repo* operators | **production** operators |

A new per-repo gate, `scripts/check-docs-private-repo-refs.sh`, keeps them clean:
it scans `CHANGELOG.md` and everything under `docs/` (any depth) for the private
repo names as whole words and **fails loud** with every offending file:line. The
three PR summaries that document the audit itself (#448, #449, #450) necessarily
quote the names they removed and are the only allowlisted files. The guard is
wired into `quality.sh` and covered by BATS, which CI runs.

This completes the guard set alongside `check-readme-private-repo-refs.sh`
(#450, README), `check-source-private-repo-refs.sh` (#452, sources/scripts/
`AGENTS.md`) and `check-private-automation-repo-refs.sh` (#451). The #452 guard's
"historical records are deliberately out of scope" comment now points at the new
docs guard.

Closes #453.

```mermaid
flowchart LR
    Q[quality.sh / CI bats] --> R[check-readme-private-repo-refs.sh<br/>README #450]
    Q --> S[check-source-private-repo-refs.sh<br/>*.rs, scripts, AGENTS.md #452]
    Q --> A[check-private-automation-repo-refs.sh<br/>automation repo #451]
    Q --> D[check-docs-private-repo-refs.sh<br/>CHANGELOG + docs/ #453]
```

## Evidence

Documentation/CLI-only change — there is no web interface to screenshot. Evidence
is the guard's own behaviour:

- Before the reword, `./scripts/check-docs-private-repo-refs.sh` exited **1** and
  listed 38 offending lines across 11 files.
- After the reword it exits **0**:
  `✅ CHANGELOG and docs free of private repo references`.
- `./quality.sh` passes end to end (shellcheck, cargo-deny, fmt, clippy, build,
  test, rustdoc, release build, all guards, 424 BATS tests).

## Test Plan

New BATS suite `tests/scripts/docs_private_repo_refs.bats` (9 tests) — each runs
the real script against synthetic fixtures and asserts exit codes and output:

- passes on a changelog with concept-level production wording
- fails when the changelog names the private repo (exit 1, offending file
  reported)
- fails when an archived PR summary names the private cluster repo
- reports **every** offending file, not just the first
- ignores markdown outside `CHANGELOG.md` and `docs/`
- allows the allowlisted remediation summaries
- fails loudly when the root does not exist (exit 1)
- rejects an unknown argument with a usage error (exit 2)
- **regression test:** the shipped `CHANGELOG.md` and `docs/` tree pass the guard
  — this test fails against the unfixed tree and passes after the reword

Existing suites are unchanged and all 424 BATS tests pass.



## Milestone
This PR is part of the **Public only** milestone and targets the `milestone/public-only` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrxij44f-cd0ec9`<!-- vibe-worker-issue-453 -->