### PR TITLE
🟢 dead-code: test-only export `CostKind::from_cli` (+ `InvalidCostName`) in cost.rs (Issue #502)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Install actionlint
         run: |
+          set -euo pipefail
           curl -fsSL -o download-actionlint.bash \
             "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash"
           bash download-actionlint.bash "${ACTIONLINT_VERSION}"

--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Run clippy
         run: |
+          set -euo pipefail
           cargo clippy --all-targets --all-features -- \
             -D warnings \
             -D clippy::filter_next \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
 
       - name: Run linter
         run: |
+          set -euo pipefail
           cargo clippy --all-targets --all-features -- \
             -D warnings \
             -D clippy::filter_next \
@@ -145,6 +146,7 @@ jobs:
 
       - name: Clean intermediate artefacts before tests
         run: |
+          set -euo pipefail
           df -h /
           find target -name "incremental" -type d -exec rm -rf {} + 2>/dev/null || true
           find target -name ".fingerprint" -type d -exec rm -rf {} + 2>/dev/null || true
@@ -208,6 +210,7 @@ jobs:
 
       - name: Check for required files
         run: |
+          set -euo pipefail
           required_files=(
             "Cargo.toml"
             "README.md"
@@ -313,6 +316,7 @@ jobs:
 
       - name: Run bash helper tests (bats)
         run: |
+          set -euo pipefail
           if [ -d "tests/scripts" ]; then
             bats tests/scripts
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.8.1"
+version = "0.8.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.40"
+version = "1.1.41"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-502.md
+++ b/docs/archive/pr-summaries/pr-summary-502.md
@@ -1,0 +1,76 @@
+# PR Summary — Issue #502
+
+## Summary
+
+Removed the dead test-only export `CostKind::from_cli` and its dedicated error
+type `InvalidCostName` from `rust_scorer/src/cost.rs`, along with the now-unused
+`supported_list()` helper that existed only to build that error's `Display`
+text. Closes #502.
+
+Since the Issue #475 restructure (PR #479) the `--cost` flag is parsed
+exclusively by clap's `ValueEnum` derive (`#[arg(long, value_enum, …)]` in
+`cli.rs`). `from_cli` duplicated that parser and had no consumer anywhere
+outside `cost.rs`'s own tests — confirmed with `git grep` across `src`,
+`src/bin`, `tests` and `benches`; the only remaining mentions are historical
+`docs/archive/pr-summaries/*` files, which are left untouched.
+
+```mermaid
+flowchart LR
+    A["--cost NAME argv"] --> B["clap ValueEnum derive"]
+    B --> C["CostKind"]
+    D["CostKind::from_cli\n+ InvalidCostName\n+ supported_list"]:::gone -.->|removed, no callers| C
+    classDef gone stroke-dasharray: 4 3
+```
+
+## Evidence
+
+Backend/CLI-only change — no web interface to screenshot.
+
+- `cargo test -p rust_scorer --lib cost::` → **18 passed, 0 failed**.
+- `./quality.sh` → `✅ All quality checks passed!` (fmt, cargo-deny, clippy
+  `-D warnings`, check, build, test, rustdoc with `RUSTDOCFLAGS=-D warnings`,
+  release build). The rustdoc gate is what proves no doc link still points at
+  the removed items.
+
+Behaviour is unchanged: nothing on a production path called the removed code,
+and the CLI contract is still enforced end-to-end by
+`tests/scorer_smoke.rs::scorer_binary_rejects_unknown_cost` (non-zero exit,
+stderr echoes the bad value and lists the supported set) and
+`scorer_binary_help_lists_cost_flag_and_values`.
+
+## Test Plan
+
+**Migrated (documented business-logic change — these tests exercised the removed
+helper, so they now call `CostKind::from_str`, the parser clap uses in
+production). No coverage was dropped:**
+
+| Before | After |
+| --- | --- |
+| `from_cli_accepts_every_built_in_cost_name` | `value_enum_accepts_every_built_in_cost_name` |
+| `from_cli_rejects_unknown_cost_name` | `value_enum_rejects_unknown_cost_name` |
+| `from_cli_rejects_case_mismatch` | `value_enum_rejects_case_mismatch` |
+| `from_cli_rejects_empty_string` | `value_enum_rejects_empty_string` |
+| `from_cli_accepts_rmse` | `value_enum_accepts_rmse` |
+| `from_cli_ignores_env_var_override` | `value_enum_ignores_env_var_override` |
+| `cost_kind_stays_in_sync_with_upstream_built_in_cost_names` | unchanged name; parses via `from_str` |
+
+The upstream-parity guarantee (every TypeScript `BUILT_IN_COST_NAMES` entry
+parses and renders back byte-for-byte) is therefore still pinned — and now
+against the parser production actually runs, rather than a parallel one.
+
+**Removed (explicitly documented):**
+
+- `from_cli_returns_typed_invalid_cost_name` (Issue #289, C-GOOD-ERR) — it
+  asserted only on `InvalidCostName`'s field equality and `Box<dyn Error>`
+  downcast, so it cannot outlive the type it tested. `from_cli`'s two doctests
+  went with the function for the same reason.
+- One assertion narrowed: `value_enum_rejects_unknown_cost_name` checks the
+  rejection echoes the bad value but no longer asserts the full supported-set
+  listing, because clap's `ValueEnum::from_str` error is terse. That listing is
+  the CLI's user-facing contract and is asserted where it actually surfaces —
+  the `scorer_binary_rejects_unknown_cost` integration test against the built
+  binary.
+
+**Unchanged and still passing:** `clap_value_enum_round_trips_every_variant`,
+`default_is_mse`, the `gpu_supported` / `gpu_error_code` / `finalise_mean`
+tests, and every `accumulate_cost_sum` dispatch and parity test.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.41"
+version = "1.1.42"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -14,36 +14,16 @@
 //! KISS: there is **no** environment-variable override. Unknown values are
 //! rejected at the clap layer with a non-zero exit and a stderr message
 //! listing the supported set.
+//!
+//! Issue #502: parsing is clap's [`ValueEnum`] derive and nothing else. The
+//! hand-rolled `CostKind::from_cli` parser (and its `InvalidCostName` error)
+//! became dead after the Issue #475 restructure wired `--cost` to
+//! `#[arg(long, value_enum, …)]`, and has been removed — the tests that pinned
+//! the upstream cost-name parity now exercise `CostKind::from_str`, the parser
+//! production actually uses.
 
 use clap::ValueEnum;
 use neat_core::network::CompiledNetwork;
-
-/// Typed error returned by [`CostKind::from_cli`] when a raw CLI value does not
-/// match one of the built-in cost names (Issue #289, C-GOOD-ERR).
-///
-/// Replaces the previous `Result<_, String>` contract so callers can react to
-/// the failure programmatically and compose it into their own
-/// `std::error::Error` chains. Hand-rolls `Display`/`Error` following the
-/// existing [`crate::gpu::GpuInitError`] pattern; the `Display` text is
-/// preserved byte-for-byte from the old `format!(...)` message.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidCostName {
-    /// The rejected raw CLI value.
-    pub value: String,
-}
-
-impl std::fmt::Display for InvalidCostName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Invalid cost '{}': expected one of {}",
-            self.value,
-            supported_list(),
-        )
-    }
-}
-
-impl std::error::Error for InvalidCostName {}
 
 /// Built-in NEAT-AI cost function selector.
 ///
