### PR TITLE
Scope the bot-push credential: replace org-level ACTIONS_PUSH PAT with a short-lived repo-scoped token (Issue #498)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -38,6 +38,13 @@ jobs:
     # Skip forks — neither GITHUB_TOKEN nor ACTIONS_PUSH can push to a
     # fork's branch. Formatting on fork PRs is the author's responsibility.
     if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      # The `secrets` context is unavailable in a step-level `if:`, so the
+      # push App's configured/not-configured state is hoisted to a job-level
+      # env flag (Issue #498). Until an organisation admin creates the App and
+      # stores its secrets this is 'false': the mint step is skipped and the
+      # push falls back to ACTIONS_PUSH / GITHUB_TOKEN.
+      PUSH_APP_CONFIGURED: ${{ secrets.ACTIONS_PUSH_APP_CLIENT_ID != '' && secrets.ACTIONS_PUSH_APP_PRIVATE_KEY != '' }}
 
     steps:
       - name: Checkout PR branch
@@ -83,13 +90,30 @@ jobs:
             echo "AUTO_FORMAT_COMMIT_MESSAGE_EOF"
           } >>"$GITHUB_OUTPUT"
 
-      # Push with the org-level ACTIONS_PUSH PAT so the resulting
-      # `synchronize` event is attributed to a trusted identity and PR
-      # checks run without the "Awaiting approval / Approve and run" gate
-      # that GITHUB_TOKEN bot pushes create (Issue #435). Fall back to
-      # GITHUB_TOKEN only when the secret is unset. The PAT is passed via
-      # env + a per-command extraheader so it never lives in `.git/config`
-      # (mirrors NEAT-AI update-package-version.yml).
+      # Mint a short-lived installation token scoped to `contents: write` on
+      # THIS repository only (Issue #498). It expires within the hour and the
+      # action's post step revokes it, so a token that leaks reaches nothing
+      # beyond this repository — unlike the long-lived organisation-level
+      # ACTIONS_PUSH PAT, which carries write access to every org repo. The
+      # push stays attributed to a trusted non-GITHUB_TOKEN identity, so the
+      # Issue #435 behaviour is preserved.
+      - name: Mint repo-scoped push token
+        id: push-token
+        if: steps.detect.outputs.changed == 'true' && env.PUSH_APP_CONFIGURED == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.ACTIONS_PUSH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ACTIONS_PUSH_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      # Push with the minted repo-scoped token, falling back to the org-level
+      # ACTIONS_PUSH PAT (then GITHUB_TOKEN) until the App exists, so the
+      # resulting `synchronize` event is attributed to a trusted identity and
+      # PR checks run without the "Awaiting approval / Approve and run" gate
+      # that GITHUB_TOKEN bot pushes create (Issue #435). The credential is
+      # passed via env + a per-command extraheader so it never lives in
+      # `.git/config` (mirrors NEAT-AI update-package-version.yml).
       #
       # Earlier steps in this job run PR-head code, so this step is hardened
       # against in-job poisoning of the PAT (Issue #497): git and base64 are
@@ -103,7 +127,7 @@ jobs:
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           COMMIT_MESSAGE: ${{ steps.detect.outputs.commit_message }}
-          GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ steps.push-token.outputs.token || secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           GIT=/usr/bin/git

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -86,6 +86,13 @@ jobs:
     if: needs.guard.outputs.should_bump == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # The `secrets` context is unavailable in a step-level `if:`, so the
