### PR TITLE
dead-code: 27 pub items are crate-internal and should be pub(crate) (Issue #474)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-474.md
+++ b/docs/archive/pr-summaries/pr-summary-474.md
@@ -1,0 +1,105 @@
+# Narrow 27 crate-internal `pub` items to `pub(crate)` (Issue #474)
+
+## Summary
+
+`rust_scorer` is not published, so `pub` on an item with no consumer outside the
+crate widens the API surface for nothing — and, worse, it suppresses the
+`dead_code` lint that would otherwise catch the item going stale. This PR
+downgrades the 27 items identified by the dead-code audit to `pub(crate)`,
+which re-arms `dead_code` on each of them. Closes #474.
+
+Items narrowed:
+
+| file | symbols |
+| --- | --- |
+| `scoring.rs` | `SEMANTIC_MAJOR_VERSION` |
+| `read_tuning.rs` | `MAX_READ_BYTES`, `default_training_read_bytes` |
+| `shallow_fixture.rs` | `ENCELADUS_SQUASHES`, `plan_synapses` |
+| `prod_fixture.rs` | `MIN_INPUTS`, `EXPECTED_OUTPUTS`, `MIN_NEURONS`, `MAX_NEURONS`, `MIN_SYNAPSES`, `MAX_SYNAPSES`, `parse_production_creature`, `check_production_topology` |
+| `gpu/forward_mse_batched.rs` | `MAX_NEURONS_ABSOLUTE`, `DEFAULT_SCRATCH_BUDGET_BYTES`, `NeuronGpu`, `CreatureMetaGpu`, `BatchedNetworkData`, `build_batched_network_data`, `BatchedRunner::from_data`, `DirectoryGpuRunners`, `DirectoryGpuRunners::kernel_label`, `scratch_workgroups_x_for` |
+| `gpu/mod.rs` | `GpuBackendLabel::from_wgpu` |
+| `stream_score.rs` | `accumulate_cost_sum_forward_only_fused_sampled` |
+| `sampling.rs` | `SampleSpec::is_full`, `RecordSampler::is_full` |
+
+`MAX_READ_BYTES` and friends are used **across** modules
+(`read_tuning.rs` → `stream_score.rs`), so `pub(crate)` — not private — is the
+right target.
+
+### Follow-on doc-link fix (required, not scope creep)
+
+Seven public doc comments linked to items this PR made private, which rustdoc
+rejects under the repo's `RUSTDOCFLAGS=-D warnings` gate
+(`public documentation for X links to private item Y`). Those seven intra-doc
+links became plain code spans — no prose was reworded:
+
+- `prod_fixture.rs` module docs → `parse_production_creature`,
+  `check_production_topology`
+- `shallow_fixture.rs::shallow_creature_json` → `ENCELADUS_SQUASHES`,
+  `plan_synapses`
+- `gpu/forward_mse_batched.rs` `TooManyNeurons` / `num_neurons` →
+  `MAX_NEURONS_ABSOLUTE`
+- `multi_score.rs::gpu_directory_compatible` → `MAX_NEURONS_ABSOLUTE`
+
+### Not changed
+
+The issue's exclusion list is honoured as-is — items that leak into a public
+signature, items with a doctest-only external consumer, and items whose `pub`
+currently acts as `dead_code` suppression for the lib target (because `main.rs`
+re-declares its own `mod` tree) all keep `pub`.
+
+## Evidence
+
+This is a library-visibility change with no web interface, so there is no
+screenshot. The compiler *is* the test: narrowing visibility either compiles or
+it does not, and the value of the change is a lint that fires on future rot.
+
+**Full gate green** — `./quality.sh < /dev/null` passed end to end against the
+sibling `neat-core` at 0.5.0: shellcheck, cargo-deny, `fmt --check`,
+`clippy --workspace --all-targets -D warnings`, build, the full test suite
+(including all 24 doctests), `cargo doc` with `RUSTDOCFLAGS=-D warnings`, and
+the release build. `Cargo.lock` is unchanged.
+
+**`dead_code` is demonstrably re-armed.** Removing the single non-test caller of
+`default_training_read_bytes` in a throwaway edit now fails the build, where
+before the change `pub` would have silently absorbed it:
+
+```text
+error: function `default_training_read_bytes` is never used
+  --> rust_scorer/src/read_tuning.rs:21:15
+   |
+21 | pub(crate) fn default_training_read_bytes(record_bytes: usize) -> usize {
+   |
+   = help: to override `-D unused` add `#[expect(dead_code)]` or `#[allow(dead_code)]`
+```
+
+Note the three `#[cfg(test)]` call sites did **not** keep it alive — exactly the
+behaviour wanted, since a function reachable only from its own unit tests is
+dead in the shipping binary. The edit was reverted immediately; it is not part
+of this PR.
+
+```mermaid
+flowchart LR
+    A["pub item<br/>no external consumer"] -->|"dead_code suppressed"| B["last caller removed"]
+    B --> C["build stays green<br/>rot found only by audit"]
+    A -->|"this PR"| D["pub(crate)"]
+    D --> E["last caller removed"]
+    E --> F["cargo build FAILS<br/>rot caught by compiler"]
+```
+
+## Test Plan
+
+No new tests were added, and no existing test was modified, commented out, or
+removed. A visibility change has no runtime behaviour to assert, and a test that
+inspected source text for `pub(crate)` would verify nothing useful. The
+verification is the compiler plus the existing suite:
+
+- `cargo clippy --workspace --all-targets -- -D warnings` — clean, proving no
+  in-crate call site lost access and no item became dead.
+- `cargo test --workspace` — every existing suite passes, including the 24
+  doctests, confirming no doctest was an external consumer of a narrowed item.
+- `cargo doc` with `RUSTDOCFLAGS=-D warnings` — clean, confirming the seven
+  intra-doc links were the complete set of doc references to narrowed items.
+- Release build under `RUSTFLAGS=-D warnings` — clean, confirming `dead_code`
+  does not fire for any of the 27 in a non-test build.
+- Manual negative check (above) confirming `dead_code` now *does* fire when a
+  narrowed item loses its last non-test caller.

--- a/docs/archive/pr-summaries/pr-summary-474.md
+++ b/docs/archive/pr-summaries/pr-summary-474.md
@@ -45,7 +45,7 @@ links became plain code spans — no prose was reworded:
 The issue's exclusion list is honoured as-is — items that leak into a public
 signature, items with a doctest-only external consumer, and items whose `pub`
 currently acts as `dead_code` suppression for the lib target (because `main.rs`
-re-declares its own `mod` tree) all keep `pub`.
+declares its own separate `mod` tree) all keep `pub`.
 
 ## Evidence
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.37"
+version = "1.1.38"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -71,13 +71,13 @@ pub const MAX_SHALLOW_NON_INPUT_NEURONS: u32 = 256;
 /// absurd neuron count would demand a nonsensical scratch allocation — reject
 /// it up-front instead. One million neurons is far above any real evolved
 /// creature (observed maxima are in the low thousands).