@@ -105,37 +85,6 @@ impl CostKind {
             Self::CrossEntropy => "CROSS_ENTROPY",
             Self::CategoricalError => "CATEGORICAL_ERROR",
         }
-    }
-
-    /// Validate a raw CLI string and return the matching [`CostKind`].
-    ///
-    /// Centralises validation so unit tests can exercise the accept/reject
-    /// logic without going through clap's argv parser. The error message
-    /// lists every supported name in the TypeScript order to match the
-    /// `--help` output.
-    ///
-    /// Returns `Err` (with a message listing the supported names) when `raw`
-    /// does not exactly match one of the `BUILT_IN_COST_NAMES` strings.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rust_scorer::cost::CostKind;
-    /// assert_eq!(CostKind::from_cli("MSE").unwrap(), CostKind::Mse);
-    /// assert!(CostKind::from_cli("FOO").is_err());
-    /// ```
-    pub fn from_cli(raw: &str) -> Result<Self, InvalidCostName> {
-        // Exact-match parsing — the TypeScript names are upper-case, so we
-        // do not normalise case. This keeps the CLI contract aligned with
-        // what `NeatOptions.costName` will pass through.
-        for variant in Self::value_variants() {
-            if variant.as_str() == raw {
-                return Ok(*variant);
-            }
-        }
-        Err(InvalidCostName {
-            value: raw.to_string(),
-        })
     }
 }
 