+      # push App's configured/not-configured state is hoisted to a job-level
+      # env flag (Issue #498). Until an organisation admin creates the App and
+      # stores its secrets this is 'false': the mint step is skipped and the
+      # push falls back to ACTIONS_PUSH / GITHUB_TOKEN.
+      PUSH_APP_CONFIGURED: ${{ secrets.ACTIONS_PUSH_APP_CLIENT_ID != '' && secrets.ACTIONS_PUSH_APP_PRIVATE_KEY != '' }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
@@ -121,13 +128,30 @@ jobs:
             echo "changed=true" >>"$GITHUB_OUTPUT"
           fi
 
-      # Push with the org-level ACTIONS_PUSH PAT so the resulting
-      # `synchronize` event is attributed to a trusted identity and PR
-      # checks run without the "Awaiting approval / Approve and run" gate
-      # that GITHUB_TOKEN bot pushes create (Issue #435). Fall back to
-      # GITHUB_TOKEN only when the secret is unset. The PAT is passed via
-      # env + a per-command extraheader so it never lives in `.git/config`
-      # (mirrors NEAT-AI update-package-version.yml).
+      # Mint a short-lived installation token scoped to `contents: write` on
+      # THIS repository only (Issue #498). It expires within the hour and the
+      # action's post step revokes it, so a token that leaks reaches nothing
+      # beyond this repository — unlike the long-lived organisation-level
+      # ACTIONS_PUSH PAT, which carries write access to every org repo. The
+      # push stays attributed to a trusted non-GITHUB_TOKEN identity, so the
+      # Issue #435 behaviour is preserved.
+      - name: Mint repo-scoped push token
+        id: push-token
+        if: steps.bump.outputs.changed == 'true' && env.PUSH_APP_CONFIGURED == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.ACTIONS_PUSH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ACTIONS_PUSH_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      # Push with the minted repo-scoped token, falling back to the org-level
+      # ACTIONS_PUSH PAT (then GITHUB_TOKEN) until the App exists, so the
+      # resulting `synchronize` event is attributed to a trusted identity and
+      # PR checks run without the "Awaiting approval / Approve and run" gate
+      # that GITHUB_TOKEN bot pushes create (Issue #435). The credential is
+      # passed via env + a per-command extraheader so it never lives in
+      # `.git/config` (mirrors NEAT-AI update-package-version.yml).
       #
       # Earlier steps in this job run PR-head code, so this step is hardened
       # against in-job poisoning of the PAT (Issue #497): git and base64 are
@@ -141,7 +165,7 @@ jobs:
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           NEXT_VERSION: ${{ needs.guard.outputs.next_version }}
-          GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ steps.push-token.outputs.token || secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           GIT=/usr/bin/git

--- a/README.md
+++ b/README.md
@@ -865,9 +865,9 @@ the patch component once and pushes that commit back to the PR branch. A
 re-run of CI — or a human-authored bump on the same branch — short-circuits
 the job, so no duplicate bump commits are produced. The underlying logic
 lives in `scripts/version-increment.sh` and is covered by
-`tests/scripts/version_increment.bats`. Bot pushes authenticate with the
-org-level `ACTIONS_PUSH` PAT (falling back to `GITHUB_TOKEN` when unset) so
-the follow-on PR checks run without an "Approve and run" gate (Issue #435).
+`tests/scripts/version_increment.bats`. Bot pushes authenticate with a
+short-lived repo-scoped installation token (see below) so the follow-on PR
+checks run without an "Approve and run" gate (Issue #435).
 
 PRs also run an auto-format job (`.github/workflows/auto-format.yml`,
 Issue #19). The job runs `cargo fmt --all` on the PR branch; if the working
@@ -877,7 +877,47 @@ re-running on a clean branch is a no-op. Change detection and the commit
 message live in `scripts/auto-format.sh` and are covered by
 `tests/scripts/auto_format.bats`; the workflow itself is validated by
 `scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`). The same
-`ACTIONS_PUSH` push token pattern applies here (Issue #435).
+bot-push token pattern applies here (Issue #435).
+
+#### Bot-push credential — repo-scoped installation token (Issue #498)
+
+Both bot-push jobs mint their push credential per run with
+`actions/create-github-app-token` (SHA-pinned, `# v3`): a GitHub App
+installation token narrowed to `permission-contents: write` on **this
+repository only**, expiring within the hour and revoked by the action's post
+step. That replaces the organisation-level `ACTIONS_PUSH` PAT as the primary
+credential — the PAT is long-lived and org-scoped, so anything that reached it
+stepped up from single-repo write access to write access on every repository
+in the organisation. Pushes stay attributed to a trusted non-`GITHUB_TOKEN`
+identity, so the Issue #435 "Approve and run" behaviour is unchanged.
+
+```mermaid
+flowchart LR
+    A[PR push] --> B{"App secrets set?"}
+    B -->|yes| C["Mint installation token<br/>contents: write, this repo, &lt;1h"]
+    B -->|no| D["Fallback:<br/>ACTIONS_PUSH PAT → GITHUB_TOKEN"]
+    C --> E[Commit and push step]
+    D --> E
+    E --> F["synchronize event —<br/>PR checks run unblocked"]
+    C -.->|post step| G[Token revoked]
+```
+
+The App requires an organisation admin to create it and store two secrets:
+
+| Secret                          | Value                                        |
+| ------------------------------- | -------------------------------------------- |
+| `ACTIONS_PUSH_APP_CLIENT_ID`    | The App's client ID                           |
+| `ACTIONS_PUSH_APP_PRIVATE_KEY`  | The App's PEM private key                     |
+
+Install the App on this repository only, with the `Contents: Read and write`
+repository permission. Until both secrets exist the job-level
+`PUSH_APP_CONFIGURED` flag is `false`, the mint step is skipped, and the push
+falls back to `secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN` — so the
+workflows keep working unchanged in the meantime. A fine-grained PAT limited
+to this single repository, stored as `ACTIONS_PUSH`, is the lower-effort
+alternative to the App. The policy is validated by
+`scripts/check-bot-push-token.sh` (invoked from `quality.sh`) and covered by
+`tests/scripts/bot_push_token.bats`.
 
 #### Hardened PAT-bearing push steps (Issue #497)
 
@@ -906,9 +946,10 @@ the same hijack vector as `git`), passes `-c core.hooksPath=/dev/null` on every
 git invocation, and resolves the commit message in an earlier step so no
 repository script runs alongside `$GH_PAT`.
 This is defence in depth, not a closed window — the durable fix is to scope
-the credential itself (a short-lived GitHub App installation token, or a
-fine-grained PAT limited to this repository), which needs an organisation
-admin to mint (tracked in Issue #498). The hardening is validated by
+the credential itself, which Issue #498 does above: once the App secrets are
+in place the credential in `$GH_PAT` is a repo-scoped token that expires
+within the hour, so exfiltrating it no longer reaches other organisation
+repositories. The hardening is validated by
 `scripts/check-push-step-hardening.sh` (invoked from `quality.sh` and from the
 CI `bats` suite) and covered by `tests/scripts/push_step_hardening.bats`.
 

--- a/docs/archive/pr-summaries/pr-summary-498.md
+++ b/docs/archive/pr-summaries/pr-summary-498.md
@@ -1,0 +1,117 @@
+# Scope the bot-push credential to a short-lived repo-scoped token
+
+## Summary
+
+`auto-format.yml` and `version-increment.yml` pushed back to the PR head
+branch with the **organisation-level** `ACTIONS_PUSH` PAT. That PAT is
+long-lived and org-scoped, so anything that reached it stepped up from
+single-repo write access to write access on every repository in the
+organisation — the residual risk left open by the Issue #497 hardening.
+
+Both jobs now mint their push credential per run with
+`actions/create-github-app-token` (SHA-pinned `bcd2ba4…`, `# v3`): a GitHub App
+installation token narrowed to `permission-contents: write` and scoped to
+**this repository only**, expiring within the hour and revoked by the action's
+post step. Pushes remain attributed to a trusted non-`GITHUB_TOKEN` identity,
+so the Issue #435 behaviour (checks run on the resulting `synchronize` event
+without an "Approve and run" gate) is preserved.
+
+Creating the App and storing its secrets needs organisation-admin access, so
+the change is written to degrade safely: a job-level `PUSH_APP_CONFIGURED`
+flag (the `secrets` context is unavailable in a step-level `if:`) skips the
+mint step until both secrets exist, and `GH_PAT` falls back to
+`secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN`. The workflows therefore behave
+exactly as before until an admin completes the handover documented in the
+README.
+
+Closes #498.
+
+## Evidence
+
+This is a CI/workflow change with no web interface to screenshot. Verification
+is the BATS suite plus the repository's own workflow checkers.
+
+```mermaid
+flowchart LR
+    A[PR push] --> B{"App secrets set?"}
+    B -->|yes| C["Mint installation token<br/>contents: write, this repo, &lt;1h"]
+    B -->|no| D["Fallback:<br/>ACTIONS_PUSH PAT → GITHUB_TOKEN"]
+    C --> E[Commit and push step]
+    D --> E
+    E --> F["synchronize event —<br/>PR checks run unblocked"]
+    C -.->|post step| G[Token revoked]
+```
+
+`scripts/check-bot-push-token.sh` was rewritten from a single `grep` for
+`secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN` into an indentation-aware
+scanner (same approach as `check-push-step-hardening.sh`) enforcing four rules
+per guarded workflow:
+
+1. the push credential is minted with `actions/create-github-app-token`,
+   SHA-pinned per the supply-chain policy (Issue #100);
+2. the mint step requests `permission-contents: write`;
+3. the mint step scopes the token with `repositories:` to a single repository
+   and sets no `owner:` (which would widen it across the organisation);
+4. every `GH_PAT` binding prefers the minted token and keeps the
+   `ACTIONS_PUSH || GITHUB_TOKEN` fallback.
+
+Local runs (all green):
+
+- `bats tests/scripts/bot_push_token.bats` — 11/11 pass.
+- `actionlint .github/workflows/auto-format.yml .github/workflows/version-increment.yml` — clean.
+- `scripts/check-push-step-hardening.sh` — the Issue #497 hardening still
+  holds on both push steps after the `GH_PAT` change.
+- `scripts/check-workflow-action-versions.sh` — the new action is pinned and
+  covered by an explicit `required:3` policy entry (v3 ships a Node 24 runtime
+  and takes the non-deprecated `client-id` input).
+- `./quality.sh` — full gate passes.
+
+**Supply chain:** `actions/create-github-app-token` v3.2.0 was published
+2026-05-12, well outside the 24 h quarantine window for external dependencies,
+and is pinned to the tag's commit SHA rather than the mutable tag.
+
+## Human action still required
+
+An organisation admin must create the GitHub App and store two repository
+secrets before the scoping takes effect:
+
+| Secret                         | Value                     |
+| ------------------------------ | ------------------------- |
+| `ACTIONS_PUSH_APP_CLIENT_ID`   | The App's client ID       |
+| `ACTIONS_PUSH_APP_PRIVATE_KEY` | The App's PEM private key |
+
+Install the App on this repository only, with the `Contents: Read and write`
+repository permission. A fine-grained PAT limited to this single repository,
+stored as `ACTIONS_PUSH`, is the lower-effort alternative. Until then the
+workflows run on the existing fallback path, unchanged.
+
+## Test Plan
+
+`tests/scripts/bot_push_token.bats` — rewritten around the Issue #498 policy:
+
+- `passes when the push token is a repo-scoped app token with PAT fallback`
+- `fails when the push relies on the org-level PAT alone` — **deliberately
+  inverted**: this case previously asserted that a bare
+  `ACTIONS_PUSH || GITHUB_TOKEN` chain passed. Issue #498 changes that business
+  rule, so the test now asserts the opposite. No test was removed or commented
+  out.
+- `fails when workflow only uses GITHUB_TOKEN` — unchanged (Issue #435).
+- `fails when the app token action is not SHA-pinned`
+- `fails when the minted token is not narrowed to contents: write`
+- `fails when the minted token is not scoped to a single repository`
+- `fails when the mint step widens scope with an owner input`
+- `fails when the push step ignores the minted token`
+- `fails when the ACTIONS_PUSH fallback is dropped`
+- `reports a missing workflow file instead of passing silently` — the checker
+  fails loud rather than treating an absent workflow as a pass.
+- `shipped auto-format and version-increment workflows validate cleanly`
+
+## Files changed
+
+- `.github/workflows/auto-format.yml`, `.github/workflows/version-increment.yml`
+  — mint step + `GH_PAT` preference chain + `PUSH_APP_CONFIGURED` job env.
+- `scripts/check-bot-push-token.sh` — new four-rule policy checker.
+- `scripts/check-workflow-action-versions.sh` — `required:3` policy entry.
+- `tests/scripts/bot_push_token.bats` — coverage for every rule.
+- `README.md` — new "Bot-push credential" section with the admin handover
+  steps; the Issue #497 section now points at the landed fix.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.40"
+version = "1.1.41"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-bot-push-token.sh
+++ b/scripts/check-bot-push-token.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
-# Validate that bot-push PR workflows authenticate with ACTIONS_PUSH
-# (Issue #435).
+# Validate that bot-push PR workflows authenticate with a short-lived,
+# repo-scoped installation token (Issues #435, #498).
 #
 # Auto Format and Version Increment commit back to the PR branch. A push
 # authenticated only with GITHUB_TOKEN attributes the resulting
 # `synchronize` event to github-actions[bot], and GitHub holds the
 # follow-on required checks behind "N checks awaiting approval /
-# Approve and run". NEAT-AI avoids this by pushing with the org-level
-# ACTIONS_PUSH PAT (GITHUB_TOKEN fallback when unset).
+# Approve and run" (Issue #435).
 #
-# Rule: each guarded workflow must reference
-# `secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN`.
+# The original fix pushed with the organisation-level ACTIONS_PUSH PAT. That
+# PAT is long-lived and org-scoped, so anything that reaches it steps up from
+# single-repo write access to the PAT's full scope — including pushing to
+# other organisation repositories. Issue #498 replaces it with a token minted
+# per run by a GitHub App: `contents: write` on **this repository only**, and
+# expiring within the hour. The PAT stays only as a fallback until an org
+# admin creates the App and stores its secrets.
+#
+# Rules enforced on each guarded workflow:
+#   1. It mints the push credential with `actions/create-github-app-token`,
+#      SHA-pinned per the supply-chain policy (Issue #100).
+#   2. The mint step narrows the token to `permission-contents: write`.
+#   3. The mint step scopes it to this repository via `repositories:` and does
+#      not set `owner:`, which would widen the token across the organisation.
+#   4. Every `GH_PAT` binding prefers that minted token, falling back to
+#      `secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN` so pushes keep working
+#      (and keep clearing the Issue #435 approval gate) before the App exists.
 set -euo pipefail
 
 usage() {
@@ -23,8 +37,9 @@ Options:
                     .github/workflows/ are checked.
   -h, --help        Show this message.
 
-Exits 0 when every target workflow authenticates bot pushes with
-ACTIONS_PUSH (GITHUB_TOKEN fallback). Exits non-zero otherwise.
+Exits 0 when every target workflow pushes with a short-lived repo-scoped
+installation token (ACTIONS_PUSH / GITHUB_TOKEN fallback). Exits non-zero
+otherwise.
 EOF
 }
 
@@ -74,12 +89,197 @@ validate_workflow() {
     return
   fi
 
-  if grep -qE 'secrets\.ACTIONS_PUSH[[:space:]]*\|\|[[:space:]]*secrets\.GITHUB_TOKEN' "$wf"; then
-    echo "OK   $wf: push authenticates with ACTIONS_PUSH (GITHUB_TOKEN fallback)"
-  else
-    echo "FAIL $wf: no 'secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN' — bot pushes will gate PR checks behind Approve and run (Issue #435)" >&2
-    EXIT_CODE=1
-  fi
+  # Emit one report line per finding:
+  #   RESULT\t<ok|fail>\t<line>\t<message>
+  # An indentation-aware scanner walks the YAML rather than pulling in a YAML
+  # parser — the same approach as check-push-step-hardening.sh.
+  local report
+  report="$(
+    python3 - "$wf" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.read().splitlines()
+
+
+def indent_of(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+STEP_START = re.compile(r"^\s*-\s")
+MINT_USES = re.compile(r"^\s*(?:-\s*)?uses:\s*actions/create-github-app-token@(\S+)")
+SHA_REF = re.compile(r"^[0-9a-f]{40}$")
+ID_LINE = re.compile(r"^\s*id:\s*(\S+)")
+OWNER_INPUT = re.compile(r"^\s*owner:\s*\S")
+REPOS_INPUT = re.compile(r"^\s*repositories:\s*(\S.*?)\s*$")
+CONTENTS_WRITE = re.compile(r"^\s*permission-contents:\s*write\s*$")
+GH_PAT_LINE = re.compile(r"^\s*GH_PAT:\s*(\S.*?)\s*$")
+
+results = []
+
+
+def report(state, lineno, message):
+    results.append(f"RESULT\t{state}\t{lineno}\t{message}")
+
+
+def step_bounds(index):
+    """Return (start, end) line indices of the step containing `index`."""
+    start = index
+    while start >= 0 and not STEP_START.match(lines[start]):
+        start -= 1
+    if start < 0:
+        return None
+    step_indent = indent_of(lines[start])
+    end = start + 1
+    while end < len(lines):
+        cur = lines[end]
+        if cur.strip() and indent_of(cur) <= step_indent:
+            break
+        end += 1
+    return start, end
+
+
+mint_id = None
+mint_line = 0
+for idx, line in enumerate(lines):
+    if line.lstrip().startswith("#"):
+        continue
+    match = MINT_USES.match(line)
+    if not match:
+        continue
+    mint_line = idx + 1
+    ref = match.group(1)
+    if SHA_REF.match(ref):
+        report("ok", mint_line, "mints the push token with SHA-pinned actions/create-github-app-token")
+    else:
+        report(
+            "fail",
+            mint_line,
+            "actions/create-github-app-token must be SHA-pinned to a 40-char "
+            f"commit (supply-chain policy, Issue #100) — found @{ref}",
+        )
+
+    bounds = step_bounds(idx)
+    if bounds is None:
+        report("fail", mint_line, "the create-github-app-token reference is not inside a step")
+        break
+    start, end = bounds
+    body = lines[start:end]
+
+    for raw in body:
+        id_match = ID_LINE.match(raw)
+        if id_match:
+            mint_id = id_match.group(1)
+            break
+    if mint_id is None:
+        report(
+            "fail",
+            mint_line,
+            "the mint step needs an 'id:' so the push step can read its token output",
+        )
+
+    if any(CONTENTS_WRITE.match(raw) for raw in body):
+        report("ok", mint_line, "narrows the minted token to 'permission-contents: write'")
+    else:
+        report(
+            "fail",
+            mint_line,
+            "the mint step must request 'permission-contents: write' so the token "
+            "carries only the permission the push needs",
+        )
+
+    repos = [REPOS_INPUT.match(raw) for raw in body]
+    repos = [m.group(1) for m in repos if m]
+    if not repos:
+        report(
+            "fail",
+            mint_line,
+            "the mint step must scope the token with 'repositories:' — an "
+            "unscoped installation token reaches every repository the App is "
+            "installed on",
+        )
+    elif len(repos) > 1 or "," in repos[0]:
+        report(
+            "fail",
+            mint_line,
+            f"'repositories:' must name this repository alone — found {repos[0]}",
+        )
+    else:
+        report("ok", mint_line, f"scopes the minted token to a single repository ({repos[0]})")
+
+    owner = [raw.strip() for raw in body if OWNER_INPUT.match(raw)]
+    if owner:
+        report(
+            "fail",
+            mint_line,
+            "the mint step must not set 'owner:' — it widens the token beyond "
+            f"this repository: {owner[0]}",
+        )
+    else:
+        report("ok", mint_line, "sets no 'owner:' input, so the token stays repo-scoped")
+    break
+
+if mint_line == 0:
+    report(
+        "fail",
+        0,
+        "no step mints a short-lived repo-scoped push token with "
+        "actions/create-github-app-token (Issue #498) — the long-lived "
+        "organisation-level ACTIONS_PUSH PAT must not be the only credential",
+    )
+
+pat_bindings = [(idx + 1, m.group(1)) for idx, m in
+                ((i, GH_PAT_LINE.match(line)) for i, line in enumerate(lines)) if m]
+
+if not pat_bindings:
+    report(
+        "fail",
+        0,
+        "no step binds GH_PAT — bot pushes must authenticate with the minted "
+        "app token, falling back to secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN "
+        "so the resulting checks are not gated behind Approve and run (Issue #435)",
+    )
+
+FALLBACK = r"secrets\.ACTIONS_PUSH\s*\|\|\s*secrets\.GITHUB_TOKEN"
+for lineno, value in pat_bindings:
+    token_ref = None
+    if mint_id is not None:
+        token_ref = re.compile(r"steps\." + re.escape(mint_id) + r"\.outputs\.token")
+    if token_ref is None or not token_ref.search(value):
+        report(
+            "fail",
+            lineno,
+            "GH_PAT must prefer the minted token "
+            f"(steps.{mint_id or '<mint-step-id>'}.outputs.token) over the "
+            f"organisation-level PAT — found {value}",
+        )
+        continue
+    if not re.search(FALLBACK, value):
+        report(
+            "fail",
+            lineno,
+            "GH_PAT must fall back to 'secrets.ACTIONS_PUSH || "
+            "secrets.GITHUB_TOKEN' so pushes keep clearing the Approve-and-run "
+            f"gate before the App exists (Issue #435) — found {value}",
+        )
+        continue
+    report("ok", lineno, "GH_PAT prefers the minted repo-scoped token, ACTIONS_PUSH fallback")
+
+print("\n".join(results))
+PY
+  )"
+
+  while IFS=$'\t' read -r tag state lineno message; do
+    [[ "$tag" == "RESULT" ]] || continue
+    if [[ "$state" == "ok" ]]; then
+      echo "OK   $wf: line $lineno $message"
+    else
+      echo "FAIL $wf: line $lineno $message" >&2
+      EXIT_CODE=1
+    fi
+  done <<<"$report"
 }
 
 for wf in "${WORKFLOWS[@]}"; do

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -131,6 +131,10 @@ lookup_policy() {
     # taiki-e/install-action installs prebuilt cargo tool binaries (Issue
     # #208), replacing source compiles. The v2 line ships a Node 24 runtime.
     taiki-e/install-action)           echo "required:2" ;;
+    # actions/create-github-app-token mints the short-lived repo-scoped bot
+    # push token (Issue #498). The v3 line ships a Node 24 runtime and takes
+    # the non-deprecated `client-id` input.
+    actions/create-github-app-token) echo "required:3" ;;
     # dtolnay/rust-toolchain is a composite/shell action. No Node runtime,
     # so the Node 24 deprecation does not apply.
     dtolnay/rust-toolchain)           echo "no-node" ;;

--- a/tests/scripts/bot_push_token.bats
+++ b/tests/scripts/bot_push_token.bats
@@ -1,5 +1,11 @@
 #!/usr/bin/env bats
-# Tests for scripts/check-bot-push-token.sh (Issue #435).
+# Tests for scripts/check-bot-push-token.sh (Issues #435, #498).
+#
+# Issue #435 established that bot pushes must not be attributed to
+# GITHUB_TOKEN. Issue #498 narrowed *which* credential satisfies that:
+# a short-lived installation token minted per run by a GitHub App and scoped
+# to `contents: write` on this repository only, with the long-lived org-level
+# ACTIONS_PUSH PAT kept only as a fallback until an org admin creates the App.
 
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-bot-push-token.sh"
@@ -12,7 +18,41 @@ teardown() {
   rm -rf "$TMP_WF"
 }
 
-@test "passes when workflow uses ACTIONS_PUSH with GITHUB_TOKEN fallback" {
+# A workflow that satisfies the Issue #498 policy in full.
+write_compliant_workflow() {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+jobs:
+  push:
+    steps:
+      - name: Mint repo-scoped push token
+        id: push-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.ACTIONS_PUSH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ACTIONS_PUSH_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+      - name: Push
+        env:
+          GH_PAT: ${{ steps.push-token.outputs.token || secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
+        run: git push
+EOF
+}
+
+@test "passes when the push token is a repo-scoped app token with PAT fallback" {
+  write_compliant_workflow
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+# Issue #498 changed the policy: the org-level PAT alone is no longer
+# sufficient, because anything that reaches it gains the PAT's full
+# organisation scope. This test previously asserted the opposite (a bare
+# ACTIONS_PUSH || GITHUB_TOKEN chain passed); it is inverted deliberately.
+@test "fails when the push relies on the org-level PAT alone" {
   cat >"$TMP_WF/wf.yml" <<'EOF'
 name: Example
 jobs:
@@ -24,8 +64,8 @@ jobs:
         run: git push
 EOF
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"OK"* ]]
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"create-github-app-token"* ]]
 }
 
 @test "fails when workflow only uses GITHUB_TOKEN" {
@@ -44,6 +84,61 @@ EOF
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"ACTIONS_PUSH"* ]]
+}
+
+@test "fails when the app token action is not SHA-pinned" {
+  write_compliant_workflow
+  sed -i.bak 's%create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1%create-github-app-token@v3%' "$TMP_WF/wf.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SHA-pinned"* ]]
+}
+
+@test "fails when the minted token is not narrowed to contents: write" {
+  write_compliant_workflow
+  sed -i.bak '/permission-contents: write/d' "$TMP_WF/wf.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"permission-contents: write"* ]]
+}
+
+@test "fails when the minted token is not scoped to a single repository" {
+  write_compliant_workflow
+  sed -i.bak '/repositories:/d' "$TMP_WF/wf.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"repositories:"* ]]
+}
+
+@test "fails when the mint step widens scope with an owner input" {
+  write_compliant_workflow
+  sed -i.bak 's%          repositories:%          owner: ${{ github.repository_owner }}\
+          repositories:%' "$TMP_WF/wf.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"owner:"* ]]
+}
+
+@test "fails when the push step ignores the minted token" {
+  write_compliant_workflow
+  sed -i.bak 's%GH_PAT: ${{ steps.push-token.outputs.token || secrets.ACTIONS_PUSH %GH_PAT: ${{ secrets.ACTIONS_PUSH %' "$TMP_WF/wf.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"outputs.token"* ]]
+}
+
+@test "fails when the ACTIONS_PUSH fallback is dropped" {
+  write_compliant_workflow
+  sed -i.bak 's%steps.push-token.outputs.token || secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN%steps.push-token.outputs.token%' "$TMP_WF/wf.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ACTIONS_PUSH"* ]]
+}
+
+@test "reports a missing workflow file instead of passing silently" {
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/absent.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
 }
 
 @test "shipped auto-format and version-increment workflows validate cleanly" {


### PR DESCRIPTION
# Scope the bot-push credential to a short-lived repo-scoped token

## Summary

`auto-format.yml` and `version-increment.yml` pushed back to the PR head
branch with the **organisation-level** `ACTIONS_PUSH` PAT. That PAT is
long-lived and org-scoped, so anything that reached it stepped up from
single-repo write access to write access on every repository in the
organisation — the residual risk left open by the Issue #497 hardening.

Both jobs now mint their push credential per run with
`actions/create-github-app-token` (SHA-pinned `bcd2ba4…`, `# v3`): a GitHub App
installation token narrowed to `permission-contents: write` and scoped to
**this repository only**, expiring within the hour and revoked by the action's
post step. Pushes remain attributed to a trusted non-`GITHUB_TOKEN` identity,
so the Issue #435 behaviour (checks run on the resulting `synchronize` event
without an "Approve and run" gate) is preserved.

