### PR TITLE
Scorer-local dead-code audit: clear vestigial code and parameters (Issue #470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ section to the released version with its date.
 
 ## [Unreleased]
 
+### Removed
+
+- **Scorer-local dead-code audit (Issue #470).** Re-ran the superseded
+  `neat-core` API check across `rust_scorer/{src,tests,benches}` — **0 hits**
+  for `score_records` / `score_records_parallel`; scoring still goes through
+  the fused packed path (`neat_core::loss::mse_sum_batch_packed` and its
+  `mae_`/`mape_` siblings). Verified every `#[allow(dead_code)]` site against
+  the consumer its comment names and cleared what no longer held: the
+  `env_tuning` / `read_tuning` module copies in
+  `rust_scorer/src/bin/cost_scan_bench.rs` were declared but never referenced
+  and have been deleted, and the now-reachable `GpuContext` and
+  `score_from_creature_dir_gpu_sampled` lost their vestigial attributes (21 →
+  17 sites). Also dropped the never-read `creature: &CreatureExport` parameter
+  from `stream_score::accumulate_cost_sum_forward_only_fused` and its
+  `_sampled` variant — `TrainingDataConfig` already carries the input/output
+  widths the fused reader needs. No behaviour change.
+
 ### Changed
 
 - **`--gpu auto` routes shallow scratch pools to GPU (Issue #467).** Issue #317

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.33"
+version = "1.1.35"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-470.md
+++ b/docs/archive/pr-summaries/pr-summary-470.md
@@ -1,0 +1,202 @@
+# Scorer-local dead-code audit (Issue #470)
+
+## Summary
+
+Scorer-only slice of the #466 plan. Confirmed `rust_scorer` uses **no**
+superseded `neat-core` entry point, verified every `#[allow(dead_code)]` site
+against the consumer its comment names, and cleared the vestigial code and
+parameters the #428–#430 sweep left behind. No behaviour change — no test
+expectation was edited to accommodate a removal. Closes #470.
+
+Headline numbers:
+
+| Audit item | Result |
+| --- | --- |
+| Superseded-API hits (`score_records`, `score_records_parallel`) across `src`, `tests`, `benches` | **0** |
+| `#[allow(dead_code)]` sites before | 21 |
+| `#[allow(dead_code)]` sites after | **17** (all consumers verified in this pass) |
+| Sites deleted as genuinely dead | 2 |
+| Sites whose attribute was dropped (item now reachable) | 2 |
+| Vestigial parameters removed | 1 (across 2 entry points) |
+
+## Task 1 — superseded `neat-core` API: 0 hits
+
+```text
+$ grep -rn "score_records" rust_scorer/src rust_scorer/tests rust_scorer/benches | wc -l
+0
+```
+
+Scoring still runs through the fused packed path — `neat_core::loss::mse_sum_batch_packed`
+(`rust_scorer/src/cost.rs`, with the `mae_` / `mape_` siblings alongside it),
+driven by `neat_core::training_bin_stream::for_each_read_chunk`. Nothing to
+migrate.
+
+## Task 2 — `#[allow(dead_code)]` disposition list
+
+Method (not a source grep — an actual compiler check): the workspace sets
+`unused = "deny"`, so every attribute was **stripped from the tree** and
+`cargo clippy --all-targets --all-features` was run. Any site that produced a
+`never used` / `never read` / `never constructed` error still has no consumer
+in at least one target and must keep the attribute; any site that produced no
+error is reachable from ordinary code and the attribute is vestigial. The named
+consumer of each surviving site was then confirmed by locating the call.
+
+### Confirmed live — attribute retained (17)
+
+| Site | Item | Verified consumer |
+| --- | --- | --- |
+| `src/multi_score.rs:77` | `training_pass_probe::reset` | `tests/single_pass_assertion.rs:73` |
+| `src/multi_score.rs:83` | `training_pass_probe::count` | `tests/single_pass_assertion.rs:89` |
+| `src/multi_score.rs:120` | `compile_probe::reset` | `tests/compile_once_assertion.rs:71` |
+| `src/multi_score.rs:126` | `compile_probe::count` | `tests/compile_once_assertion.rs:87` |
+| `src/multi_score.rs:310` | `enum EarlyExit` | `tests/early_exit_tdd.rs:110/166/221/266`, `benches/scoring.rs:1026` |
+| `src/multi_score.rs:372` | `score_from_creature_dir` | `tests/{compile_once_assertion,single_pass_assertion,sample_rate_directory,early_exit_tdd,gpu_mae_parity,gpu_rmse_parity}.rs`, `benches/scoring.rs` |
+| `src/multi_score.rs:464` | `score_from_creature_dir_with_early_exit` | `tests/early_exit_tdd.rs:101/153/214/248`, `benches/scoring.rs:1013` |
+| `src/multi_score.rs:996` | `score_from_creature_dir_gpu` | `tests/gpu_{mae_parity,rmse_parity,pipelined_parity,pipelined_scratch_multi_bin,sample_rate_parity}.rs`, `src/bin/gpu_pipeline_alloc_bench.rs:159`, `benches/scoring.rs` |
+| `src/stream_score.rs:157` | `accumulate_cost_sum_forward_only_fused` | `src/bin/cost_scan_bench.rs:116/128`, `benches/scoring.rs:254/834` |
+| `src/gpu/forward_mse_batched.rs:644` | `BatchedRunner::kernel` | `tests/gpu_multi_score_parity.rs:128` |
+| `src/gpu/mod.rs:134` | `GpuBackendLabel::as_str` | `tests/gpu_mae_parity.rs:120` |
+| `src/gpu/mod.rs:216` | `ScoringPath::SingleCreature` | `src/gpu/mod.rs:562/830` (unit tests) |
+| `src/gpu/mod.rs:503` | `resolve_backend` | all seven `tests/gpu_*.rs` files, `benches/scoring.rs:49` |
+| `src/sampling.rs:79` | `SampleSpec::phase` | `src/sampling.rs:241` (unit test) |
+| `src/sampling.rs:147` | `RecordSampler::full` | `src/sampling.rs:265/397`, `src/stream_io.rs:318/350/407` (unit tests) |
+| `src/cost.rs:131` | `CostKind::from_cli` | doctest at `src/cost.rs:124-125` + `cost::tests` |
+| `src/cost.rs:340` | `supported_list` | `src/cost.rs:41` (`Display for InvalidCostName`) |
+
+Three of these had a **stale comment** naming a consumer that no longer
+described reality; the comments were corrected in place (the item itself stayed):
+
+- `GpuBackendLabel::as_str` — "consumed by callers once GPU kernels land" (they
+  landed; the real consumer is `tests/gpu_mae_parity.rs`).
+- `CostKind::from_cli` — "dispatch landing in #119-3"; the live consumers are
+  the doctest and the `cost::tests` unit tests.
+- `accumulate_cost_sum_forward_only_fused` — "benches/tests" narrowed to the two
+  files that actually call it.
+
+### Deleted — genuinely unused (2)
+
+- `src/bin/cost_scan_bench.rs` — `#[path = "../env_tuning.rs"] mod env_tuning;`
+  and `#[path = "../read_tuning.rs"] mod read_tuning;`. Both module copies were
+  declared (mirroring `float_scan_bench`, which *does* use them) but nothing in
+  the bench referenced a single item from either; stripping the attributes
+  surfaced eight `never used` errors covering the whole of both modules. This
+  bench drives the library entry point
+  `rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused`, which
+  applies the crate's own read tuning internally.
+
+### Attribute dropped — item now reachable from ordinary code (2)
+
+- `src/gpu/mod.rs` — `struct GpuContext`. The Issue #80 comment said "nothing
+  consumes `device`/`queue` yet"; both are now consumed by the batched and
+  scratch kernels in `gpu::forward_mse_batched`, and `main.rs:327` holds the
+  context. Doc comment updated to match.
+- `src/multi_score.rs` — `score_from_creature_dir_gpu_sampled`. Its own comment
+  already said "used by the CLI's sampled path" — `main.rs:354` calls it, so the
+  binary's module tree reaches it and the attribute was pure noise.
+
+### GPU sites — checked, not deleted (per the issue's "out of scope")
+
+`gpu/**` is live code (#467 benchmarked GPU 45–50 % faster on shallow creatures;
+issue #323 is closed). Every GPU allow site above was verified to have a real
+consumer, so "investigate, not delete" did not need to be exercised.
+
+## Task 3 — vestigial parameters
+
+Every `fn` in `rust_scorer/src` was traced to all call sites in `src`, `tests`
+and `benches`, looking for parameters that are never read or that receive the
+same constant everywhere.
+
+**Removed:**
+
+- `creature: &CreatureExport` from
+  `stream_score::accumulate_cost_sum_forward_only_fused` **and**
+  `accumulate_cost_sum_forward_only_fused_sampled`. The `_sampled` variant had
+  already been `_`-prefixed (never read); the full-rate wrapper existed only to
+  thread the value into it. `TrainingDataConfig` already carries the
+  input/output widths the fused reader needs, and the pre-compiled
+  `CompiledNetwork` carries the topology, so the export was dead weight at every
+  call site. Updated: `src/main.rs`, `src/bin/cost_scan_bench.rs` (×2),
+  `benches/scoring.rs` (×2) and the doctest.
+
+**Kept, with a comment stating why** (each is read, so removal would change the
+public reporting seam rather than delete dead weight):
+
+- `gpu_backend: GpuBackendLabel` on `main.rs::score_from_json` and on the CPU
+  directory chain (`multi_score::score_from_creature_dir_cpu` and its wrappers).
+  Always `CpuFallback` at every CPU call site, but it *is* read into
+  `ScoreResult::gpu_backend` — the value serialised as the `gpuBackend` JSON
+  field — and `score_from_creature_dir_gpu_impl` passes a real adapter label
+  through the same parameter. Hard-coding it would fork the reporting path.
+- `path: ScoringPath` on `gpu::auto_topology_fallback_note`. Every call site
+  passes `CreatureDirectory`, so the guard cannot fire today; the parameter
+  mirrors the sibling `auto_cost_fallback_note` (which *is* exercised with
+  `SingleCreature`), and `main.rs` selects the note helper by mode rather than
+  by path — a future single-creature kernel must not silently inherit the
+  directory-topology note.
+- `num_outputs` on `shallow_fixture::plan_synapses` / `shallow_creature_json`.
+  Always `1` in-tree (the Enceladus shape) but genuinely read — it sets the
+  `hidden → output` edge count.
+- `forward_only: bool` and its companions on `cost::accumulate_cost_sum`.
+  **Mirrors the `neat_core::loss::*_sum_batch_packed` signature** and is
+  genuinely variable (`false` at `main.rs` for the recurrent branch).
+- `num_creatures: u32` on `BatchedRunner::from_data` — derivable from
+  `data.creatures.len()`, but it is the dispatch height every other runner field
+  keys off. Its doc comment claimed "used by tests"; corrected to name the only
+  in-tree caller, `BatchedRunner::new`.
+
+Explicitly re-checked and found genuinely variable (no action): `inflight_chunks`,
+`effective_directory_gpu_inflight::requested`, `SampleSpec::new::phase`,
+`growth_cost`, `auto_should_use_gpu::path`, the fallback helpers' `mode`, every
+`cost: CostKind`, and `env_tuning::parse_tuning_var::name`. `ScoringConfig::forward_only`
+was excluded up front per the issue.
+
+## Evidence
+
+Backend/CLI change only — no web interface, so no Playwright screenshot. The
+gate is the compiler plus the existing regression suites.
+
+```mermaid
+flowchart TD
+    A["21 #[allow(dead_code)] sites"] --> B["Strip every attribute<br/>from rust_scorer/src"]
+    B --> C["cargo clippy --all-targets<br/>(workspace: unused = deny)"]
+    C -->|"error: never used"| D["Attribute still required<br/>→ locate named consumer"]
+    C -->|"compiles clean"| E["Attribute vestigial"]
+    D -->|consumer found| F["Keep — 17 sites<br/>(3 stale comments corrected)"]
+    D -->|no consumer anywhere| G["Delete item — 2 sites<br/>cost_scan_bench mod copies"]
+    E --> H["Drop attribute — 2 sites<br/>GpuContext, ..._gpu_sampled"]
+```
+
+Verification commands (all run locally, stdin redirected from `/dev/null`):
+
+- `cargo clippy --all-targets --all-features` — clean. This is the tripwire for
+  a wrong deletion: `unused = "deny"` turns "removed something still live" or
+  "dropped an attribute from something genuinely unreferenced" into a hard
+  compile error.
+- `./quality.sh < /dev/null` — green (fmt, cargo-deny, clippy, build, test,
+  rustdoc, release build, shellcheck, codespell, bats).
+
+## Test Plan
+
+No new test file: the acceptance criteria are enforced by gates that already
+exist, and adding a source-grepping "audit test" would assert on source text
+rather than behaviour.
+
+- **Wrong deletion of live code** → `unused = "deny"` + ordinary type-checking.
+  `cargo clippy --all-targets --all-features` inside `./quality.sh`, mirrored by
+  the PR CI workflow, fails the build. Exercised deliberately during the audit
+  (the strip-and-compile pass above) rather than assumed.
+- **Removal of the `env_tuning` / `read_tuning` module copies** →
+  `rust_scorer/tests/cost_scan_bench_smoke.rs::cost_scan_bench_emits_one_row_per_supported_cost`
+  drives the `cost_scan_bench` binary end-to-end against a synthetic creature
+  and corpus and asserts one JSON row per supported `CostKind`. It passes
+  unchanged.
+- **Behaviour drift from the `creature` parameter removal** → the scoring
+  regression suites pin real outputs and pass unchanged:
+  `tests/scorer_smoke.rs`, `tests/cost_parity.rs`, `tests/directory_mode_tdd.rs`,
+  `tests/sample_rate_tdd.rs`, `tests/sample_rate_directory.rs`,
+  `tests/single_pass_assertion.rs`, `tests/compile_once_assertion.rs`,
+  `tests/early_exit_tdd.rs`, plus the `prod_fixture`-backed Criterion path and
+  the `tests/gpu_*.rs` GPU-vs-CPU parity set. **No test expectation was edited.**
+- **Doctest** for `accumulate_cost_sum_forward_only_fused` updated to the new
+  signature and re-checked by `RUSTDOCFLAGS="-D warnings" cargo doc` /
+  `cargo test --doc` in `./quality.sh`.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.35"
+version = "1.1.36"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/benches/scoring.rs
+++ b/rust_scorer/benches/scoring.rs
@@ -255,7 +255,6 @@ fn bench_score_from_json_fused(c: &mut Criterion) {
                     CostKind::Mse,
                     &bin_files,
                     &config,
-                    &creature,
                     &mut net,
                 )
                 .expect("fused MSE accumulate");
@@ -836,7 +835,6 @@ fn bench_production_single(c: &mut Criterion) {
                     CostKind::Mse,
                     &bin_files,
                     &config,
-                    creature,
                     &mut net,
                 )
                 .expect("fused MSE accumulate");

--- a/rust_scorer/src/bin/cost_scan_bench.rs
+++ b/rust_scorer/src/bin/cost_scan_bench.rs
@@ -27,12 +27,12 @@
 //! existing `float_scan_bench` defaults to 7 runs, this bin defaults to 5 so
 //! a 6-cost sweep stays within ~1 minute on a small corpus.
 
-#[path = "../env_tuning.rs"]
-#[allow(dead_code)] // helper module shared with read_tuning; only the parser is used here.
-mod env_tuning;
-#[path = "../read_tuning.rs"]
-#[allow(dead_code)] // selectively used by the bench; the rest mirrors float_scan_bench.
-mod read_tuning;
+// Issue #470 dead-code audit: the `env_tuning` / `read_tuning` module copies
+// `float_scan_bench` needs were declared here too but never referenced — this
+// bench drives the library entry point
+// `rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused`, which
+// applies the crate's own read tuning internally. Both `mod` declarations (and
+// the `#[allow(dead_code)]` attributes that masked them) have been removed.
 
 use std::fs;
 use std::path::PathBuf;
@@ -113,7 +113,7 @@ fn run_one_cost(
     // Warm-up run: validates the cost is dispatchable and primes caches.
     let mut net = compile_creature(&creature).map_err(|e| e.to_string())?;
     let (warm_sum, warm_records, _, _, _) =
-        accumulate_cost_sum_forward_only_fused(cost, bin_files, config, &creature, &mut net)?;
+        accumulate_cost_sum_forward_only_fused(cost, bin_files, config, &mut net)?;
 
     let mut times = Vec::with_capacity(runs);
     let mut checksum = warm_sum;
@@ -125,7 +125,7 @@ fn run_one_cost(
         let mut net = compile_creature(&creature).map_err(|e| e.to_string())?;
         let t0 = Instant::now();
         let (sum, n_records, _, _, _) =
-            accumulate_cost_sum_forward_only_fused(cost, bin_files, config, &creature, &mut net)?;
+            accumulate_cost_sum_forward_only_fused(cost, bin_files, config, &mut net)?;
         let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
         times.push(elapsed_ms);
         checksum = sum;

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -124,9 +124,10 @@ impl CostKind {
     /// assert_eq!(CostKind::from_cli("MSE").unwrap(), CostKind::Mse);
     /// assert!(CostKind::from_cli("FOO").is_err());
     /// ```
-    // Consumed by unit tests and downstream callers (`NeatOptions.costName`
-    // pass-through, dispatch landing in #119-3); the bin target itself
-    // relies on clap, not this helper.
+    // `#[allow(dead_code)]`: public library API for `NeatOptions.costName`
+    // pass-through, exercised by the doctest above and by the `cost::tests`
+    // unit tests; the bin target parses `--cost` through clap's `ValueEnum`,
+    // not this helper. Consumers re-verified in the Issue #470 audit.
     #[allow(dead_code)]
     pub fn from_cli(raw: &str) -> Result<Self, InvalidCostName> {
         // Exact-match parsing — the TypeScript names are upper-case, so we

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -424,9 +424,11 @@ impl BatchedRunner {
         Ok(Self::from_data(ctx, &data, networks.len() as u32, cost))
     }
 
-    /// Construct a runner from already-serialised batched data. Used by tests
+    /// Construct a runner from already-serialised batched data, for callers
     /// that want to drive the kernel without building a full `CompiledNetwork`
-    /// pool.
+    /// pool. Issue #470 audit: the only in-tree caller today is
+    /// [`BatchedRunner::new`]; `num_creatures` stays explicit because it is the
+    /// dispatch height and every other field of the runner is derived from it.
     ///
     /// `cost` selects the per-record loss the kernel accumulates (Issue #316):
     /// squared error for MSE/RMSE, absolute error for MAE. Only a

--- a/rust_scorer/src/gpu/mod.rs
+++ b/rust_scorer/src/gpu/mod.rs
@@ -128,7 +128,10 @@ pub enum GpuBackendLabel {
 
 impl GpuBackendLabel {
     /// Stable serialised label as a `&'static str`. Matches the JSON form.
-    #[allow(dead_code)] // used by tests; consumed by callers once GPU kernels land.
+    // `#[allow(dead_code)]`: consumed by `tests/gpu_mae_parity.rs` (backend
+    // gating); the binary serialises the label through `serde`, not this
+    // accessor. Consumer re-verified in the Issue #470 audit.
+    #[allow(dead_code)]
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Metal => "metal",
@@ -183,10 +186,11 @@ impl std::error::Error for GpuInitError {}
 
 /// A successfully-initialised GPU context ready to drive kernels.
 ///
-/// For Issue #80 nothing consumes `device`/`queue` yet — they exist so the
-/// follow-up GPU kernel work in #81 can plug straight in without churning
-/// this module's public API.
-#[allow(dead_code)] // device/queue used by follow-up GPU kernel issues (#81+).
+/// Every field is live: `device`/`queue` are consumed by the batched and
+/// scratch kernels in [`crate::gpu::forward_mse_batched`], and `backend`
+/// feeds the `gpuBackend` JSON field. The Issue #80 `#[allow(dead_code)]`
+/// placeholder was retired in the Issue #470 audit once those consumers
+/// landed.
 pub struct GpuContext {
     /// The initialised `wgpu` logical device used to allocate kernel resources.
     pub device: wgpu::Device,
@@ -298,6 +302,13 @@ pub fn auto_should_use_gpu_directory(
 /// Takes the same shared probe as [`auto_should_use_gpu_directory`].
 pub fn auto_topology_fallback_note(
     mode: GpuMode,
+    // Issue #470 vestigial-parameter sweep: every current call site passes
+    // `ScoringPath::CreatureDirectory`, so the guard below cannot fire today.
+    // The parameter stays deliberately — it mirrors the sibling
+    // [`auto_cost_fallback_note`] signature (which *is* exercised with
+    // `SingleCreature`), and `main.rs` picks the note helper by mode, not by
+    // path, so a future single-creature GPU kernel must not silently inherit
+    // the directory-topology note.
     path: ScoringPath,
     cost: crate::cost::CostKind,
     probe: Option<crate::multi_score::DirectoryGpuProbe>,

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -408,6 +408,11 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
 fn score_from_json(
     creature_json: &str,
     data_path: &Path,
+    // Issue #470 vestigial-parameter sweep: always `CpuFallback` today because
+    // Issue #81 closed single-creature GPU as a negative result. Kept because
+    // it is read into `ScoreResult::gpu_backend` (the `gpuBackend` JSON field)
+    // and keeps one reporting seam shared with the directory paths, so a future
+    // single-creature kernel flips the label in one place.
     gpu_backend: GpuBackendLabel,
     // Issue #121 — resolved cost selector. Dispatched through the fused
     // streaming path for `forwardOnly` creatures and through a per-record
@@ -471,7 +476,6 @@ fn score_from_json(
                     cost,
                     &bin_files,
                     &config,
-                    &creature,
                     &mut network,
                     *sample,
                 )?;

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -491,6 +491,13 @@ where
 fn score_from_creature_dir_cpu(
     creatures_dir: &Path,
     data_path: &Path,
+    // Issue #470 vestigial-parameter sweep: every CPU-path call site (`main.rs`,
+    // the benches and the CPU legs of the parity tests) passes
+    // `GpuBackendLabel::CpuFallback`, but the parameter must stay. It is read
+    // into `ScoreResult::gpu_backend` — i.e. it is the value serialised as the
+    // `gpuBackend` JSON field — and the label is threaded rather than hard-coded
+    // so the CPU and GPU directory paths keep one shared reporting seam
+    // (`score_from_creature_dir_gpu_impl` passes a real adapter label here).
     gpu_backend: GpuBackendLabel,
     cost: CostKind,
     mut on_chunk: Option<&mut EarlyExitCallback<'_>>,
@@ -1018,9 +1025,9 @@ pub fn score_from_creature_dir_gpu(
 /// Same single-pass GPU envelope, but only the deterministic subsample selected
 /// by `sample` is dispatched to the kernel. `SampleSpec::full()` reproduces the
 /// full-corpus GPU result exactly.
-// `#[allow(dead_code)]`: library API used by the CLI's sampled path and by
-// tests/benches; the binary's self-contained module tree may not call it.
-#[allow(dead_code)]
+// Issue #470 dead-code audit: no `#[allow(dead_code)]` here — the binary's
+// own module tree reaches this function (`main.rs` GPU directory path), as do
+// `tests/gpu_sample_rate_parity.rs` and the Criterion bench.
 pub fn score_from_creature_dir_gpu_sampled(
     creatures_dir: &Path,
     data_path: &Path,

--- a/rust_scorer/src/shallow_fixture.rs
+++ b/rust_scorer/src/shallow_fixture.rs
@@ -53,6 +53,10 @@ pub const ENCELADUS_SQUASHES: &[&str] = &[
 /// (`input_hidden + hidden_output`) can differ from `target_synapses` only when
 /// the request is outside the representable range; callers that need the exact
 /// figure should sum the pair.
+// Issue #470 vestigial-parameter sweep: every in-tree caller passes
+// `num_outputs = 1` (the Enceladus shape), but the parameter is genuinely read
+// — it sets the `hidden → output` edge count — and keeping it generic keeps
+// this fixture symmetrical with `prod_fixture`. Not a vestige.
 #[must_use]
 pub fn plan_synapses(
     num_inputs: usize,

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -19,7 +19,6 @@ use crate::cost::{CostKind, accumulate_cost_sum};
 use crate::read_tuning::{MAX_READ_BYTES, training_read_target_bytes_from_env};
 use crate::sampling::SampleSpec;
 use crate::stream_io::run_io_loop;
-use neat_core::creature::CreatureExport;
 use neat_core::network::CompiledNetwork;
 use neat_core::training_bin_stream::for_each_read_chunk;
 use neat_core::training_data::TrainingDataConfig;
@@ -145,7 +144,6 @@ fn partition_packed_records(
 ///         CostKind::Mse,
 ///         &bin_files,
 ///         &config,
-///         &creature,
 ///         &mut network,
 ///     )
 ///     .unwrap();
@@ -153,21 +151,20 @@ fn partition_packed_records(
 /// println!("mean error = {mean_error}");
 /// ```
 // `#[allow(dead_code)]`: the full-rate wrapper is the library entry point used
-// by benches/tests; the CLI binary calls the `_sampled` variant directly, so its
-// self-contained module tree never invokes this delegator.
+// by `src/bin/cost_scan_bench.rs` and `benches/scoring.rs`; the CLI binary
+// calls the `_sampled` variant directly, so its self-contained module tree
+// never invokes this delegator. Consumers re-verified in the Issue #470 audit.
 #[allow(dead_code)]
 pub fn accumulate_cost_sum_forward_only_fused(
     cost: CostKind,
     bin_files: &[std::path::PathBuf],
     config: &TrainingDataConfig,
-    creature: &CreatureExport,
     network: &mut CompiledNetwork,
 ) -> Result<(f64, usize, usize, usize, f64), String> {
     accumulate_cost_sum_forward_only_fused_sampled(
         cost,
         bin_files,
         config,
-        creature,
         network,
         SampleSpec::full(),
     )
@@ -183,11 +180,17 @@ pub fn accumulate_cost_sum_forward_only_fused(
 /// count); a sub-rate `sample` returns the loss sum and count over the **kept**
 /// records only, so `loss_sum / record_count` is still the mean error over the
 /// scored subset.
+///
+/// Issue #470 vestigial-parameter sweep: the former `_creature:
+/// &CreatureExport` argument was dropped from both entry points. It had been
+/// unread since the fused path started driving the pre-compiled
+/// `CompiledNetwork` directly — `config` already carries the input/output
+/// widths the reader needs, so the export was pure dead weight at every call
+/// site.
 pub fn accumulate_cost_sum_forward_only_fused_sampled(
     cost: CostKind,
     bin_files: &[std::path::PathBuf],
     config: &TrainingDataConfig,
-    _creature: &CreatureExport,
     network: &mut CompiledNetwork,
     sample: SampleSpec,
 ) -> Result<(f64, usize, usize, usize, f64), String> {


### PR DESCRIPTION
# Scorer-local dead-code audit (Issue #470)

## Summary

Scorer-only slice of the #466 plan. Confirmed `rust_scorer` uses **no**
superseded `neat-core` entry point, verified every `#[allow(dead_code)]` site
against the consumer its comment names, and cleared the vestigial code and
parameters the #428–#430 sweep left behind. No behaviour change — no test
expectation was edited to accommodate a removal. Closes #470.

Headline numbers:

| Audit item | Result |
| --- | --- |
| Superseded-API hits (`score_records`, `score_records_parallel`) across `src`, `tests`, `benches` | **0** |
| `#[allow(dead_code)]` sites before | 21 |
| `#[allow(dead_code)]` sites after | **17** (all consumers verified in this pass) |
| Sites deleted as genuinely dead | 2 |
| Sites whose attribute was dropped (item now reachable) | 2 |
| Vestigial parameters removed | 1 (across 2 entry points) |

## Task 1 — superseded `neat-core` API: 0 hits

```text
$ grep -rn "score_records" rust_scorer/src rust_scorer/tests rust_scorer/benches | wc -l
0
```

Scoring still runs through the fused packed path — `neat_core::loss::mse_sum_batch_packed`
(`rust_scorer/src/cost.rs`, with the `mae_` / `mape_` siblings alongside it),
driven by `neat_core::training_bin_stream::for_each_read_chunk`. Nothing to
migrate.

## Task 2 — `#[allow(dead_code)]` disposition list

Method (not a source grep — an actual compiler check): the workspace sets
`unused = "deny"`, so every attribute was **stripped from the tree** and
`cargo clippy --all-targets --all-features` was run. Any site that produced a
`never used` / `never read` / `never constructed` error still has no consumer
in at least one target and must keep the attribute; any site that produced no
error is reachable from ordinary code and the attribute is vestigial. The named
consumer of each surviving site was then confirmed by locating the call.

### Confirmed live — attribute retained (17)

| Site | Item | Verified consumer |
| --- | --- | --- |
| `src/multi_score.rs:77` | `training_pass_probe::reset` | `tests/single_pass_assertion.rs:73` |
| `src/multi_score.rs:83` | `training_pass_probe::count` | `tests/single_pass_assertion.rs:89` |
| `src/multi_score.rs:120` | `compile_probe::reset` | `tests/compile_once_assertion.rs:71` |
| `src/multi_score.rs:126` | `compile_probe::count` | `tests/compile_once_assertion.rs:87` |
| `src/multi_score.rs:310` | `enum EarlyExit` | `tests/early_exit_tdd.rs:110/166/221/266`, `benches/scoring.rs:1026` |
| `src/multi_score.rs:372` | `score_from_creature_dir` | `tests/{compile_once_assertion,single_pass_assertion,sample_rate_directory,early_exit_tdd,gpu_mae_parity,gpu_rmse_parity}.rs`, `benches/scoring.rs` |
| `src/multi_score.rs:464` | `score_from_creature_dir_with_early_exit` | `tests/early_exit_tdd.rs:101/153/214/248`, `benches/scoring.rs:1013` |
| `src/multi_score.rs:996` | `score_from_creature_dir_gpu` | `tests/gpu_{mae_parity,rmse_parity,pipelined_parity,pipelined_scratch_multi_bin,sample_rate_parity}.rs`, `src/bin/gpu_pipeline_alloc_bench.rs:159`, `benches/scoring.rs` |
| `src/stream_score.rs:157` | `accumulate_cost_sum_forward_only_fused` | `src/bin/cost_scan_bench.rs:116/128`, `benches/scoring.rs:254/834` |
| `src/gpu/forward_mse_batched.rs:644` | `BatchedRunner::kernel` | `tests/gpu_multi_score_parity.rs:128` |
| `src/gpu/mod.rs:134` | `GpuBackendLabel::as_str` | `tests/gpu_mae_parity.rs:120` |
| `src/gpu/mod.rs:216` | `ScoringPath::SingleCreature` | `src/gpu/mod.rs:562/830` (unit tests) |
| `src/gpu/mod.rs:503` | `resolve_backend` | all seven `tests/gpu_*.rs` files, `benches/scoring.rs:49` |
| `src/sampling.rs:79` | `SampleSpec::phase` | `src/sampling.rs:241` (unit test) |
| `src/sampling.rs:147` | `RecordSampler::full` | `src/sampling.rs:265/397`, `src/stream_io.rs:318/350/407` (unit tests) |
| `src/cost.rs:131` | `CostKind::from_cli` | doctest at `src/cost.rs:124-125` + `cost::tests` |
| `src/cost.rs:340` | `supported_list` | `src/cost.rs:41` (`Display for InvalidCostName`) |

Three of these had a **stale comment** naming a consumer that no longer
described reality; the comments were corrected in place (the item itself stayed):

- `GpuBackendLabel::as_str` — "consumed by callers once GPU kernels land" (they
  landed; the real consumer is `tests/gpu_mae_parity.rs`).
- `CostKind::from_cli` — "dispatch landing in #119-3"; the live consumers are
  the doctest and the `cost::tests` unit tests.
- `accumulate_cost_sum_forward_only_fused` — "benches/tests" narrowed to the two
  files that actually call it.

### Deleted — genuinely unused (2)

- `src/bin/cost_scan_bench.rs` — `#[path = "../env_tuning.rs"] mod env_tuning;`
  and `#[path = "../read_tuning.rs"] mod read_tuning;`. Both module copies were
  declared (mirroring `float_scan_bench`, which *does* use them) but nothing in
  the bench referenced a single item from either; stripping the attributes
  surfaced eight `never used` errors covering the whole of both modules. This
  bench drives the library entry point
  `rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused`, which
  applies the crate's own read tuning internally.

### Attribute dropped — item now reachable from ordinary code (2)

- `src/gpu/mod.rs` — `struct GpuContext`. The Issue #80 comment said "nothing
  consumes `device`/`queue` yet"; both are now consumed by the batched and
  scratch kernels in `gpu::forward_mse_batched`, and `main.rs:327` holds the
  context. Doc comment updated to match.
- `src/multi_score.rs` — `score_from_creature_dir_gpu_sampled`. Its own comment
  already said "used by the CLI's sampled path" — `main.rs:354` calls it, so the
  binary's module tree reaches it and the attribute was pure noise.

### GPU sites — checked, not deleted (per the issue's "out of scope")

`gpu/**` is live code (#467 benchmarked GPU 45–50 % faster on shallow creatures;
issue #323 is closed). Every GPU allow site above was verified to have a real
consumer, so "investigate, not delete" did not need to be exercised.

## Task 3 — vestigial parameters

Every `fn` in `rust_scorer/src` was traced to all call sites in `src`, `tests`
and `benches`, looking for parameters that are never read or that receive the
same constant everywhere.

**Removed:**

- `creature: &CreatureExport` from
  `stream_score::accumulate_cost_sum_forward_only_fused` **and**
  `accumulate_cost_sum_forward_only_fused_sampled`. The `_sampled` variant had
  already been `_`-prefixed (never read); the full-rate wrapper existed only to
  thread the value into it. `TrainingDataConfig` already carries the
  input/output widths the fused reader needs, and the pre-compiled
  `CompiledNetwork` carries the topology, so the export was dead weight at every
  call site. Updated: `src/main.rs`, `src/bin/cost_scan_bench.rs` (×2),
  `benches/scoring.rs` (×2) and the doctest.

**Kept, with a comment stating why** (each is read, so removal would change the
public reporting seam rather than delete dead weight):

- `gpu_backend: GpuBackendLabel` on `main.rs::score_from_json` and on the CPU
  directory chain (`multi_score::score_from_creature_dir_cpu` and its wrappers).
  Always `CpuFallback` at every CPU call site, but it *is* read into
  `ScoreResult::gpu_backend` — the value serialised as the `gpuBackend` JSON
  field — and `score_from_creature_dir_gpu_impl` passes a real adapter label
  through the same parameter. Hard-coding it would fork the reporting path.
- `path: ScoringPath` on `gpu::auto_topology_fallback_note`. Every call site
  passes `CreatureDirectory`, so the guard cannot fire today; the parameter
  mirrors the sibling `auto_cost_fallback_note` (which *is* exercised with
  `SingleCreature`), and `main.rs` selects the note helper by mode rather than
  by path — a future single-creature kernel must not silently inherit the
  directory-topology note.
- `num_outputs` on `shallow_fixture::plan_synapses` / `shallow_creature_json`.
  Always `1` in-tree (the Enceladus shape) but genuinely read — it sets the
  `hidden → output` edge count.
- `forward_only: bool` and its companions on `cost::accumulate_cost_sum`.
  **Mirrors the `neat_core::loss::*_sum_batch_packed` signature** and is
  genuinely variable (`false` at `main.rs` for the recurrent branch).
- `num_creatures: u32` on `BatchedRunner::from_data` — derivable from
  `data.creatures.len()`, but it is the dispatch height every other runner field
  keys off. Its doc comment claimed "used by tests"; corrected to name the only
  in-tree caller, `BatchedRunner::new`.

Explicitly re-checked and found genuinely variable (no action): `inflight_chunks`,
`effective_directory_gpu_inflight::requested`, `SampleSpec::new::phase`,
`growth_cost`, `auto_should_use_gpu::path`, the fallback helpers' `mode`, every
`cost: CostKind`, and `env_tuning::parse_tuning_var::name`. `ScoringConfig::forward_only`
was excluded up front per the issue.

## Evidence

Backend/CLI change only — no web interface, so no Playwright screenshot. The
gate is the compiler plus the existing regression suites.

```mermaid
flowchart TD
    A["21 #[allow(dead_code)] sites"] --> B["Strip every attribute<br/>from rust_scorer/src"]
    B --> C["cargo clippy --all-targets<br/>(workspace: unused = deny)"]
    C -->|"error: never used"| D["Attribute still required<br/>→ locate named consumer"]
    C -->|"compiles clean"| E["Attribute vestigial"]
    D -->|consumer found| F["Keep — 17 sites<br/>(3 stale comments corrected)"]
    D -->|no consumer anywhere| G["Delete item — 2 sites<br/>cost_scan_bench mod copies"]
    E --> H["Drop attribute — 2 sites<br/>GpuContext, ..._gpu_sampled"]
```

Verification commands (all run locally, stdin redirected from `/dev/null`):

- `cargo clippy --all-targets --all-features` — clean. This is the tripwire for
  a wrong deletion: `unused = "deny"` turns "removed something still live" or
  "dropped an attribute from something genuinely unreferenced" into a hard
  compile error.
- `./quality.sh < /dev/null` — green (fmt, cargo-deny, clippy, build, test,
  rustdoc, release build, shellcheck, codespell, bats).

## Test Plan

No new test file: the acceptance criteria are enforced by gates that already
exist, and adding a source-grepping "audit test" would assert on source text
rather than behaviour.

- **Wrong deletion of live code** → `unused = "deny"` + ordinary type-checking.
  `cargo clippy --all-targets --all-features` inside `./quality.sh`, mirrored by
  the PR CI workflow, fails the build. Exercised deliberately during the audit
  (the strip-and-compile pass above) rather than assumed.
- **Removal of the `env_tuning` / `read_tuning` module copies** →
  `rust_scorer/tests/cost_scan_bench_smoke.rs::cost_scan_bench_emits_one_row_per_supported_cost`
  drives the `cost_scan_bench` binary end-to-end against a synthetic creature
  and corpus and asserts one JSON row per supported `CostKind`. It passes
  unchanged.
- **Behaviour drift from the `creature` parameter removal** → the scoring
  regression suites pin real outputs and pass unchanged:
  `tests/scorer_smoke.rs`, `tests/cost_parity.rs`, `tests/directory_mode_tdd.rs`,
  `tests/sample_rate_tdd.rs`, `tests/sample_rate_directory.rs`,
  `tests/single_pass_assertion.rs`, `tests/compile_once_assertion.rs`,
  `tests/early_exit_tdd.rs`, plus the `prod_fixture`-backed Criterion path and
  the `tests/gpu_*.rs` GPU-vs-CPU parity set. **No test expectation was edited.**
- **Doctest** for `accumulate_cost_sum_forward_only_fused` updated to the new
  signature and re-checked by `RUSTDOCFLAGS="-D warnings" cargo doc` /
  `cargo test --doc` in `./quality.sh`.



## Milestone
This PR is part of the **#466 Scorer dead-code audit; raise neat-core flat-slice wrapper-removal issue** milestone and targets the `milestone/466-scorer-dead-code-audit-raise-neat-core-flat-sl` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms28sw3s-14ac8e`<!-- vibe-worker-issue-470 -->