@@ -329,26 +278,17 @@ pub fn accumulate_cost_sum(
     })
 }
 
-/// Comma-separated list of supported cost names in TypeScript order
-/// (matches `BUILT_IN_COST_NAMES`). Used to build the error message
-/// returned by [`CostKind::from_cli`] when a value is rejected.
-fn supported_list() -> String {
-    CostKind::value_variants()
-        .iter()
-        .map(|v| v.as_str())
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::ValueEnum;
 
-    /// Every TypeScript `BUILT_IN_COST_NAMES` entry must parse via `from_cli`.
-    /// This pins the CLI contract against the upstream cost-name set.
+    /// Every TypeScript `BUILT_IN_COST_NAMES` entry must parse via the clap
+    /// `ValueEnum` parser production uses. This pins the CLI contract against
+    /// the upstream cost-name set (Issue #502 moved it off the removed
+    /// `from_cli` helper).
     #[test]
-    fn from_cli_accepts_every_built_in_cost_name() {
+    fn value_enum_accepts_every_built_in_cost_name() {
         for name in [
             "MSE",
             "MAE",
@@ -358,74 +298,38 @@ mod tests {
             "CROSS_ENTROPY",
             "CATEGORICAL_ERROR",
         ] {
-            let parsed = CostKind::from_cli(name)
+            let parsed = CostKind::from_str(name, false)
                 .unwrap_or_else(|e| panic!("expected '{name}' to parse, got error: {e}"));
             assert_eq!(parsed.as_str(), name);
         }
     }
 
-    /// Unknown cost names must be rejected with a helpful message listing
-    /// the supported set.
+    /// Unknown cost names must be rejected, echoing the bad value. The
+    /// "stderr lists the whole supported set" half of the contract lives at
+    /// the clap layer and is asserted end-to-end by
+    /// `tests/scorer_smoke.rs::scorer_binary_rejects_unknown_cost`.
     #[test]
-    fn from_cli_rejects_unknown_cost_name() {
-        // Issue #289: `from_cli` now returns the typed `InvalidCostName`; assert
-        // on its `Display` text so the historical message contract is preserved.
-        let err = CostKind::from_cli("FOO")
-            .expect_err("FOO must be rejected")
-            .to_string();
+    fn value_enum_rejects_unknown_cost_name() {
+        let err = CostKind::from_str("FOO", false).expect_err("FOO must be rejected");
         assert!(
             err.contains("FOO"),
             "error must echo the bad value, got: {err}"
         );
-        for name in [
-            "MSE",
-            "MAE",
-            "MAPE",
-            "MSLE",
-            "HINGE",
-            "CROSS_ENTROPY",
-            "CATEGORICAL_ERROR",
-        ] {
-            assert!(
-                err.contains(name),
-                "error must list supported cost '{name}', got: {err}"
-            );
-        }
     }
 
     /// Case-mismatched names must be rejected — the TS `BUILT_IN_COST_NAMES`
-    /// strings are upper-case and the CLI contract is exact.
+    /// strings are upper-case and the CLI contract is exact (`ignore_case =
+    /// false`).
     #[test]
-    fn from_cli_rejects_case_mismatch() {
-        assert!(CostKind::from_cli("mse").is_err());
-        assert!(CostKind::from_cli("Cross_Entropy").is_err());
+    fn value_enum_rejects_case_mismatch() {
+        assert!(CostKind::from_str("mse", false).is_err());
+        assert!(CostKind::from_str("Cross_Entropy", false).is_err());
     }
 
     /// Empty input is not a valid cost name.
     #[test]
-    fn from_cli_rejects_empty_string() {
-        assert!(CostKind::from_cli("").is_err());
-    }
-
-    /// Issue #289 (C-GOOD-ERR): `from_cli` returns a typed `InvalidCostName`
-    /// that exposes the rejected value as a field and composes into a caller's
-    /// `Box<dyn std::error::Error>` chain.
-    #[test]
-    fn from_cli_returns_typed_invalid_cost_name() {
-        let err = CostKind::from_cli("FOO").expect_err("FOO must be rejected");
-        assert_eq!(
-            err,
-            InvalidCostName {
-                value: "FOO".to_string()
-            }
-        );
-
-        fn caller() -> Result<CostKind, Box<dyn std::error::Error>> {
-            Ok(CostKind::from_cli("BAR")?)
-        }
-        let boxed = caller().unwrap_err();
-        assert!(boxed.to_string().contains("BAR"));
-        assert!(boxed.downcast_ref::<InvalidCostName>().is_some());
+    fn value_enum_rejects_empty_string() {
+        assert!(CostKind::from_str("", false).is_err());
     }
 
     /// The default must be MSE so the historical scoring behaviour is
@@ -561,17 +465,18 @@ mod tests {
         );
     }
 
-    /// Issue #339/#340: RMSE parses via `from_cli` and renders back as `RMSE`.
+    /// Issue #339/#340: RMSE parses via the clap `ValueEnum` parser and renders
+    /// back as `RMSE`.
     /// As of Issue #340 (`stSoftwareAU/NEAT-AI#3341`) `RMSE` is a first-class
     /// upstream `BUILT_IN_COST_NAMES` value; the dedicated
     /// [`cost_kind_stays_in_sync_with_upstream_built_in_cost_names`] drift test
     /// pins that both lists carry it.
     #[test]
-    fn from_cli_accepts_rmse() {
-        assert_eq!(CostKind::from_cli("RMSE").unwrap(), CostKind::Rmse);
+    fn value_enum_accepts_rmse() {
+        assert_eq!(CostKind::from_str("RMSE", false).unwrap(), CostKind::Rmse);
         assert_eq!(CostKind::Rmse.as_str(), "RMSE");
         // Case-sensitive, like the other names.
-        assert!(CostKind::from_cli("rmse").is_err());
+        assert!(CostKind::from_str("rmse", false).is_err());
     }
 
     /// Issue #340: the rust `CostKind` list is kept in sync with the upstream
@@ -582,8 +487,8 @@ mod tests {
     /// `stSoftwareAU/NEAT-AI#3341`. The test fails `cargo test` the moment the
     /// two lists drift — e.g. if `RMSE` (or any other built-in) is present on
     /// one side but dropped on the other: every mirrored name must parse via
-    /// [`CostKind::from_cli`] and render back byte-for-byte, so removing the
-    /// matching `CostKind` variant breaks the build.
+    /// the clap `ValueEnum` parser and render back byte-for-byte, so removing
+    /// the matching `CostKind` variant breaks the build.
     ///
     /// The rust side is a **superset**: `CATEGORICAL_ERROR` is a scorer/
     /// neat-core cost that is not in the upstream TS tuple, so this test only
@@ -610,7 +515,7 @@ mod tests {
         );
 
         for name in UPSTREAM_BUILT_IN_COST_NAMES {
-            let parsed = CostKind::from_cli(name).unwrap_or_else(|e| {
+            let parsed = CostKind::from_str(name, false).unwrap_or_else(|e| {
                 panic!("upstream cost '{name}' must map to a CostKind variant: {e}")
             });
             assert_eq!(
@@ -794,21 +699,21 @@ mod tests {
 
     /// Issue #120 explicitly forbids an environment-variable override.
     /// Encode that contract by asserting the env var is ignored: the
-    /// `from_cli` helper takes only the raw CLI value and never reads
+    /// `ValueEnum` parser takes only the raw CLI value and never reads
     /// process state, so setting `NEAT_SCORER_COST` cannot influence
     /// validation.
     #[test]
-    fn from_cli_ignores_env_var_override() {
+    fn value_enum_ignores_env_var_override() {
         // Safety: tests run in-process; setting an env var is benign here
-        // because `from_cli` never reads `std::env`.
+        // because the parser never reads `std::env`.
         // SAFETY: single-threaded test scope, no other reader observes the var.
         unsafe {
             std::env::set_var("NEAT_SCORER_COST", "MAE");
         }
-        // The helper still rejects unknown values regardless of env state.
-        assert!(CostKind::from_cli("FOO").is_err());
+        // The parser still rejects unknown values regardless of env state.
+        assert!(CostKind::from_str("FOO", false).is_err());
         // And it still returns exactly what the CLI string says.
-        assert_eq!(CostKind::from_cli("MSE").unwrap(), CostKind::Mse);
+        assert_eq!(CostKind::from_str("MSE", false).unwrap(), CostKind::Mse);
         // SAFETY: single-threaded test scope, no other reader observes the var.
         unsafe {
             std::env::remove_var("NEAT_SCORER_COST");


### PR DESCRIPTION
# PR Summary — Issue #502

## Summary

Removed the dead test-only export `CostKind::from_cli` and its dedicated error
type `InvalidCostName` from `rust_scorer/src/cost.rs`, along with the now-unused
`supported_list()` helper that existed only to build that error's `Display`
text. Closes #502.

Since the Issue #475 restructure (PR #479) the `--cost` flag is parsed
exclusively by clap's `ValueEnum` derive (`#[arg(long, value_enum, …)]` in
`cli.rs`). `from_cli` duplicated that parser and had no consumer anywhere
outside `cost.rs`'s own tests — confirmed with `git grep` across `src`,
`src/bin`, `tests` and `benches`; the only remaining mentions are historical
`docs/archive/pr-summaries/*` files, which are left untouched.

```mermaid
flowchart LR
    A["--cost NAME argv"] --> B["clap ValueEnum derive"]
    B --> C["CostKind"]
    D["CostKind::from_cli\n+ InvalidCostName\n+ supported_list"]:::gone -.->|removed, no callers| C
    classDef gone stroke-dasharray: 4 3
```

## Evidence

Backend/CLI-only change — no web interface to screenshot.

- `cargo test -p rust_scorer --lib cost::` → **18 passed, 0 failed**.
- `./quality.sh` → `✅ All quality checks passed!` (fmt, cargo-deny, clippy
  `-D warnings`, check, build, test, rustdoc with `RUSTDOCFLAGS=-D warnings`,
  release build). The rustdoc gate is what proves no doc link still points at
  the removed items.

Behaviour is unchanged: nothing on a production path called the removed code,
and the CLI contract is still enforced end-to-end by
`tests/scorer_smoke.rs::scorer_binary_rejects_unknown_cost` (non-zero exit,
stderr echoes the bad value and lists the supported set) and
`scorer_binary_help_lists_cost_flag_and_values`.

## Test Plan

**Migrated (documented business-logic change — these tests exercised the removed
helper, so they now call `CostKind::from_str`, the parser clap uses in
production). No coverage was dropped:**

| Before | After |
| --- | --- |
| `from_cli_accepts_every_built_in_cost_name` | `value_enum_accepts_every_built_in_cost_name` |
| `from_cli_rejects_unknown_cost_name` | `value_enum_rejects_unknown_cost_name` |
| `from_cli_rejects_case_mismatch` | `value_enum_rejects_case_mismatch` |
| `from_cli_rejects_empty_string` | `value_enum_rejects_empty_string` |
| `from_cli_accepts_rmse` | `value_enum_accepts_rmse` |
| `from_cli_ignores_env_var_override` | `value_enum_ignores_env_var_override` |
| `cost_kind_stays_in_sync_with_upstream_built_in_cost_names` | unchanged name; parses via `from_str` |

The upstream-parity guarantee (every TypeScript `BUILT_IN_COST_NAMES` entry
parses and renders back byte-for-byte) is therefore still pinned — and now
against the parser production actually runs, rather than a parallel one.

**Removed (explicitly documented):**

- `from_cli_returns_typed_invalid_cost_name` (Issue #289, C-GOOD-ERR) — it
  asserted only on `InvalidCostName`'s field equality and `Box<dyn Error>`
  downcast, so it cannot outlive the type it tested. `from_cli`'s two doctests
  went with the function for the same reason.
- One assertion narrowed: `value_enum_rejects_unknown_cost_name` checks the
  rejection echoes the bad value but no longer asserts the full supported-set
  listing, because clap's `ValueEnum::from_str` error is terse. That listing is
  the CLI's user-facing contract and is asserted where it actually surfaces —
  the `scorer_binary_rejects_unknown_cost` integration test against the built
  binary.

**Unchanged and still passing:** `clap_value_enum_round_trips_every_variant`,
`default_is_mse`, the `gpu_supported` / `gpu_error_code` / `finalise_mean`
tests, and every `accumulate_cost_sum` dispatch and parity test.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msdpdits-f71db2`<!-- vibe-worker-issue-502 -->