Creating the App and storing its secrets needs organisation-admin access, so
the change is written to degrade safely: a job-level `PUSH_APP_CONFIGURED`
flag (the `secrets` context is unavailable in a step-level `if:`) skips the
mint step until both secrets exist, and `GH_PAT` falls back to
`secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN`. The workflows therefore behave
exactly as before until an admin completes the handover documented in the
README.

Closes #498.

## Evidence

This is a CI/workflow change with no web interface to screenshot. Verification
is the BATS suite plus the repository's own workflow checkers.

```mermaid
flowchart LR
    A[PR push] --> B{"App secrets set?"}
    B -->|yes| C["Mint installation token<br/>contents: write, this repo, &lt;1h"]
    B -->|no| D["Fallback:<br/>ACTIONS_PUSH PAT → GITHUB_TOKEN"]
    C --> E[Commit and push step]
    D --> E
    E --> F["synchronize event —<br/>PR checks run unblocked"]
    C -.->|post step| G[Token revoked]
```

`scripts/check-bot-push-token.sh` was rewritten from a single `grep` for
`secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN` into an indentation-aware
scanner (same approach as `check-push-step-hardening.sh`) enforcing four rules
per guarded workflow:

1. the push credential is minted with `actions/create-github-app-token`,
   SHA-pinned per the supply-chain policy (Issue #100);
2. the mint step requests `permission-contents: write`;
3. the mint step scopes the token with `repositories:` to a single repository
   and sets no `owner:` (which would widen it across the organisation);
4. every `GH_PAT` binding prefers the minted token and keeps the
   `ACTIONS_PUSH || GITHUB_TOKEN` fallback.

Local runs (all green):

- `bats tests/scripts/bot_push_token.bats` — 11/11 pass.
- `actionlint .github/workflows/auto-format.yml .github/workflows/version-increment.yml` — clean.
- `scripts/check-push-step-hardening.sh` — the Issue #497 hardening still
  holds on both push steps after the `GH_PAT` change.
- `scripts/check-workflow-action-versions.sh` — the new action is pinned and
  covered by an explicit `required:3` policy entry (v3 ships a Node 24 runtime
  and takes the non-deprecated `client-id` input).
- `./quality.sh` — full gate passes.

**Supply chain:** `actions/create-github-app-token` v3.2.0 was published
2026-05-12, well outside the 24 h quarantine window for external dependencies,
and is pinned to the tag's commit SHA rather than the mutable tag.

## Human action still required

An organisation admin must create the GitHub App and store two repository
secrets before the scoping takes effect:

| Secret                         | Value                     |
| ------------------------------ | ------------------------- |
| `ACTIONS_PUSH_APP_CLIENT_ID`   | The App's client ID       |
| `ACTIONS_PUSH_APP_PRIVATE_KEY` | The App's PEM private key |

Install the App on this repository only, with the `Contents: Read and write`
repository permission. A fine-grained PAT limited to this single repository,
stored as `ACTIONS_PUSH`, is the lower-effort alternative. Until then the
workflows run on the existing fallback path, unchanged.

## Test Plan

`tests/scripts/bot_push_token.bats` — rewritten around the Issue #498 policy:

- `passes when the push token is a repo-scoped app token with PAT fallback`
- `fails when the push relies on the org-level PAT alone` — **deliberately
  inverted**: this case previously asserted that a bare
  `ACTIONS_PUSH || GITHUB_TOKEN` chain passed. Issue #498 changes that business
  rule, so the test now asserts the opposite. No test was removed or commented
  out.
- `fails when workflow only uses GITHUB_TOKEN` — unchanged (Issue #435).
- `fails when the app token action is not SHA-pinned`
- `fails when the minted token is not narrowed to contents: write`
- `fails when the minted token is not scoped to a single repository`
- `fails when the mint step widens scope with an owner input`
- `fails when the push step ignores the minted token`
- `fails when the ACTIONS_PUSH fallback is dropped`
- `reports a missing workflow file instead of passing silently` — the checker
  fails loud rather than treating an absent workflow as a pass.
- `shipped auto-format and version-increment workflows validate cleanly`

## Files changed

- `.github/workflows/auto-format.yml`, `.github/workflows/version-increment.yml`
  — mint step + `GH_PAT` preference chain + `PUSH_APP_CONFIGURED` job env.
- `scripts/check-bot-push-token.sh` — new four-rule policy checker.
- `scripts/check-workflow-action-versions.sh` — `required:3` policy entry.
- `tests/scripts/bot_push_token.bats` — coverage for every rule.
- `README.md` — new "Bot-push credential" section with the admin handover
  steps; the Issue #497 section now points at the landed fix.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msalso3m-52aa84`<!-- vibe-worker-issue-498 -->