### PR TITLE
Benchmark GPU vs CPU on shallow Enceladus creatures — negative result (Issue #467)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -331,6 +331,88 @@ target/release/rust_scorer            /tmp/neat-prod-creatures /tmp/neat-bench-d
 production `learn.sh` path: full-corpus evidence on M4 shows CPU wins at
 N=63, so the heuristic is topology-based rather than N-threshold.
 
+## Shallow-creature GPU vs CPU — 26 July 2026 (Issue #467, negative result)
+
+Cross-links [#333](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/333)
+(remains open, human-gated), [#317](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/317)
+(production-shape CPU winner) and [#323](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/323)
+(delete-GPU-code decision — unchanged by this result).
+
+**Question.** #317 measured CPU ~3× faster than GPU on the *deep* production
+shape (~1666 hidden). Issue #467 asks whether the GPU helps the **shallow**
+`Enceladus` island shape instead — far less per-record work, but the same
+scratch-kernel routing. If GPU won by the ≥3 % wall-clock gate (#323) at
+N=50–63 the GPU code would be kept and #333's production experiments closed as
+moot; otherwise the negative result is recorded and #333 stays open.
+
+**The shallow creatures** (from a private sample repository — not
+committed or fetched here):
+
+| Property | `Enceladus` | `Enceladus-Terminal` |
+|---|---:|---:|
+| Inputs / outputs | 2461 / 1 | 2461 / 1 |
+| Hidden neurons | 16 | 19 |
+| Synapses | 12 171 | 12 177 |
+| Squash mix | 13 point-wise (LogSigmoid, LeakyReLU, Softplus, ReLU, ELU, BENT_IDENTITY, SELU, ABSOLUTE, ReLU6, Mish, SOFTSIGN, ArcTan, TANH) | + MAXIMUM / IF aggregates + IDENTITY |
+| GPU-hostable? | Yes (all point-wise) | Yes (aggregates host since #312) |
+| Topology class | **ScratchOnly** (2461 inputs > 256 private cap) | **ScratchOnly** |
+
+Both exceed the 256-neuron private cap because **inputs count** toward it, so
+both route to `forward_mse_scratch` — the same kernel the deep production
+creature uses. The only variable versus #317 is the far lighter hidden layer.
+
+**Host:** Apple M4 (10 cores), 24 GB, macOS 26.5 / Metal 4; release
+`rust_scorer`. **Corpus:** synthetic production-record-size data (2461 inputs / 1
+output → 9848 B/record), 64 MiB (6814 records). The full 521-bin corpus is
+unavailable to the unattended worker (the #333 blocker), so bench data is
+generated at record size — fully autonomous.
+
+**Real-creature CLI wall-clock A/B** (`--gpu off` vs `--gpu on`, median of the
+binary's own `timeTaken` over 5 runs):
+
+| Shape | `N` | CPU (`--gpu off`) | GPU (`--gpu on`, metal) | GPU vs CPU |
+|---|---|---|---|---|
+| `Enceladus` | 50 | **0.371 s** | 0.811 s | **+119 % (2.19× slower)** |
+| `Enceladus` | 63 | **0.479 s** | 0.972 s | **+103 % (2.03× slower)** |
+| `Enceladus-Terminal` | 50 | **0.451 s** | 0.779 s | **+73 % (1.73× slower)** |
+| `Enceladus-Terminal` | 63 | **0.625 s** | 0.981 s | **+57 % (1.57× slower)** |
+
+**Reproducible synthetic confirmation** — the committed `shallow_gpu_vs_cpu`
+Criterion group scores a synthetic stand-in of the `Enceladus` topology (built
+by [`shallow_fixture`](../rust_scorer/src/shallow_fixture.rs), so no private
+creature is needed). Corpus 32 MiB; Criterion median:
+
+| `N` | CPU | GPU | GPU vs CPU |
+|---|---|---|---|
+| 50 | **324 ms** | 444 ms | **+37 % slower** |
+| 63 | **379 ms** | 522 ms | **+38 % slower** |
+
+```bash
+BENCH_SHALLOW_CREATURES=50 \
+  cargo bench -p rust_scorer --bench scoring -- shallow_gpu_vs_cpu
+```
+
+**Decision (negative result — GPU does not help).** The GPU is slower than CPU
+in **every** shape × `N` configuration; the ≥3 % win gate is not met (the sign
+is reversed). The scratch kernel's fixed per-dispatch and readback cost still
+dominates even though the shallow forward pass is light, so — exactly as for the
+deep production shape (#317) — CPU wins. Consequences:
+
+* **`--gpu auto` routing is unchanged.** Both shallow shapes are ScratchOnly, so
+  `auto_should_use_gpu_directory` already routes them to CPU (verified: `--gpu
+  auto` reports `gpuBackend: cpu-fallback` and prints the topology fallback
+  note, matching the `--gpu off` winner). No routing edit is warranted.
+* **#333 stays open and human-gated** — the remaining production-topology
+  experiments are not made moot; a shallow-shape GPU win would have closed them,
+  but there is none.
+* **The #323 delete-GPU-code decision is unchanged by this issue** (`--gpu on`
+  still forces GPU for debugging; the shallow benches join the standing
+  "CPU wins on scratch topology" evidence).
+
+**Do not re-benchmark GPU for shallow creatures** unless the creature topology
+(sub-256 total neurons → private kernel) or the scratch kernel architecture
+changes materially.
+
 ## Baseline — 25 April 2026
 
 | Field | Value |

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.34"
+version = "1.1.35"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/benches/scoring.rs
+++ b/rust_scorer/benches/scoring.rs
@@ -586,6 +586,98 @@ fn bench_large_creature_cpu_vs_gpu(c: &mut Criterion) {
     group.finish();
 }
 
+/// Issue #467: shallow-creature CPU vs GPU comparison. The `Enceladus` island
+/// shape (2461 inputs → 16 hidden → 1 output, ≈ 12 180 point-wise synapses)
+/// exceeds the 256-neuron private cap (inputs count) so it routes to the GPU
+/// `forward_mse_scratch` kernel, exactly like the deep production creature, but
+/// does far less per-record work. This group A/Bs `score_from_creature_dir`
+/// (CPU, `--gpu off`) against `score_from_creature_dir_gpu` (`--gpu on`) on a
+/// synthetic stand-in built by [`rust_scorer::shallow_fixture`], so the negative
+/// result is reproducible without the private `Enceladus` creature.
+///
+/// Sized via `BENCH_SHALLOW_HIDDEN` (default 16), `BENCH_SHALLOW_SYNAPSES`
+/// (default 12180), `BENCH_SHALLOW_CREATURES` (default 50 — a realistic island
+/// population; set 63 to match the #317 sweep) and `BENCH_SHALLOW_BYTES`
+/// (default 32 MiB). When no GPU adapter is present the GPU row is skipped so
+/// CPU-only CI runners still pass.
+fn bench_shallow_gpu_vs_cpu(c: &mut Criterion) {
+    let hidden = env_usize("BENCH_SHALLOW_HIDDEN", 16).max(1);
+    let synapses = env_usize("BENCH_SHALLOW_SYNAPSES", 12_180);
+    let n_creatures = env_usize("BENCH_SHALLOW_CREATURES", 50).max(1);
+    let total_bytes = env_usize("BENCH_SHALLOW_BYTES", 32 * 1024 * 1024);
+    // The Enceladus record shape: 2461 inputs / 1 output.
+    let num_inputs = env_usize("BENCH_SHALLOW_INPUTS", 2461).max(1);
+    let num_outputs = 1;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let creatures_dir = tmp.path().join("creatures");
+    fs::create_dir_all(&creatures_dir).unwrap();
+    let data_dir = tmp.path().join("data");
+    fs::create_dir_all(&data_dir).unwrap();
+
+    let json = rust_scorer::shallow_fixture::shallow_creature_json(
+        num_inputs,
+        num_outputs,
+        hidden,
+        synapses,
+    );
+    for n in 0..n_creatures {
+        fs::write(creatures_dir.join(format!("creature-{n:03}.json")), &json).unwrap();
+    }
+    write_synthetic_bin(&data_dir, num_inputs, num_outputs, total_bytes);
+
+    let mut group = c.benchmark_group("shallow_gpu_vs_cpu");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(20));
+    group.throughput(Throughput::Bytes(total_bytes as u64));
+
+    // CPU path (`--gpu off`).
+    group.bench_function(BenchmarkId::new("cpu", n_creatures), |b| {
+        b.iter(|| {
+            let result = score_from_creature_dir(
+                &creatures_dir,
+                &data_dir,
+                GpuBackendLabel::CpuFallback,
+                CostKind::default(),
+            )
+            .expect("cpu shallow-creature score");
+            black_box(result);
+        });
+    });
+
+    // GPU path (`--gpu on`, `forward_mse_scratch`).
+    let backend = resolve_backend(GpuMode::Auto).unwrap_or(GpuBackendLabel::CpuFallback);
+    if backend == GpuBackendLabel::CpuFallback {
+        eprintln!("shallow_gpu_vs_cpu: no GPU adapter — skipping GPU row");
+        group.finish();
+        return;
+    }
+    let ctx = match select_adapter() {
+        Ok(Some(c)) => Arc::new(c),
+        _ => {
+            eprintln!("shallow_gpu_vs_cpu: select_adapter returned no context");
+            group.finish();
+            return;
+        }
+    };
+    group.bench_function(BenchmarkId::new("gpu", n_creatures), |b| {
+        let ctx = ctx.clone();
+        b.iter(|| {
+            let result = score_from_creature_dir_gpu(
+                &creatures_dir,
+                &data_dir,
+                backend,
+                ctx.clone(),
+                2,
+                CostKind::default(),
+            )
+            .expect("gpu shallow-creature score");
+            black_box(result);
+        });
+    });
+    group.finish();
+}
+
 // ---------------------------------------------------------------------------
 // Issue #296 — production-scale fixture (evolved production creature).
 //
@@ -953,6 +1045,7 @@ criterion_group!(
     bench_gpu_score_from_creature_dir,
     bench_gpu_pipelining_toggle,
     bench_large_creature_cpu_vs_gpu,
+    bench_shallow_gpu_vs_cpu,
     bench_production_single,
     bench_production_multi,
     bench_production_gpu_vs_cpu,

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -23,5 +23,6 @@ pub mod prod_fixture;
 pub mod read_tuning;
 pub mod sampling;
 pub mod scoring;
+pub mod shallow_fixture;
 pub mod stream_io;
 pub mod stream_score;

--- a/rust_scorer/src/shallow_fixture.rs
+++ b/rust_scorer/src/shallow_fixture.rs
@@ -1,0 +1,225 @@
+//! Shallow-creature benchmark fixture — Issue #467.
+//!
+//! The [`production`](crate::prod_fixture) fixture gates optimisations against
+//! the deep evolved creature (~1666 hidden neurons). Issue #467 asks a
+//! different question: does the GPU help a **shallow** creature — the
+//! `Enceladus` island shape (2461 inputs → **16** hidden → 1 output, ≈ 12 180
+//! synapses, all point-wise squashes)? Both shapes exceed the 256-neuron
+//! private-kernel cap (inputs count toward it), so both route to the
+//! `forward_mse_scratch` GPU kernel; the shallow shape simply does far less
+//! per-record work, which is exactly the regime the A/B interrogates.
+//!
+//! The real `Enceladus` creature lives in a private sample repository and is
+//! **never** committed or fetched here (mirroring the [`prod_fixture`](crate::prod_fixture)
+//! contract).
+//! This module builds a **synthetic** stand-in of the same topology so the
+//! CPU-vs-GPU result is reproducible in CI without the private creature. The
+//! pure functions below are unit-tested; the Criterion `shallow_gpu_vs_cpu`
+//! group in [`benches/scoring.rs`](../../benches/scoring.rs) consumes them.
+
+/// The point-wise squash mix observed in the real `Enceladus` hidden layer.
+///
+/// Every entry is a **point-wise** activation (`SquashType` 0..=31), so the
+/// synthetic creature is fully GPU-hostable by both scratch and batched kernels
+/// — the same property the real creature has. Cycling this set across the
+/// hidden neurons reproduces the transcendental mix (`Mish`, `SELU`, `ELU`, …)
+/// that determines per-neuron CPU cost, the variable the A/B is sensitive to.
+pub const ENCELADUS_SQUASHES: &[&str] = &[
+    "LogSigmoid",
+    "LeakyReLU",
+    "Softplus",
+    "ReLU",
+    "ELU",
+    "BENT_IDENTITY",
+    "SELU",
+    "ABSOLUTE",
+    "ReLU6",
+    "Mish",
+    "SOFTSIGN",
+    "ArcTan",
+    "TANH",
+];
+
+/// How many `input → hidden` and `hidden → output` synapses a shallow creature
+/// of the given shape carries for a requested `target_synapses` total.
+///
+/// The `hidden → output` block is always fully wired (`hidden * num_outputs`);
+/// the remainder is spent on `input → hidden` edges. The `input → hidden` count
+/// is clamped to `[hidden, num_inputs * hidden]` so every hidden neuron has at
+/// least one incoming edge (no degenerate constant activation) and the wiring
+/// never exceeds the fully-connected maximum.
+///
+/// Returns `(input_hidden, hidden_output)`. The realised total
+/// (`input_hidden + hidden_output`) can differ from `target_synapses` only when
+/// the request is outside the representable range; callers that need the exact
+/// figure should sum the pair.
+#[must_use]
+pub fn plan_synapses(
+    num_inputs: usize,
+    num_outputs: usize,
+    hidden: usize,
+    target_synapses: usize,
+) -> (usize, usize) {
+    let hidden_output = hidden.saturating_mul(num_outputs);
+    let remainder = target_synapses.saturating_sub(hidden_output);
+    let max_input_hidden = num_inputs.saturating_mul(hidden);
+    let min_input_hidden = hidden.min(max_input_hidden);
+    let input_hidden = remainder.clamp(min_input_hidden, max_input_hidden);
+    (input_hidden, hidden_output)
+}
+
+/// Build a forward-only synthetic creature JSON matching the shallow `Enceladus`
+/// topology.
+///
+/// `input → hidden` edges are laid out as `(input = c / hidden, hidden =
+/// c % hidden)` for `c` in `0..input_hidden`, which yields **distinct** pairs
+/// (a base-`hidden` decomposition) spread evenly across the hidden layer while
+/// keeping the input index within `num_inputs`. Hidden neurons cycle
+/// [`ENCELADUS_SQUASHES`]; outputs use `IDENTITY`. The result parses with
+/// `neat_core::creature::parse_creature_json` and reports exactly
+/// `input_hidden + hidden_output` synapses (see [`plan_synapses`]).
+#[must_use]
+pub fn shallow_creature_json(
+    num_inputs: usize,
+    num_outputs: usize,
+    hidden: usize,
+    target_synapses: usize,
+) -> String {
+    let (input_hidden, _hidden_output) =
+        plan_synapses(num_inputs, num_outputs, hidden, target_synapses);
+
+    let mut neurons: Vec<String> = Vec::with_capacity(hidden + num_outputs);
+    for h in 0..hidden {
+        let squash = ENCELADUS_SQUASHES[h % ENCELADUS_SQUASHES.len()];
+        neurons.push(format!(
+            r#"{{"type":"hidden","uuid":"hidden-{h}","bias":0.05,"squash":"{squash}"}}"#
+        ));
+    }
+    for o in 0..num_outputs {
+        neurons.push(format!(
+            r#"{{"type":"output","uuid":"output-{o}","bias":0.0,"squash":"IDENTITY"}}"#
+        ));
+    }
+
+    let mut synapses: Vec<String> = Vec::with_capacity(input_hidden + hidden * num_outputs);
+    // input -> hidden, distinct (input, hidden) pairs spread across the layer.
+    // Weights are small and sign-alternating so the pre-activation of a hidden
+    // neuron fed by hundreds of inputs stays bounded: the *unbounded* squashes
+    // in the Enceladus mix (Softplus/ELU/Mish/ReLU) would overflow f32 to `inf`
+    // under large weights, whereas the real creature carries trained small
+    // weights. Timing depends on topology and squash type, not weight
+    // magnitude, so this keeps the A/B representative while finite.
+    for c in 0..input_hidden {
+        let i = c.checked_div(hidden).unwrap_or(0);
+        let h = c.checked_rem(hidden).unwrap_or(0);
+        let sign = if c % 2 == 0 { 1.0 } else { -1.0 };
+        let w = sign * (0.002 + 0.0001 * ((c % 37) as f64));
+        synapses.push(format!(
+            r#"{{"fromUUID":"input-{i}","toUUID":"hidden-{h}","weight":{w}}}"#
+        ));
+    }
+    // hidden -> output, fully wired.
+    for h in 0..hidden {
+        for o in 0..num_outputs {
+            let w = 0.05 + 0.001 * ((h * num_outputs + o) as f64);
+            synapses.push(format!(
+                r#"{{"fromUUID":"hidden-{h}","toUUID":"output-{o}","weight":{w}}}"#
+            ));
+        }
+    }
+
+    format!(
+        r#"{{"input":{num_inputs},"output":{num_outputs},"forwardOnly":true,"semanticVersion":"4.0.0","neurons":[{}],"synapses":[{}]}}"#,
+        neurons.join(","),
+        synapses.join(","),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neat_core::creature::parse_creature_json;
+
+    // The real Enceladus shape, observed in the private sample repository.
+    const ENC_INPUTS: usize = 2461;
+    const ENC_HIDDEN: usize = 16;
+    const ENC_SYNAPSES: usize = 12_171;
+
+    #[test]
+    fn plan_synapses_hits_enceladus_shape() {
+        // Happy path: 16*1 = 16 hidden->output, rest input->hidden.
+        let (ih, ho) = plan_synapses(ENC_INPUTS, 1, ENC_HIDDEN, ENC_SYNAPSES);
+        assert_eq!(ho, 16);
+        assert_eq!(ih, ENC_SYNAPSES - 16);
+        assert_eq!(ih + ho, ENC_SYNAPSES);
+    }
+
+    #[test]
+    fn plan_synapses_clamps_below_minimum() {
+        // Edge case: a target smaller than the hidden->output block still
+        // guarantees one incoming edge per hidden neuron.
+        let (ih, ho) = plan_synapses(ENC_INPUTS, 1, ENC_HIDDEN, 4);
+        assert_eq!(ho, 16);
+        assert_eq!(ih, ENC_HIDDEN, "input->hidden clamps up to `hidden`");
+    }
+
+    #[test]
+    fn plan_synapses_clamps_to_fully_connected_maximum() {
+        // Edge case: an absurd target cannot exceed inputs*hidden.
+        let (ih, _ho) = plan_synapses(10, 1, 4, 1_000_000);
+        assert_eq!(ih, 40, "input->hidden clamps down to num_inputs*hidden");
+    }
+
+    #[test]
+    fn shallow_creature_json_parses_with_expected_topology() {
+        let json = shallow_creature_json(ENC_INPUTS, 1, ENC_HIDDEN, ENC_SYNAPSES);
+        let creature = parse_creature_json(&json).expect("shallow creature parses");
+        assert_eq!(creature.input, ENC_INPUTS);
+        assert_eq!(creature.output, 1);
+        assert!(creature.forward_only);
+        assert_eq!(creature.neurons.len(), ENC_HIDDEN + 1, "hidden + output");
+        assert_eq!(
+            creature.synapses.len(),
+            ENC_SYNAPSES,
+            "realised synapse count matches the requested Enceladus total"
+        );
+    }
+
+    #[test]
+    fn shallow_creature_input_hidden_edges_are_distinct() {
+        // Regression guard: duplicate (input, hidden) pairs would let neat_core
+        // merge edges and silently shrink the synapse count, corrupting the A/B.
+        let json = shallow_creature_json(ENC_INPUTS, 1, ENC_HIDDEN, ENC_SYNAPSES);
+        let creature = parse_creature_json(&json).expect("parse");
+        let mut seen = std::collections::HashSet::new();
+        for syn in &creature.synapses {
+            assert!(
+                seen.insert((syn.from_uuid.clone(), syn.to_uuid.clone())),
+                "duplicate synapse {} -> {}",
+                syn.from_uuid,
+                syn.to_uuid
+            );
+        }
+    }
+
+    #[test]
+    fn shallow_creature_uses_only_pointwise_squashes() {
+        // Every hidden squash must be a real, GPU-hostable point-wise name so
+        // the synthetic creature routes through the same kernel as the real one.
+        let json = shallow_creature_json(ENC_INPUTS, 1, ENC_HIDDEN, ENC_SYNAPSES);
+        let creature = parse_creature_json(&json).expect("parse");
+        let hidden: Vec<_> = creature
+            .neurons
+            .iter()
+            .filter(|n| n.neuron_type == "hidden")
+            .collect();
+        assert_eq!(hidden.len(), ENC_HIDDEN);
+        for n in hidden {
+            let squash = n.squash.as_deref().expect("hidden neuron has a squash");
+            assert!(
+                ENCELADUS_SQUASHES.contains(&squash),
+                "unexpected hidden squash {squash}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Benchmarked `--gpu on` vs `--gpu off` scoring on the **shallow** `Enceladus`
island creature shape (2461 inputs → 16 hidden → 1 output, ≈ 12 180 point-wise
synapses) and its near-twin `Enceladus-Terminal` (19 hidden, + MAXIMUM/IF
aggregates) to decide whether the GPU helps this topology. **It does not.** The
GPU is slower than CPU in every shape × N configuration measured — the opposite
of the ≥ 3 % wall-clock win gate — so this is a **negative result**. Closes #467.

Consequences (all per the issue's accepted scope):

* **`--gpu auto` routing is unchanged.** Both shapes are ScratchOnly (2461
  inputs exceed the 256-neuron private-kernel cap, which counts inputs), so
  `auto_should_use_gpu_directory` already routes them to CPU. Verified: `--gpu
  auto` reports `gpuBackend: cpu-fallback` with the topology fallback note,
  matching the `--gpu off` winner. No routing edit is warranted.
* **#333 stays open and human-gated** — a shallow-shape GPU win would have
  closed its remaining production-topology experiments; there is none.
* **The #323 delete-GPU-code decision is unchanged** — `--gpu on` still forces
  GPU for debugging; these benches join the standing "CPU wins on scratch
  topology" evidence (#317).

This is a measurement/decision task; the deliverable is the recorded result plus
a reproducible bench, not a routing change.

## Evidence

Backend/CLI change — no web UI to screenshot. Evidence is benchmark numbers,
recorded in [`docs/performance-baseline.md`](../../performance-baseline.md) under
*"Shallow-creature GPU vs CPU — 26 July 2026 (Issue #467, negative result)"*.

**Real-creature CLI wall-clock A/B** (Apple M4 / Metal, release binary, 64 MiB
synthetic production-record-size corpus; median of the binary's own `timeTaken`
over 5 runs):

| Shape | N | CPU (`--gpu off`) | GPU (`--gpu on`, metal) | GPU vs CPU |
|---|---|---|---|---|
| `Enceladus` | 50 | **0.371 s** | 0.811 s | **+119 % (2.19× slower)** |
| `Enceladus` | 63 | **0.479 s** | 0.972 s | **+103 % (2.03× slower)** |
| `Enceladus-Terminal` | 50 | **0.451 s** | 0.779 s | **+73 % (1.73× slower)** |
| `Enceladus-Terminal` | 63 | **0.625 s** | 0.981 s | **+57 % (1.57× slower)** |

**Reproducible synthetic confirmation** — the committed `shallow_gpu_vs_cpu`
Criterion group scores a synthetic stand-in of the `Enceladus` topology built by
the new `shallow_fixture` module, so no private creature is required (32 MiB
corpus, Criterion median):

| N | CPU | GPU | GPU vs CPU |
|---|---|---|---|
| 50 | **324 ms** | 444 ms | **+37 % slower** |
| 63 | **379 ms** | 522 ms | **+38 % slower** |

```bash
BENCH_SHALLOW_CREATURES=50 \
  cargo bench -p rust_scorer --bench scoring -- shallow_gpu_vs_cpu
```

```mermaid
flowchart TD
    A[Shallow Enceladus shape<br/>2461 in / 16 hidden / 1 out] --> B{Total neurons > 256 cap?<br/>inputs count}
    B -->|Yes: 2461 > 256| C[ScratchOnly topology<br/>routes to forward_mse_scratch]
    C --> D{"--gpu on vs off<br/>N = 50-63"}
    D -->|Measured| E["GPU 1.6-2.2x SLOWER<br/>gate not met"]
    E --> F[auto stays CPU · #333 stays open · #323 unchanged]
```

Why: the scratch kernel's fixed per-dispatch and readback cost dominates even
though the shallow forward pass is light — the same reason CPU wins on the deep
production shape (#317).

## Test Plan

- Added `rust_scorer/src/shallow_fixture.rs` with 6 unit tests (TDD, written
  before the implementation) exercising the real fixture functions:
  - `plan_synapses_hits_enceladus_shape` — happy path, exact split.
  - `plan_synapses_clamps_below_minimum` — edge: target below the
    hidden→output block still gives every hidden neuron an incoming edge.
  - `plan_synapses_clamps_to_fully_connected_maximum` — edge: absurd target
    clamps to `inputs × hidden`.
  - `shallow_creature_json_parses_with_expected_topology` — parses via
    `neat_core::creature::parse_creature_json`; asserts inputs/outputs/neuron
    and exact synapse counts.
  - `shallow_creature_input_hidden_edges_are_distinct` — regression guard: no
    duplicate `(input, hidden)` pairs (which would let neat_core merge edges and
    silently shrink the synapse count).
  - `shallow_creature_uses_only_pointwise_squashes` — every hidden squash is a
    real, GPU-hostable point-wise name.
- Added the `shallow_gpu_vs_cpu` Criterion group in
  `rust_scorer/benches/scoring.rs` (CPU vs GPU on the synthetic shallow shape),
  registered in `criterion_group!`.
- `./quality.sh` passes cleanly (fmt, clippy `-D warnings`, cargo-deny, build,
  test, rustdoc, release build, shellcheck, codespell, private-repo-ref guards).

No existing tests were modified or removed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms1p9lgr-32e850`<!-- vibe-worker-issue-467 -->