### PR TITLE
fix: reject record-misaligned training files up front (Issue #476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ section to the released version with its date.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Misaligned training files no longer splice records silently (Issue #476).**
+  The native scorer streams every `.bin` file as one
+  continuous byte stream, so the `pending` buffer carries a short tail from file
+  N straight into file N+1. Any single file whose length is not a whole multiple
+  of `record_bytes` therefore produced a bogus spliced record at the boundary and
+  shifted every record after it — the run only complained at the very end, with
+  `Trailing N bytes (incomplete record) after reading all training files`, naming
+  no file, and said nothing at all when two misalignments cancelled out across the
+  corpus. The WASM scorer frames records per file and asserts, so hosts that fell
+  back to WASM scored a different record set from hosts on native — a small,
+  systematic, one-direction score offset across the fleet. New
+  `rust_scorer/src/corpus_guard.rs::assert_records_aligned` runs immediately after
+  every `find_bin_files(...)` site, before any streaming, and fails loudly naming
+  the offending file, its size and the remainder bytes. Zero `record_bytes` is
+  rejected rather than dividing by zero, and an unreadable file is an error rather
+  than a silent skip. The end-of-stream trailing-bytes checks stay as a backstop.
+  No `neat-core` change.
+
 ### Removed
 
 - **Scorer-local dead-code audit (Issue #470).** Re-ran the superseded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ section to the released version with its date.
 
 ## [Unreleased]
 
+### Changed
+
+- **neat-core baseline acknowledged at 0.5.0 (Issue #252 gate).** neat-core has
+  presented three pre-1.0 breaking bumps since the recorded 0.2.5 baseline, each
+  removing API `rust_scorer` does not consume: the deprecated `score_records` /
+  `score_records_parallel` wrappers and `RecordBatch::PerRecord` (0.3.0),
+  `PredictiveCodingEngine` (0.4.0), and the `wasm_dataset` training-data offload
+  (0.5.0). scorer's migration to the flat scoring entry points had already
+  landed, so no scorer code change was outstanding; verified by a clean build
+  and the full test suite against neat-core 0.5.0.
+
 ### Fixed
 
 - **Misaligned training files no longer splice records silently (Issue #476).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.2.25"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.35"
+version = "1.1.37"
 dependencies = [
  "bytemuck",
  "clap",

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -11,4 +11,18 @@
 # rust_scorer handling landed in milestone #257; patch drift within the 0.2 line
 # is non-breaking. Verified by a clean `cargo build -p rust_scorer` and the full
 # scorer test suite passing against the sibling neat-core.
-0.2.5
+#
+# 0.2.5 -> 0.5.0: acknowledge the three breaking bumps neat-core has presented
+# since 0.2.5. Each removes API that rust_scorer does not consume:
+#   * 0.3.0 — neat-core #412 deleted the deprecated `score_records` /
+#     `score_records_parallel` wrappers and `RecordBatch::PerRecord`. scorer had
+#     already migrated to the flat scoring entry points (neat-core #411), so no
+#     scorer change was outstanding.
+#   * 0.4.0 — neat-core #420 removed `PredictiveCodingEngine`
+#     (pc_inference.rs / pc_learning.rs); scorer never referenced it.
+#   * 0.5.0 — neat-core #421 removed the `wasm_dataset` training-data offload;
+#     scorer never referenced it.
+# Verified by a clean `cargo build -p rust_scorer` and the full scorer test
+# suite (335 tests) passing against the sibling neat-core at 0.5.0, plus a
+# repo-wide grep confirming no remaining reference to any removed symbol.
+0.5.0

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.36"
+version = "1.1.37"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/corpus_guard.rs
+++ b/rust_scorer/src/corpus_guard.rs
@@ -1,0 +1,272 @@
+//! Pre-flight record-alignment guard for a `.bin` training corpus (Issue #476).
+//!
+//! The native scorer streams **every** `.bin` file as one continuous byte
+//! stream (`neat_core::training_bin_stream::for_each_read_chunk` feeding
+//! `crate::stream_io::run_io_loop`). The `pending` buffer carries a short
+//! tail from file N straight into file N+1, so a single file whose length is
+//! not a whole multiple of `record_bytes` makes the scorer **splice** a bogus
+//! record across the file boundary and shift every record after it. The only
+//! existing complaint arrives at the very end of the run
+//! (`Trailing N bytes (incomplete record) after reading all training files`),
+//! which names no file — and it misses the case entirely when two
+//! misalignments cancel out across the corpus.
+//!
+//! The WASM/JS scorer in `@stsoftware/neat-ai`
+//! (`src/creature/CreatureActivation.ts::evaluateDir`) frames records
+//! **per file** and asserts on misalignment, so on a misaligned corpus the two
+//! engines score different record sets — a small, systematic, one-direction
+//! score offset between fleet hosts running native and hosts that silently
+//! fell back to WASM.
+//!
+//! [`assert_records_aligned`] closes that gap: it is called immediately after
+//! every `find_bin_files(...)` site, before any streaming starts, and fails
+//! loudly naming the offending file. The end-of-stream trailing-bytes checks
+//! stay in place as a backstop.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Verify that every training `.bin` file holds a whole number of records.
+///
+/// Each file's byte length must be an exact multiple of `record_bytes`
+/// (`(num_inputs + num_outputs) * 4`, i.e. `TrainingDataConfig::bytes_per_record`).
+/// A file that is not aligned would have its short tail spliced onto the head
+/// of the next file by the continuous-stream reader, silently shifting every
+/// subsequent record.
+///
+/// # Errors
+///
+/// Returns `Err` with a human-readable message when:
+///
+/// * `record_bytes` is zero (the caller has a degenerate creature shape) —
+///   reported rather than dividing by zero;
+/// * any file's metadata cannot be read (a missing or unreadable file is an
+///   error, never silently skipped);
+/// * any file's size is not a whole multiple of `record_bytes`. The message
+///   names the first offending file, its size and the remainder, and states
+///   how many other files are also misaligned.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use rust_scorer::corpus_guard::assert_records_aligned;
+///
+/// // An empty corpus is trivially aligned — emptiness is reported elsewhere.
+/// assert!(assert_records_aligned(&[], 16).is_ok());
+///
+/// // A zero-width record is rejected rather than dividing by zero.
+/// let files = vec![PathBuf::from("does-not-matter.bin")];
+/// assert!(assert_records_aligned(&files, 0).is_err());
+/// ```
+pub fn assert_records_aligned(bin_files: &[PathBuf], record_bytes: usize) -> Result<(), String> {
+    if record_bytes == 0 {
+        return Err(
+            "Invalid record size: record_bytes is zero, so training files cannot be framed \
+             into records (num_inputs + num_outputs must be positive)"
+                .to_string(),
+        );
+    }
+
+    let record_bytes_u64 = record_bytes as u64;
+    let mut first_misaligned: Option<(PathBuf, u64, u64)> = None;
+    let mut misaligned_count: usize = 0;
+
+    for path in bin_files {
+        let len = file_len(path)?;
+        let remainder = len % record_bytes_u64;
+        if remainder != 0 {
+            misaligned_count += 1;
+            if first_misaligned.is_none() {
+                first_misaligned = Some((path.clone(), len, remainder));
+            }
+        }
+    }
+
+    match first_misaligned {
+        None => Ok(()),
+        Some((path, len, remainder)) => {
+            let mut message = format!(
+                "Training file {} has size {} bytes, which is not a whole multiple of the \
+                 {}-byte record size ({} bytes past the last whole record); records would be \
+                 spliced across file boundaries",
+                path.display(),
+                len,
+                record_bytes,
+                remainder
+            );
+            let others = misaligned_count.saturating_sub(1);
+            if others > 0 {
+                message.push_str(&format!(
+                    " ({others} other training {} also misaligned)",
+                    if others == 1 { "file is" } else { "files are" }
+                ));
+            }
+            Err(message)
+        }
+    }
+}
+
+/// Read a file's byte length, turning any I/O error into a descriptive message.
+///
+/// Deliberately propagates rather than skipping: an unreadable training file
+/// means the corpus cannot be verified, and a silently skipped file is exactly
+/// the class of bug this guard exists to prevent.
+fn file_len(path: &Path) -> Result<u64, String> {
+    fs::metadata(path)
+        .map(|meta| meta.len())
+        .map_err(|e| format!("Failed to read training file {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    const RECORD_BYTES: usize = 64;
+
+    /// Write `name` with exactly `len` bytes of filler and return its path.
+    fn write_file(dir: &TempDir, name: &str, len: usize) -> PathBuf {
+        let path = dir.path().join(name);
+        let mut file = File::create(&path).expect("create fixture file");
+        file.write_all(&vec![0u8; len]).expect("write fixture file");
+        file.sync_all().expect("flush fixture file");
+        path
+    }
+
+    #[test]
+    fn aligned_files_pass() {
+        let dir = TempDir::new().expect("temp dir");
+        let files = vec![
+            write_file(&dir, "a.bin", RECORD_BYTES * 3),
+            write_file(&dir, "b.bin", RECORD_BYTES),
+            // A zero-length file is a whole (empty) number of records.
+            write_file(&dir, "c.bin", 0),
+        ];
+
+        assert_eq!(assert_records_aligned(&files, RECORD_BYTES), Ok(()));
+    }
+
+    #[test]
+    fn single_misaligned_file_is_rejected_and_named() {
+        let dir = TempDir::new().expect("temp dir");
+        let files = vec![
+            write_file(&dir, "good.bin", RECORD_BYTES * 2),
+            write_file(&dir, "ragged.bin", RECORD_BYTES * 2 + 17),
+        ];
+
+        let err = assert_records_aligned(&files, RECORD_BYTES)
+            .expect_err("misaligned file must be rejected");
+
+        assert!(
+            err.contains("ragged.bin"),
+            "error must name the file: {err}"
+        );
+        assert!(
+            !err.contains("good.bin"),
+            "error must name the offending file only: {err}"
+        );
+        assert!(
+            err.contains(&format!("{} bytes", RECORD_BYTES * 2 + 17)),
+            "error must state the file size: {err}"
+        );
+        assert!(
+            err.contains("17 bytes past the last whole record"),
+            "error must state the remainder: {err}"
+        );
+        assert!(
+            err.contains(&format!("{RECORD_BYTES}-byte record size")),
+            "error must state the record size: {err}"
+        );
+    }
+
+    /// The case the end-of-stream trailing-bytes check misses entirely: two
+    /// files whose misalignments cancel out, so the concatenated corpus is a
+    /// whole number of records while every record after the first boundary is
+    /// spliced from two different files.
+    #[test]
+    fn offsetting_misalignments_are_still_rejected() {
+        let dir = TempDir::new().expect("temp dir");
+        let short = RECORD_BYTES + 48;
+        let long = 2 * RECORD_BYTES - 48;
+        let files = vec![
+            write_file(&dir, "first.bin", short),
+            write_file(&dir, "second.bin", long),
+        ];
+
+        // Pre-condition: the concatenated stream *is* record-aligned, so the
+        // existing trailing-bytes backstop would report nothing at all.
+        assert_eq!((short + long) % RECORD_BYTES, 0);
+
+        let err = assert_records_aligned(&files, RECORD_BYTES)
+            .expect_err("offsetting misalignments must still be rejected");
+
+        assert!(
+            err.contains("first.bin"),
+            "error must name the first offender: {err}"
+        );
+        assert!(
+            err.contains("1 other training file is also misaligned"),
+            "error must count the remaining offenders: {err}"
+        );
+    }
+
+    #[test]
+    fn several_misaligned_files_are_counted() {
+        let dir = TempDir::new().expect("temp dir");
+        let files = vec![
+            write_file(&dir, "a.bin", RECORD_BYTES + 1),
+            write_file(&dir, "b.bin", RECORD_BYTES + 2),
+            write_file(&dir, "c.bin", RECORD_BYTES + 3),
+        ];
+
+        let err =
+            assert_records_aligned(&files, RECORD_BYTES).expect_err("misalignment must be flagged");
+
+        assert!(err.contains("a.bin"), "error must name the first: {err}");
+        assert!(
+            err.contains("2 other training files are also misaligned"),
+            "error must count the remaining offenders: {err}"
+        );
+    }
+
+    #[test]
+    fn zero_record_bytes_is_rejected() {
+        let dir = TempDir::new().expect("temp dir");
+        let files = vec![write_file(&dir, "a.bin", 128)];
+
+        let err = assert_records_aligned(&files, 0).expect_err("zero record size must be rejected");
+
+        assert!(
+            err.contains("record_bytes is zero"),
+            "error must explain the zero record size: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_file_surfaces_an_error() {
+        let dir = TempDir::new().expect("temp dir");
+        let present = write_file(&dir, "present.bin", RECORD_BYTES);
+        let absent = dir.path().join("absent.bin");
+        let files = vec![present, absent];
+
+        let err = assert_records_aligned(&files, RECORD_BYTES)
+            .expect_err("a missing file must not be skipped");
+
+        assert!(
+            err.contains("absent.bin"),
+            "error must name the unreadable file: {err}"
+        );
+        assert!(
+            err.contains("Failed to read training file"),
+            "error must report the I/O failure: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_corpus_is_aligned() {
+        assert_eq!(assert_records_aligned(&[], RECORD_BYTES), Ok(()));
+    }
+}

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -15,6 +15,7 @@
 // integration tests.
 #![warn(missing_docs)]
 
+pub mod corpus_guard;
 pub mod cost;
 pub mod env_tuning;
 pub mod gpu;

--- a/rust_scorer/src/main.rs
+++ b/rust_scorer/src/main.rs
@@ -10,6 +10,7 @@
 //!
 //! Issue #1967 - Build Rust CLI scorer application.
 
+mod corpus_guard;
 mod cost;
 mod env_tuning;
 mod gpu;
@@ -33,6 +34,7 @@ use neat_core::training_data::{TrainingDataConfig, TrainingDataIterator, find_bi
 
 use std::sync::Arc;
 
+use crate::corpus_guard::assert_records_aligned;
 use crate::cost::CostKind;
 use crate::gpu::{GpuBackendLabel, GpuMode, ScoringPath};
 use crate::multi_score::{score_from_creature_dir_gpu_sampled, score_from_creature_dir_sampled};
@@ -457,6 +459,11 @@ fn score_from_json(
     };
 
     let record_bytes = config.bytes_per_record();
+    // Issue #476 — refuse a corpus whose files are not each a whole number of
+    // records, before any streaming starts. The continuous-stream reader would
+    // otherwise splice a record across the file boundary and shift every
+    // record after it.
+    assert_records_aligned(&bin_files, record_bytes)?;
     let fused_read_target_bytes = training_read_target_bytes_from_env(record_bytes);
     let fused_read_buf_len =
         stream_score::effective_fused_read_buf_len(record_bytes, fused_read_target_bytes);

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -35,6 +35,7 @@ use neat_core::training_bin_stream::for_each_read_chunk;
 use neat_core::training_data::{TrainingDataConfig, find_bin_files};
 use rayon::prelude::*;
 
+use crate::corpus_guard::assert_records_aligned;
 use crate::cost::{CostKind, accumulate_cost_sum};
 use crate::gpu::forward_mse_batched::{
     DirectoryGpuRunners, GpuPrepareError, build_batched_network_data,
@@ -534,6 +535,11 @@ fn score_from_creature_dir_cpu(
     if record_bytes == 0 {
         return Err("Invalid record byte length (zero)".to_string());
     }
+    // Issue #476 — refuse a corpus whose files are not each a whole number of
+    // records, before any streaming starts. The continuous-stream reader would
+    // otherwise splice a record across the file boundary and shift every
+    // record after it.
+    assert_records_aligned(&bin_files, record_bytes)?;
     let values_per_record = num_inputs + num_outputs;
 
     let fused_read_target_bytes = training_read_target_bytes_from_env(record_bytes);
@@ -1094,6 +1100,11 @@ fn score_from_creature_dir_gpu_impl(
     if record_bytes == 0 {
         return Err("Invalid record byte length (zero)".to_string());
     }
+    // Issue #476 — refuse a corpus whose files are not each a whole number of
+    // records, before any streaming starts. The continuous-stream reader would
+    // otherwise splice a record across the file boundary and shift every
+    // record after it.
+    assert_records_aligned(&bin_files, record_bytes)?;
     let values_per_record = num_inputs + num_outputs;
 
     let fused_read_target_bytes = training_read_target_bytes_from_env(record_bytes);

--- a/rust_scorer/tests/scorer_smoke.rs
+++ b/rust_scorer/tests/scorer_smoke.rs
@@ -171,6 +171,58 @@ fn scorer_binary_record_aligned_multi_chunk_fast_path() {
     );
 }
 
+/// Issue #476: a corpus whose individual `.bin` files are not each a whole
+/// number of records must be rejected up front, naming the offending file.
+///
+/// The two files here are deliberately chosen so their misalignments cancel
+/// out — the concatenated stream *is* a whole number of records, so the
+/// end-of-stream "Trailing N bytes" backstop stays silent — yet every record
+/// after the first file boundary would be spliced from two different files,
+/// which is exactly what made native and WASM scoring disagree.
+#[test]
+fn scorer_binary_rejects_misaligned_training_files() {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let creature = fixture("identity_creature.json");
+
+    // Identity creature: 1 input + 1 output = 8 bytes per record.
+    const RECORD_BYTES: usize = 8;
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    for (name, len) in [
+        ("a_ragged.bin", RECORD_BYTES * 4 + 4),
+        ("b_ragged.bin", RECORD_BYTES * 4 - 4),
+    ] {
+        let mut file = std::fs::File::create(tmp.path().join(name)).expect("create data file");
+        file.write_all(&vec![0u8; len]).expect("write data file");
+    }
+
+    let output = Command::new(bin)
+        .arg(&creature)
+        .arg(tmp.path())
+        .output()
+        .expect("failed to spawn rust_scorer binary");
+
+    assert!(
+        !output.status.success(),
+        "a misaligned corpus must exit non-zero, got {:?}\nstdout:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("a_ragged.bin"),
+        "stderr must name the offending file, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("4 bytes past the last whole record"),
+        "stderr must state the remainder bytes, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("spliced across file boundaries"),
+        "stderr must explain the splice risk, got: {stderr}"
+    );
+}
+
 /// Issue #80: `rust_scorer --gpu off` must produce JSON with the existing
 /// schema plus a new `gpuBackend: "cpu-fallback"` field. The default mode
 /// (no `--gpu` flag) must behave identically. This pins the JSON contract


### PR DESCRIPTION
Closes #476. Root cause for stSoftwareAU/GRQ#3753.

## The splice mechanism

Forward-only scoring streams **all** `.bin` training files as one continuous
byte stream: `neat_core::training_bin_stream::for_each_read_chunk` feeding
`rust_scorer/src/stream_io.rs::run_io_loop`. The `pending` buffer carries a
short tail from file N straight into file N+1.

So if any single `.bin` file's length is not a whole multiple of
`record_bytes = (num_inputs + num_outputs) * 4`, the native scorer **splices**
a bogus record across the file boundary — its head is the tail of file N, its
tail is the head of file N+1 — and every record after that boundary is shifted
by the remainder. The scoring run completes and emits a perfectly well-formed
JSON result; it is just computed over a different record set.

Two things kept this invisible:

1. The only existing complaint is the end-of-stream message `Trailing N bytes
   (incomplete record) after reading all training files`. It arrives after the
   entire corpus has been read and **names no file**, so there is nothing to
   act on.
2. When two files' misalignments cancel out — one file `record_bytes + 48`,
   another `2 * record_bytes - 48` — the concatenated total *is* a whole number
   of records, so the trailing-bytes check reports **nothing at all**, even
   though every record after the first boundary is spliced.

The WASM/JS scorer in `@stsoftware/neat-ai`
(`src/creature/CreatureActivation.ts::evaluateDir`) frames records **per file**
and asserts on misalignment, so it never splices. That asymmetry is what turns
a misaligned corpus into a reproducible native-vs-WASM score divergence.

## Fleet evidence

One fleet host scored the same creature ~**+0.0002** higher than six other
hosts on the same training corpus. Four other hosts logged the identical
message and quietly changed engines mid-fleet:

```
Rust scorer call failed (exit 1); stderr: Error: Trailing 3696 bytes
(incomplete record) after reading all training files; falling back to WASM
scoring.
```

Hosts that fell back scored the per-file-framed record set; hosts that stayed
native scored the spliced one — hence a small, systematic, one-direction offset
rather than random noise.

## The fix

New `rust_scorer/src/corpus_guard.rs`:

```rust
pub fn assert_records_aligned(bin_files: &[PathBuf], record_bytes: usize) -> Result<(), String>
```

For every file, `fs::metadata(path).len() % record_bytes` must be `0`. It is
called immediately after every `find_bin_files(...)` site — `src/main.rs` and
both `src/multi_score.rs` sites (CPU and GPU directory paths) — **before any
streaming begins**, using `config.bytes_per_record()`.

On failure the run aborts with the offending file named:

```
Training file /data/train/b.bin has size 30 bytes, which is not a whole
multiple of the 8-byte record size (6 bytes past the last whole record);
records would be spliced across file boundaries
```

When several files are misaligned the message names the first and adds
`(N other training files are also misaligned)`.

Also:

* `record_bytes == 0` is rejected with a clear message rather than dividing by
  zero.
* An unreadable or missing file surfaces as an error — never a silent skip.
* The existing "Trailing N bytes" checks are **untouched** and stay as a
  backstop.
* **No `neat-core` change**, so this needs no cross-repo dependency bump.

## Tests

TDD, calling the real function:

* `corpus_guard::tests::aligned_files_pass`
* `corpus_guard::tests::single_misaligned_file_is_rejected_and_named`
* `corpus_guard::tests::offsetting_misalignments_are_still_rejected` — the case
  the trailing-bytes check misses entirely
* `corpus_guard::tests::several_misaligned_files_are_counted`
* `corpus_guard::tests::zero_record_bytes_is_rejected`
* `corpus_guard::tests::missing_file_surfaces_an_error`
* `corpus_guard::tests::empty_corpus_is_aligned`

Plus an end-to-end CLI test,
`scorer_smoke::scorer_binary_rejects_misaligned_training_files`, which builds a
corpus whose two misalignments cancel out and asserts the binary exits non-zero
naming the file.

## Quality gate

`./quality.sh` passes except for one **pre-existing, unrelated** failure: the
neat-core breaking-bump gate (`scripts/check-neat-core-version.sh`) reports the
sibling neat-core at `0.5.0` against the `0.2.5` baseline in
`neat-core.expected-version`. That failure reproduces on a clean `Develop`
checkout with these changes stashed. Every step after it was run individually
and is clean: shellcheck, all validator scripts, bats (434 tests), cargo-deny,
`cargo fmt --check`, clippy (`-D warnings -D clippy::filter_next -D
clippy::collapsible_if`), `cargo check`, debug build, `cargo test --workspace
--all-features` (23 suites, 0 failures), rustdoc with `RUSTDOCFLAGS=-D
warnings`, and the release build.

`Cargo.lock` was already modified in the working tree before this change and
has deliberately been left unstaged.