-pub const MAX_NEURONS_ABSOLUTE: u32 = 1 << 20;
+pub(crate) const MAX_NEURONS_ABSOLUTE: u32 = 1 << 20;
 
 /// Default activation-scratch memory budget for the `forward_mse_scratch`
 /// kernel, in bytes (512 MiB). The host caps the grid-stride thread count so
 /// `num_creatures * G_x * WG_SIZE * max_neurons * 4` bytes stays within this
 /// budget. Override with `NEAT_SCORER_GPU_SCRATCH_BYTES` (used by benchmarks).
-pub const DEFAULT_SCRATCH_BUDGET_BYTES: u64 = 512 * 1024 * 1024;
+pub(crate) const DEFAULT_SCRATCH_BUDGET_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Highest point-wise squash discriminant the kernels inline (Issue #305).
 ///
@@ -122,7 +122,7 @@ struct HeaderGpu {
 /// GPU-side mirror of a compiled neuron (`#[repr(C)]`, uploaded as an SSBO element).
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable, Debug, Default)]
-pub struct NeuronGpu {
+pub(crate) struct NeuronGpu {
     bias: f32,
     squash_type: u32,
     start_synapse: u32,
@@ -149,7 +149,7 @@ pub struct SynapseGpu {
 /// GPU-side mirror of a compiled creature's buffer layout (`#[repr(C)]`, uploaded as an SSBO element).
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable, Debug, Default)]
-pub struct CreatureMetaGpu {
+pub(crate) struct CreatureMetaGpu {
     neuron_offset: u32,
     num_non_inputs: u32,
     synapse_offset: u32,
@@ -158,7 +158,7 @@ pub struct CreatureMetaGpu {
 
 /// Concatenated per-creature data ready for upload.
 #[derive(Debug, Default)]
-pub struct BatchedNetworkData {
+pub(crate) struct BatchedNetworkData {
     /// All creatures' neurons concatenated into one upload buffer.
     pub neurons: Vec<NeuronGpu>,
     /// All creatures' synapses concatenated into one upload buffer.
@@ -181,7 +181,7 @@ pub enum GpuPrepareError {
     /// MINIMUM/MAXIMUM/IF (32..=34); this now fires only for the remaining
     /// aggregates HYPOT/HYPOTv2/MEAN (35..=37).
     UnsupportedSquash(u8),
-    /// A creature claims more than [`MAX_NEURONS_ABSOLUTE`] neurons — far
+    /// A creature claims more than `MAX_NEURONS_ABSOLUTE` neurons — far
     /// beyond any real evolved creature, so it is rejected rather than sized
     /// into a nonsensical scratch allocation (Issue #182). Creatures merely
     /// above the 256-neuron private-array cap are *not* rejected: they route to
@@ -189,7 +189,7 @@ pub enum GpuPrepareError {
     TooManyNeurons {
         /// Index of the offending creature within the batch.
         creature_idx: usize,
-        /// The rejected neuron count that exceeded [`MAX_NEURONS_ABSOLUTE`].
+        /// The rejected neuron count that exceeded `MAX_NEURONS_ABSOLUTE`.
         num_neurons: usize,
     },
     /// Every creature must share the same `(num_inputs, num_outputs)` shape
@@ -232,7 +232,7 @@ fn squash_supported(t: u8) -> bool {
 ///
 /// Returns [`GpuPrepareError::UnsupportedSquash`] for any non-supported squash
 /// type so the caller can fall back to CPU before allocating any GPU buffers.
-pub fn build_batched_network_data(
+pub(crate) fn build_batched_network_data(
     networks: &[CompiledNetwork],
     num_inputs: usize,
     num_outputs: usize,
@@ -433,7 +433,7 @@ impl BatchedRunner {
     /// `cost` selects the per-record loss the kernel accumulates (Issue #316):
     /// squared error for MSE/RMSE, absolute error for MAE. Only a
     /// [`CostKind::gpu_supported`] cost should reach here.
-    pub fn from_data(
+    pub(crate) fn from_data(
         ctx: Arc<GpuContext>,
         data: &BatchedNetworkData,
         num_creatures: u32,
@@ -1009,7 +1009,7 @@ pub fn directory_pool_is_shallow(networks: &[CompiledNetwork]) -> bool {
 
 /// Directory-mode GPU runners — may hold private and/or scratch kernels when the
 /// creature pool is mixed so small creatures avoid the scratch-kernel tax.
-pub struct DirectoryGpuRunners {
+pub(crate) struct DirectoryGpuRunners {
     private: Option<BatchedRunner>,
     private_orig: Vec<usize>,
     scratch: Option<BatchedRunner>,
@@ -1099,7 +1099,7 @@ impl DirectoryGpuRunners {
     }
 
     /// Stable label for the `gpuKernel` JSON field.
-    pub fn kernel_label(&self) -> String {
+    pub(crate) fn kernel_label(&self) -> String {
         match self.topology() {
             DirectoryGpuTopology::Mixed => "forward_mse_batched+forward_mse_scratch".to_string(),
             DirectoryGpuTopology::ScratchOnly => "forward_mse_scratch".to_string(),
@@ -1119,7 +1119,7 @@ impl DirectoryGpuRunners {
 
 /// Pure helper for `BatchedRunner::scratch_workgroups_x` so the bounding
 /// logic is unit-testable without a GPU (Issue #182).
-pub fn scratch_workgroups_x_for(
+pub(crate) fn scratch_workgroups_x_for(
     n_records: usize,
     num_creatures: u32,
     max_neurons: u32,

--- a/rust_scorer/src/gpu/mod.rs
+++ b/rust_scorer/src/gpu/mod.rs
@@ -148,7 +148,7 @@ impl GpuBackendLabel {
     /// is a "real" native GPU backend the scorer can run kernels on, and
     /// returning `CpuFallback` keeps the JSON contract simple (only one label
     /// per "no GPU available" path).
-    pub fn from_wgpu(b: wgpu::Backend) -> Self {
+    pub(crate) fn from_wgpu(b: wgpu::Backend) -> Self {
         match b {
             wgpu::Backend::Metal => Self::Metal,
             wgpu::Backend::Vulkan => Self::Vulkan,

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -872,7 +872,7 @@ fn score_from_creature_dir_cpu(
 /// Returns:
 /// * `Err(GpuPrepareError)` — the set is genuinely incompatible with the GPU
 ///   kernels (an unsupported squash, a shape mismatch, or an absurd neuron
-///   count beyond [`crate::gpu::forward_mse_batched::MAX_NEURONS_ABSOLUTE`]).
+///   count beyond `gpu::forward_mse_batched::MAX_NEURONS_ABSOLUTE`).
 ///   Issue #289 (C-GOOD-ERR): the underlying typed [`GpuPrepareError`] is now
 ///   returned directly instead of being flattened to a `String`, so callers can
 ///   `match` on the specific incompatibility. Its `Display` still yields the

--- a/rust_scorer/src/prod_fixture.rs
+++ b/rust_scorer/src/prod_fixture.rs
@@ -16,8 +16,8 @@
 //! topology outside the expected production ranges — the latter catches a
 //! regression that swaps in a trivially small creature.
 //!
-//! The pure functions here ([`parse_production_creature`],
-//! [`check_production_topology`], [`load_production_creature`],
+//! The pure functions here (`parse_production_creature`,
+//! `check_production_topology`, [`load_production_creature`],
 //! [`corpus_record_count`]) are unit-tested. The production creature itself is
 //! **not** shipped and is **never fetched** by this public repo — it lives in a
 //! private repository. A contributor supplies their own local copy via the
@@ -44,17 +44,17 @@ pub const PROD_CREATURE_ENV: &str = "BENCH_PROD_CREATURE";
 // such as the synthetic 8→8→2 fixture (10 neurons, 8 inputs).
 
 /// Minimum plausible input width for the production creature (observed 2461).
-pub const MIN_INPUTS: usize = 1500;
+pub(crate) const MIN_INPUTS: usize = 1500;
 /// Expected number of outputs for the production creature (observed 1).
-pub const EXPECTED_OUTPUTS: usize = 1;
+pub(crate) const EXPECTED_OUTPUTS: usize = 1;
 /// Lower bound on production neuron count (observed 1666).
-pub const MIN_NEURONS: usize = 800;
+pub(crate) const MIN_NEURONS: usize = 800;
 /// Upper bound on production neuron count (guards against absurd inputs).
-pub const MAX_NEURONS: usize = 12_000;
+pub(crate) const MAX_NEURONS: usize = 12_000;
 /// Lower bound on production synapse count (observed 21 510).
-pub const MIN_SYNAPSES: usize = 8_000;
+pub(crate) const MIN_SYNAPSES: usize = 8_000;
 /// Upper bound on production synapse count.
-pub const MAX_SYNAPSES: usize = 120_000;
+pub(crate) const MAX_SYNAPSES: usize = 120_000;
 
 // --- Production corpus sizing (from the production performance.csv) ----------
 
@@ -96,7 +96,7 @@ impl std::error::Error for ProdFixtureError {}
 ///
 /// Does **not** validate topology — see [`check_production_topology`]. Splitting
 /// the two lets callers report the more specific failure.
-pub fn parse_production_creature(json: &str) -> Result<CreatureExport, ProdFixtureError> {
+pub(crate) fn parse_production_creature(json: &str) -> Result<CreatureExport, ProdFixtureError> {
     if json.trim().is_empty() {
         return Err(ProdFixtureError::Empty);
     }
@@ -107,7 +107,7 @@ pub fn parse_production_creature(json: &str) -> Result<CreatureExport, ProdFixtu
 ///
 /// Rejects a trivially small stand-in (e.g. the synthetic 8→8→2 fixture) so a
 /// regression cannot quietly benchmark a meaningless creature.
-pub fn check_production_topology(creature: &CreatureExport) -> Result<(), ProdFixtureError> {
+pub(crate) fn check_production_topology(creature: &CreatureExport) -> Result<(), ProdFixtureError> {
     let neurons = creature.neurons.len();
     let synapses = creature.synapses.len();
 

--- a/rust_scorer/src/read_tuning.rs
+++ b/rust_scorer/src/read_tuning.rs
@@ -15,10 +15,10 @@ const LARGE_RECORD_BYTES_THRESHOLD: usize = 8000;
 const LARGE_RECORD_DEFAULT_READ_BYTES: usize = 32 * 1024 * 1024;
 
 /// Upper bound for read buffer size (matches previous `neat_core` tuner cap).
-pub const MAX_READ_BYTES: usize = 64 * 1024 * 1024;
+pub(crate) const MAX_READ_BYTES: usize = 64 * 1024 * 1024;
 
 /// Default read target when `NEAT_SCORER_READ_BYTES` is unset.
-pub fn default_training_read_bytes(record_bytes: usize) -> usize {
+pub(crate) fn default_training_read_bytes(record_bytes: usize) -> usize {
     let rb = record_bytes.max(1);
     if rb >= LARGE_RECORD_BYTES_THRESHOLD {
         LARGE_RECORD_DEFAULT_READ_BYTES

--- a/rust_scorer/src/sampling.rs
+++ b/rust_scorer/src/sampling.rs
@@ -82,7 +82,7 @@ impl SampleSpec {
     }
 
     /// `true` when this spec keeps every record (`rate == 1.0`).
-    pub fn is_full(&self) -> bool {
+    pub(crate) fn is_full(&self) -> bool {
         self.rate >= 1.0
     }
 
@@ -150,7 +150,7 @@ impl RecordSampler {
     }
 
     /// `true` when every record is kept (no filtering work performed).
-    pub fn is_full(&self) -> bool {
+    pub(crate) fn is_full(&self) -> bool {
         self.spec.is_full()
     }
 

--- a/rust_scorer/src/scoring.rs
+++ b/rust_scorer/src/scoring.rs
@@ -10,7 +10,7 @@ use crate::gpu::GpuBackendLabel;
 
 /// The current semantic major version matching the TypeScript constant.
 /// Creatures not at this version receive a small penalty.
-pub const SEMANTIC_MAJOR_VERSION: u32 = 4;
+pub(crate) const SEMANTIC_MAJOR_VERSION: u32 = 4;
 
 /// Typed error for the public scoring API (Issue #289, C-GOOD-ERR).
 ///

--- a/rust_scorer/src/shallow_fixture.rs
+++ b/rust_scorer/src/shallow_fixture.rs
@@ -24,7 +24,7 @@
 /// — the same property the real creature has. Cycling this set across the
 /// hidden neurons reproduces the transcendental mix (`Mish`, `SELU`, `ELU`, …)
 /// that determines per-neuron CPU cost, the variable the A/B is sensitive to.
-pub const ENCELADUS_SQUASHES: &[&str] = &[
+pub(crate) const ENCELADUS_SQUASHES: &[&str] = &[
     "LogSigmoid",
     "LeakyReLU",
     "Softplus",
@@ -58,7 +58,7 @@ pub const ENCELADUS_SQUASHES: &[&str] = &[
 // — it sets the `hidden → output` edge count — and keeping it generic keeps
 // this fixture symmetrical with `prod_fixture`. Not a vestige.
 #[must_use]
-pub fn plan_synapses(
+pub(crate) fn plan_synapses(
     num_inputs: usize,
     num_outputs: usize,
     hidden: usize,
@@ -79,9 +79,9 @@ pub fn plan_synapses(
 /// c % hidden)` for `c` in `0..input_hidden`, which yields **distinct** pairs
 /// (a base-`hidden` decomposition) spread evenly across the hidden layer while
 /// keeping the input index within `num_inputs`. Hidden neurons cycle
-/// [`ENCELADUS_SQUASHES`]; outputs use `IDENTITY`. The result parses with
+/// `ENCELADUS_SQUASHES`; outputs use `IDENTITY`. The result parses with
 /// `neat_core::creature::parse_creature_json` and reports exactly
-/// `input_hidden + hidden_output` synapses (see [`plan_synapses`]).
+/// `input_hidden + hidden_output` synapses (see `plan_synapses`).
 #[must_use]
 pub fn shallow_creature_json(
     num_inputs: usize,

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -187,7 +187,7 @@ pub fn accumulate_cost_sum_forward_only_fused(
 /// `CompiledNetwork` directly — `config` already carries the input/output
 /// widths the reader needs, so the export was pure dead weight at every call
 /// site.
-pub fn accumulate_cost_sum_forward_only_fused_sampled(
+pub(crate) fn accumulate_cost_sum_forward_only_fused_sampled(
     cost: CostKind,
     bin_files: &[std::path::PathBuf],
     config: &TrainingDataConfig,


### PR DESCRIPTION
# Narrow 27 crate-internal `pub` items to `pub(crate)` (Issue #474)

## Summary

`rust_scorer` is not published, so `pub` on an item with no consumer outside the
crate widens the API surface for nothing — and, worse, it suppresses the
`dead_code` lint that would otherwise catch the item going stale. This PR
downgrades the 27 items identified by the dead-code audit to `pub(crate)`,
which re-arms `dead_code` on each of them. Closes #474.

Items narrowed:

| file | symbols |
| --- | --- |
| `scoring.rs` | `SEMANTIC_MAJOR_VERSION` |
| `read_tuning.rs` | `MAX_READ_BYTES`, `default_training_read_bytes` |
| `shallow_fixture.rs` | `ENCELADUS_SQUASHES`, `plan_synapses` |
| `prod_fixture.rs` | `MIN_INPUTS`, `EXPECTED_OUTPUTS`, `MIN_NEURONS`, `MAX_NEURONS`, `MIN_SYNAPSES`, `MAX_SYNAPSES`, `parse_production_creature`, `check_production_topology` |
| `gpu/forward_mse_batched.rs` | `MAX_NEURONS_ABSOLUTE`, `DEFAULT_SCRATCH_BUDGET_BYTES`, `NeuronGpu`, `CreatureMetaGpu`, `BatchedNetworkData`, `build_batched_network_data`, `BatchedRunner::from_data`, `DirectoryGpuRunners`, `DirectoryGpuRunners::kernel_label`, `scratch_workgroups_x_for` |
| `gpu/mod.rs` | `GpuBackendLabel::from_wgpu` |
| `stream_score.rs` | `accumulate_cost_sum_forward_only_fused_sampled` |
| `sampling.rs` | `SampleSpec::is_full`, `RecordSampler::is_full` |

`MAX_READ_BYTES` and friends are used **across** modules
(`read_tuning.rs` → `stream_score.rs`), so `pub(crate)` — not private — is the
right target.

### Follow-on doc-link fix (required, not scope creep)

Seven public doc comments linked to items this PR made private, which rustdoc
rejects under the repo's `RUSTDOCFLAGS=-D warnings` gate
(`public documentation for X links to private item Y`). Those seven intra-doc
links became plain code spans — no prose was reworded:

- `prod_fixture.rs` module docs → `parse_production_creature`,
  `check_production_topology`
- `shallow_fixture.rs::shallow_creature_json` → `ENCELADUS_SQUASHES`,
  `plan_synapses`
- `gpu/forward_mse_batched.rs` `TooManyNeurons` / `num_neurons` →
  `MAX_NEURONS_ABSOLUTE`
- `multi_score.rs::gpu_directory_compatible` → `MAX_NEURONS_ABSOLUTE`

### Not changed

The issue's exclusion list is honoured as-is — items that leak into a public
signature, items with a doctest-only external consumer, and items whose `pub`
currently acts as `dead_code` suppression for the lib target (because `main.rs`
declares its own separate `mod` tree) all keep `pub`.

## Evidence

This is a library-visibility change with no web interface, so there is no
screenshot. The compiler *is* the test: narrowing visibility either compiles or
it does not, and the value of the change is a lint that fires on future rot.

**Full gate green** — `./quality.sh < /dev/null` passed end to end against the
sibling `neat-core` at 0.5.0: shellcheck, cargo-deny, `fmt --check`,
`clippy --workspace --all-targets -D warnings`, build, the full test suite
(including all 24 doctests), `cargo doc` with `RUSTDOCFLAGS=-D warnings`, and
the release build. `Cargo.lock` is unchanged.

**`dead_code` is demonstrably re-armed.** Removing the single non-test caller of
`default_training_read_bytes` in a throwaway edit now fails the build, where
before the change `pub` would have silently absorbed it:

```text
error: function `default_training_read_bytes` is never used
  --> rust_scorer/src/read_tuning.rs:21:15
   |
21 | pub(crate) fn default_training_read_bytes(record_bytes: usize) -> usize {
   |
   = help: to override `-D unused` add `#[expect(dead_code)]` or `#[allow(dead_code)]`
```

Note the three `#[cfg(test)]` call sites did **not** keep it alive — exactly the
behaviour wanted, since a function reachable only from its own unit tests is
dead in the shipping binary. The edit was reverted immediately; it is not part
of this PR.

```mermaid
flowchart LR
    A["pub item<br/>no external consumer"] -->|"dead_code suppressed"| B["last caller removed"]
    B --> C["build stays green<br/>rot found only by audit"]
    A -->|"this PR"| D["pub(crate)"]
    D --> E["last caller removed"]
    E --> F["cargo build FAILS<br/>rot caught by compiler"]
```

## Test Plan

No new tests were added, and no existing test was modified, commented out, or
removed. A visibility change has no runtime behaviour to assert, and a test that
inspected source text for `pub(crate)` would verify nothing useful. The
verification is the compiler plus the existing suite:

- `cargo clippy --workspace --all-targets -- -D warnings` — clean, proving no
  in-crate call site lost access and no item became dead.
- `cargo test --workspace` — every existing suite passes, including the 24
  doctests, confirming no doctest was an external consumer of a narrowed item.
- `cargo doc` with `RUSTDOCFLAGS=-D warnings` — clean, confirming the seven
  intra-doc links were the complete set of doc references to narrowed items.
- Release build under `RUSTFLAGS=-D warnings` — clean, confirming `dead_code`
  does not fire for any of the 27 in a non-test build.
- Manual negative check (above) confirming `dead_code` now *does* fire when a
  narrowed item loses its last non-test caller.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms5u9she-d183ec`<!-- vibe-worker-issue-474 -->