### PR TITLE
Document the shipped adaptive NEAT_SCORER_READ_BYTES default (Issue #504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ section to the released version with its date.
 
 ### Changed
 
+- **Read-chunk docs now describe the shipped adaptive default (Issue #504).**
+  The README "Large-record hosts" section still told readers the
+  `NEAT_SCORER_READ_BYTES` default was a fixed 2 MiB and that production hosts
+  should `export NEAT_SCORER_READ_BYTES=33554432`, contradicting both
+  `AGENTS.md` and `rust_scorer/src/read_tuning.rs`, where records ≥ 8000 B
+  default to 32 MiB reads. The section now documents the record-size adaptive
+  default (with a Mermaid flowchart), keeps the #307 sweep as its supporting
+  evidence, and states the 64 MiB `MAX_READ_BYTES` clamp.
+  `docs/performance-baseline.md` keeps its dated #307 decision text unedited
+  and carries an appended supersession banner. New
+  `scripts/check-read-bytes-docs.sh` (run from `quality.sh`, covered by
+  `tests/scripts/read_bytes_docs.bats`) reads the constants from
+  `read_tuning.rs` and fails the gate if either document drifts again.
+
 - **Acknowledged the neat-core 0.5.0 → 0.8.1 breaking bumps (Issue #252 gate).**
   neat-core removed three dead WASM/SIMD surfaces —
   `apply_derivative_simd_4way` / `derivative_batch_4way` (0.6.0),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.41"
+version = "1.1.42"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -550,18 +550,50 @@ default, mirroring how `NEAT_SCORER_GPU` already rejects invalid values:
 ```
 
 Unset or blank values stay silent, and a valid value is honoured without any
-warning.
+warning. The default quoted in the message is the **record-size adaptive**
+default described below, so it reads `33554432` on production-sized records.
 
-### Large-record hosts: raise `NEAT_SCORER_READ_BYTES` (Issue #307)
+### Large-record hosts: adaptive `NEAT_SCORER_READ_BYTES` default (Issues #307, #504)
 
-The default `NEAT_SCORER_READ_BYTES` (2 MiB) is tuned for the synthetic
-small-record fixtures. **Production records are 9848 bytes**
-(2461 inputs + 1 output, `f32`), so a 2 MiB chunk holds only ~213 records —
-too few to amortise the per-chunk Rayon dispatch across the worker pool. A
-sweep on the #296 production fixture (see
-[`docs/performance-baseline.md`](docs/performance-baseline.md)) shows larger
-aligned reads recover **~20 %** on the single-creature path, with the sweet
-spot at **16–32 MiB**:
+The read-chunk default is **record-size adaptive** — the constants live in
+[`rust_scorer/src/read_tuning.rs`](rust_scorer/src/read_tuning.rs) and apply to
+every scoring path (single-creature, directory/multi-creature, streaming, CLI
+and `float_scan_bench`):
+
+| Record size | Default read chunk when `NEAT_SCORER_READ_BYTES` is **unset** |
+|---|---|
+| < 8000 B/record (synthetic fixtures) | **2 MiB** (`DEFAULT_READ_BYTES`) |
+| ≥ 8000 B/record (`LARGE_RECORD_BYTES_THRESHOLD`) | **32 MiB** (`LARGE_RECORD_DEFAULT_READ_BYTES`) |
+
+**Production records are 9848 bytes** (2461 inputs + 1 output, `f32`), so
+production runs already read 32 MiB chunks with **no environment variable set**
+— exporting `NEAT_SCORER_READ_BYTES=33554432` by hand is now redundant.
+
+```mermaid
+flowchart TD
+    A[Scoring path needs a read chunk] --> B{NEAT_SCORER_READ_BYTES set?}
+    B -- yes --> C[Use the env value]
+    B -- no --> D{record_bytes >= 8000?}
+    D -- yes --> E[32 MiB default]
+    D -- no --> F[2 MiB default]
+    C --> G[Clamp to record_bytes..64 MiB cap]
+    E --> G
+    F --> G
+    G --> H[Round down to a whole number of records]
+```
+
+`NEAT_SCORER_READ_BYTES` still **overrides** the adaptive default when you want
+a different size. Any value — env or default — is clamped to the **64 MiB** cap
+(`MAX_READ_BYTES`, and to at least one record) and rounded down to a whole
+number of records, so a chunk never splits a record.
+
+#### Why 32 MiB (the supporting sweep)
+
+A 2 MiB chunk holds only ~213 production records — too few to amortise the
+per-chunk Rayon dispatch across the worker pool. A sweep on the #296 production
+fixture (see [`docs/performance-baseline.md`](docs/performance-baseline.md))
+shows larger aligned reads recover **~20 %** on the single-creature path, with
+the sweet spot at **16–32 MiB**:
 
 | `NEAT_SCORER_READ_BYTES` | `production_single_creature` | `production_multi_creature/1` | `production_multi_creature/4` |
 |---|---:|---:|---:|
@@ -576,23 +608,29 @@ back-to-back on one Apple Silicon host; absolute times are host-load
 sensitive, so the table reports the relative improvement each cell held across
 repeated interleaved runs.)
 
-On production hosts with these large records, export a bigger chunk before scoring:
+Those numbers are why the ≥ 8000 B/record default is **32 MiB**; no export is
+needed to get them. To pick a different size — for example `16777216` (16 MiB),
+which captures most of the gain at half the transient read buffer — set the env
+explicitly:
 
 ```bash
-# ~24 % faster forward-only scoring on 9848-byte production records.
-export NEAT_SCORER_READ_BYTES=33554432   # 32 MiB
+# Override the adaptive default; 32 MiB (33554432) is already the default here.
+export NEAT_SCORER_READ_BYTES=16777216   # 16 MiB
 ```
 
-`16777216` (16 MiB) captures most of the gain at half the transient read
-buffer. The read buffer is **per-scan, not per-worker** — directory mode runs
+The read buffer is **per-scan, not per-worker** — directory mode runs
 a single shared scan and partitions the unpacked records across the worker
 pool — so a 32 MiB setting adds at most ~64 MiB of transient buffer (the
 pipelined path double-buffers), not 32 MiB × worker count. That stays well
 within production host RAM headroom.
 
-The global default is intentionally **left at 2 MiB**: the gain is specific to
-large (> ~1 KiB) records, and raising it globally would enlarge the buffer for
-the small-record synthetic path for no benefit. Set the env per-host instead.
+The default is raised **per record size, not globally**: the gain is specific to
+large records, so the small-record synthetic path keeps its 2 MiB buffer while
+large-record corpora get 32 MiB automatically. The #307 sweep originally shipped
+as env-var advice with the global default fixed at 2 MiB; that recommendation was
+superseded when the adaptive default landed in `read_tuning.rs` (see the
+supersession note in
+[`docs/performance-baseline.md`](docs/performance-baseline.md)).
 
 ## Local layout
 

--- a/docs/archive/pr-summaries/pr-summary-504.md
+++ b/docs/archive/pr-summaries/pr-summary-504.md
@@ -1,0 +1,89 @@
+# README and performance-baseline now match the shipped adaptive read default
+
+## Summary
+
+`README.md` documented a **fixed 2 MiB** `NEAT_SCORER_READ_BYTES` default and
+told production hosts to `export NEAT_SCORER_READ_BYTES=33554432`, while
+`docs/performance-baseline.md` recorded "the global default stays 2 MiB and no
+auto-tuner ships". Both contradicted the shipped code and `AGENTS.md`:
+`rust_scorer/src/read_tuning.rs` defaults corpora with records ≥ 8000 B
+(production ≈ 9848 B) to **32 MiB** reads when the env var is unset. Closes #504.
+
+Changes:
+
+- **README** — the section is now "Large-record hosts: adaptive
+  `NEAT_SCORER_READ_BYTES` default", stating the record-size adaptive default
+  (2 MiB / 32 MiB by threshold), that the env var still overrides, and that any
+  value clamps to the 64 MiB `MAX_READ_BYTES` cap and rounds down to whole
+  records. `read_tuning.rs` is linked as the constants' home; the #307 sweep
+  table is kept as supporting evidence under a "Why 32 MiB" sub-heading. The
+  Issue #204 malformed-value section notes that the default quoted in the
+  warning is the adaptive one.
+- **`docs/performance-baseline.md`** — the dated "Decision (Issue #307)" text is
+  left **unedited** per that document's own convention; a supersession banner is
+  appended beneath the heading (mirroring the Issue #211 banner in
+  `docs/gpu-scoring-design.md`).
+- **New gate** — `scripts/check-read-bytes-docs.sh` parses
+  `LARGE_RECORD_BYTES_THRESHOLD`, `LARGE_RECORD_DEFAULT_READ_BYTES`,
+  `DEFAULT_READ_BYTES` and `MAX_READ_BYTES` from `read_tuning.rs` and fails if
+  either document omits them, revives the superseded "left at 2 MiB" advice, or
+  overwrites (rather than appends to) the historical baseline decision. Run from
+  `quality.sh`; enforced in CI through the existing `bats tests/scripts` step.
+
+## Evidence
+
+Documentation/CLI change — no web interface to screenshot. The gate script is
+the evidence that the docs now agree with the code:
+
+```text
+📚 Validating read-chunk docs match read_tuning.rs constants (Issue #504)...
+OK   README documents the large-record threshold (LARGE_RECORD_BYTES_THRESHOLD): 8000
+OK   README documents the adaptive large-record default (LARGE_RECORD_DEFAULT_READ_BYTES): 32 MiB
+OK   README documents the small-record default (DEFAULT_READ_BYTES): 2 MiB
+OK   README documents the clamp cap (MAX_READ_BYTES): 64 MiB
+OK   README documents the constants' home (read_tuning.rs): read_tuning
+OK   README documents the env override: NEAT_SCORER_READ_BYTES
+OK   performance-baseline keeps its historical 2 MiB decision text
+OK   performance-baseline decision carries a supersession note pointing at read_tuning
+README and performance-baseline agree with the shipped read_tuning constants.
+```
+
+Behaviour the README now describes (added as a Mermaid flowchart in the README):
+
+```mermaid
+flowchart TD
+    A[Scoring path needs a read chunk] --> B{NEAT_SCORER_READ_BYTES set?}
+    B -- yes --> C[Use the env value]
+    B -- no --> D{record_bytes >= 8000?}
+    D -- yes --> E[32 MiB default]
+    D -- no --> F[2 MiB default]
+    C --> G[Clamp to record_bytes..64 MiB cap]
+    E --> G
+    F --> G
+    G --> H[Round down to a whole number of records]
+```
+
+`./quality.sh < /dev/null` passes end-to-end (shellcheck, all validators, the
+full bats suite, cargo fmt/clippy/build/test/doc/release): **"✅ All quality
+checks passed!"**.
+
+## Test Plan
+
+New `tests/scripts/read_bytes_docs.bats` (12 tests, TDD — written first and
+failing until the docs were fixed) exercises the validator against synthetic
+fixtures plus the real tree:
+
+- passes on documents aligned with the shipped constants;
+- fails when the README omits the 8000 B threshold, the 32 MiB adaptive default,
+  or the 64 MiB cap;
+- fails when the README does not name `read_tuning` as the constants' home;
+- fails when the README revives the superseded "left at 2 MiB" advice;
+- fails when the README section is missing entirely;
+- fails when the baseline decision carries no supersession note, or when its
+  historical 2 MiB text was overwritten instead of annotated;
+- reports missing files and unknown flags loudly (exit 1 / usage exit 2);
+- **the real repository documents satisfy the check** — this test failed before
+  the doc fix and passes after it.
+
+No production code changed, so the existing Rust suite is unaffected and was
+re-run unchanged by `quality.sh`.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -1030,6 +1030,22 @@ the sweet spot is specific to large-record production hosts.
 
 ### Decision (Issue #307)
 
+> **Superseded (2026-08-04, Issue #504) — the decision below is dated history.**
+> The "global default stays 2 MiB, no auto-tuner ships" call recorded here was
+> later overtaken by the **record-size adaptive default** that shipped in
+> [`rust_scorer/src/read_tuning.rs`](../rust_scorer/src/read_tuning.rs):
+> corpora with records ≥ `LARGE_RECORD_BYTES_THRESHOLD` (8000 B — production is
+> ≈ 9848 B) now default to **32 MiB** reads when `NEAT_SCORER_READ_BYTES` is
+> unset, while smaller records keep the 2 MiB default. The env var remains an
+> override, clamped to the 64 MiB `MAX_READ_BYTES` cap. Exporting
+> `NEAT_SCORER_READ_BYTES=33554432` on production hosts — the recommendation
+> below — is therefore **redundant**. The measurements in this section stand as
+> the evidence that motivated the adaptive default; for current behaviour read
+> the README "Large-record hosts" section and `AGENTS.md`. *(Banner added per
+> [Issue #504](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/504),
+> mirroring the Issue #211 pattern in `docs/gpu-scoring-design.md`. Per this
+> document's convention the historical text below is left unedited.)*
+
 The clear ≥ 5 % gain on every production group qualifies under the issue's
 merge gate, but the **global default stays 2 MiB** and no auto-tuner ships:
 

--- a/quality.sh
+++ b/quality.sh
@@ -135,6 +135,9 @@ echo "🛟 Validating risk-bearing multi-line run: blocks open with set -euo pip
 echo "📖 Validating README 'matches CI' block aligns with the CI quality job (Issue #212)..."
 ./scripts/check-readme-ci-alignment.sh
 
+echo "📚 Validating read-chunk docs match read_tuning.rs constants (Issue #504)..."
+./scripts/check-read-bytes-docs.sh
+
 echo "🕵️  Validating README names no private repository (Issue #450)..."
 ./scripts/check-readme-private-repo-refs.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.42"
+version = "1.1.43"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-read-bytes-docs.sh
+++ b/scripts/check-read-bytes-docs.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# check-read-bytes-docs.sh — Issue #504.
+#
+# Guards against drift between the shipped adaptive read-chunk default in
+# rust_scorer/src/read_tuning.rs and the two documents that describe it:
+#
+#   * README.md — the "Large-record hosts" section must state the live
+#     behaviour (threshold, adaptive default, cap, constants' home) and must not
+#     revive the superseded "default left at 2 MiB" advice.
+#   * docs/performance-baseline.md — the "Decision (Issue #307)" section records
+#     dated history, so its original 2-MiB text must stay put and carry an
+#     appended supersession note rather than being rewritten.
+#
+# Values are read from read_tuning.rs, so bumping a constant fails the gate
+# until both documents follow.
+#
+# Usage:
+#   check-read-bytes-docs.sh [--readme PATH] [--baseline PATH] [--source PATH]
+#
+# Exit codes:
+#   0  documents agree with the shipped constants
+#   1  a document has drifted, or a file/section could not be found
+#   2  usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+README="$REPO_ROOT/README.md"
+BASELINE="$REPO_ROOT/docs/performance-baseline.md"
+SOURCE="$REPO_ROOT/rust_scorer/src/read_tuning.rs"
+
+usage() {
+  echo "Usage: $0 [--readme PATH] [--baseline PATH] [--source PATH]"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --readme)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      README="$2"; shift 2 ;;
+    --baseline)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      BASELINE="$2"; shift 2 ;;
+    --source)
+      [ $# -ge 2 ] || { usage >&2; exit 2; }
+      SOURCE="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      usage >&2; exit 2 ;;
+  esac
+done
+
+for file in "$README" "$BASELINE" "$SOURCE"; do
+  if [ ! -f "$file" ]; then
+    echo "FAIL: file not found: $file" >&2
+    exit 1
+  fi
+done
+
+# Evaluate a `const NAME: usize = <expr>;` definition (e.g. `32 * 1024 * 1024`).
+const_value() {
+  local name="$1" expr
+  expr="$(sed -n "s/^[[:space:]]*\(pub([a-z]*) \)\{0,1\}const ${name}: usize = \([^;]*\);.*/\2/p" "$SOURCE" \
+    | head -n 1 | tr -d '_')"
+  if [ -z "$expr" ]; then
+    echo "FAIL: could not read const ${name} from $SOURCE" >&2
+    exit 1
+  fi
+  echo "$((expr))"
+}
+
+threshold="$(const_value LARGE_RECORD_BYTES_THRESHOLD)"
+large_default="$(const_value LARGE_RECORD_DEFAULT_READ_BYTES)"
+small_default="$(const_value DEFAULT_READ_BYTES)"
+max_bytes="$(const_value MAX_READ_BYTES)"
+
+large_mib=$((large_default / 1024 / 1024))
+small_mib=$((small_default / 1024 / 1024))
+max_mib=$((max_bytes / 1024 / 1024))
+
+# Extract a markdown section: the heading matching $1, up to the next heading of
+# the same or a higher level.
+section_of() {
+  local file="$1" pattern="$2"
+  awk -v pat="$pattern" '
+    /^#+ / {
+      match($0, /^#+/)
+      if (seen) { if (RLENGTH <= level) { exit } }
+      else if (index($0, pat) > 0) { seen = 1; level = RLENGTH }
+    }
+    seen { print }
+  ' "$file"
+}
+
+# Collapse whitespace and strip markdown emphasis/backticks so prose matches
+# regardless of wrapping or formatting.
+flatten() {
+  tr '\n' ' ' | tr -d '`*' | tr -s ' '
+}
+
+fail=0
+
+readme_section="$(section_of "$README" 'Large-record hosts')"
+if [ -z "$readme_section" ]; then
+  echo "FAIL: could not find the 'Large-record hosts' section in $README" >&2
+  exit 1
+fi
+readme_flat="$(printf '%s\n' "$readme_section" | flatten)"
+
+require_readme() {
+  local needle="$1" why="$2"
+  if [[ "$readme_flat" == *"$needle"* ]]; then
+    echo "OK   README documents ${why}: ${needle}"
+  else
+    echo "FAIL README section is missing ${why}: ${needle}" >&2
+    fail=1
+  fi
+}
+
+require_readme "$threshold" "the large-record threshold (LARGE_RECORD_BYTES_THRESHOLD)"
+require_readme "${large_mib} MiB" "the adaptive large-record default (LARGE_RECORD_DEFAULT_READ_BYTES)"
+require_readme "${small_mib} MiB" "the small-record default (DEFAULT_READ_BYTES)"
+require_readme "${max_mib} MiB" "the clamp cap (MAX_READ_BYTES)"
+require_readme "read_tuning" "the constants' home (read_tuning.rs)"
+require_readme "NEAT_SCORER_READ_BYTES" "the env override"
+
+# Superseded advice: the default is adaptive now, so the README must not tell
+# readers it is fixed at the small-record value or that they should export the
+# large-record value by hand.
+forbidden=(
+  "left at ${small_mib} MiB"
+  "global default stays ${small_mib} MiB"
+  "default is intentionally"
+)
+for phrase in "${forbidden[@]}"; do
+  if [[ "$readme_flat" == *"$phrase"* ]]; then
+    echo "FAIL README section revives superseded advice: '${phrase}' — the default is record-size adaptive" >&2
+    fail=1
+  fi
+done
+
+baseline_section="$(section_of "$BASELINE" 'Decision (Issue #307)')"
+if [ -z "$baseline_section" ]; then
+  echo "FAIL: could not find the 'Decision (Issue #307)' section in $BASELINE" >&2
+  exit 1
+fi
+baseline_flat="$(printf '%s\n' "$baseline_section" | flatten)"
+
+# The baseline is dated history: keep the original decision text, append the
+# supersession note beneath it (mirrors the docs/gpu-scoring-design.md banner).
+if [[ "$baseline_flat" == *"global default stays ${small_mib} MiB"* ]]; then
+  echo "OK   performance-baseline keeps its historical ${small_mib} MiB decision text"
+else
+  echo "FAIL performance-baseline overwrote historical decision text; append a note instead" >&2
+  fail=1
+fi
+
+if [[ "$baseline_flat" == *[Ss]uperseded* ]] && [[ "$baseline_flat" == *read_tuning* ]]; then
+  echo "OK   performance-baseline decision carries a supersession note pointing at read_tuning"
+else
+  echo "FAIL performance-baseline decision has no supersession note naming read_tuning (superseded by the adaptive default)" >&2
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "Read-chunk documentation has drifted from rust_scorer/src/read_tuning.rs." >&2
+  exit 1
+fi
+
+echo "README and performance-baseline agree with the shipped read_tuning constants."

--- a/tests/scripts/read_bytes_docs.bats
+++ b/tests/scripts/read_bytes_docs.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-read-bytes-docs.sh — Issue #504.
+#
+# Verifies the validator that keeps the README "Large-record hosts" section and
+# the docs/performance-baseline.md "Decision (Issue #307)" section aligned with
+# the adaptive read-chunk default shipped in rust_scorer/src/read_tuning.rs.
+# Synthetic fixtures in a temp directory exercise the pass/fail behaviour, so
+# the real documents are never mutated by the tests.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-read-bytes-docs.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+  export REPO_ROOT
+
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+
+  write_source "$TMP_DIR/read_tuning.rs"
+  write_readme "$TMP_DIR/README.md"
+  write_baseline "$TMP_DIR/performance-baseline.md"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+run_check() {
+  run "$SCRIPT_UNDER_TEST" \
+    --readme "$TMP_DIR/README.md" \
+    --baseline "$TMP_DIR/performance-baseline.md" \
+    --source "$TMP_DIR/read_tuning.rs"
+}
+
+# Minimal stand-in for rust_scorer/src/read_tuning.rs — the constants are the
+# source of truth the documents must agree with.
+write_source() {
+  cat >"$1" <<'EOF'
+const DEFAULT_READ_BYTES: usize = 2 * 1024 * 1024;
+const LARGE_RECORD_BYTES_THRESHOLD: usize = 8000;
+const LARGE_RECORD_DEFAULT_READ_BYTES: usize = 32 * 1024 * 1024;
+pub(crate) const MAX_READ_BYTES: usize = 64 * 1024 * 1024;
+EOF
+}
+
+# README fixture that documents the shipped adaptive default correctly.
+write_readme() {
+  cat >"$1" <<'EOF'
+# Title
+
+### Large-record hosts: adaptive `NEAT_SCORER_READ_BYTES` default
+
+Records of 8000 bytes or more default to 32 MiB reads when the env var is
+unset (`rust_scorer/src/read_tuning.rs`); smaller records keep the 2 MiB
+default. `NEAT_SCORER_READ_BYTES` still overrides, clamped to the 64 MiB cap.
+
+## Next section
+
+Unrelated prose.
+EOF
+}
+
+# performance-baseline fixture: historical decision text preserved, with the
+# dated supersession note appended beneath it.
+write_baseline() {
+  cat >"$1" <<'EOF'
+# Baseline
+
+### Decision (Issue #307)
+
+The clear gain qualifies, but the **global default stays 2 MiB** and no
+auto-tuner ships.
+
+> **Superseded (2026-08-04, Issue #504).** The 2-MiB-only decision above was
+> later superseded by the adaptive default in `read_tuning.rs`.
+
+## Next section
+
+Unrelated prose.
+EOF
+}
+
+@test "passes on documents aligned with the shipped constants" {
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"agree with"* ]]
+}
+
+@test "fails when the README omits the large-record threshold" {
+  sed -i.bak 's/8000 bytes or more/large records/' "$TMP_DIR/README.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"8000"* ]]
+}
+
+@test "fails when the README omits the adaptive 32 MiB default" {
+  sed -i.bak 's/32 MiB reads/2 MiB reads/' "$TMP_DIR/README.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"32 MiB"* ]]
+}
+
+@test "fails when the README omits the MAX_READ_BYTES cap" {
+  sed -i.bak 's/the 64 MiB cap/the documented cap/' "$TMP_DIR/README.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"64 MiB"* ]]
+}
+
+@test "fails when the README does not point at read_tuning as the constants' home" {
+  sed -i.bak 's|(`rust_scorer/src/read_tuning.rs`)||' "$TMP_DIR/README.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"read_tuning"* ]]
+}
+
+@test "fails when the README revives the superseded 'left at 2 MiB' claim" {
+  sed -i.bak \
+    's/smaller records keep the 2 MiB/the global default is intentionally left at 2 MiB, so smaller records keep the 2 MiB/' \
+    "$TMP_DIR/README.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"left at 2 MiB"* ]]
+}
+
+@test "fails when the README section is absent entirely" {
+  cat >"$TMP_DIR/README.md" <<'EOF'
+# Title
+
+No read-tuning section here.
+EOF
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not find"* ]]
+}
+
+@test "fails when the baseline decision carries no supersession note" {
+  sed -i.bak '/Superseded/,+1d' "$TMP_DIR/performance-baseline.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"superseded"* ]]
+}
+
+@test "fails when the historical 2 MiB decision text was overwritten" {
+  sed -i.bak 's/\*\*global default stays 2 MiB\*\*/global default is adaptive/' \
+    "$TMP_DIR/performance-baseline.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"historical"* ]]
+}
+
+@test "reports an error when a document is missing" {
+  rm -f "$TMP_DIR/README.md"
+  run_check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "unknown flag prints usage and exits non-zero" {
+  run "$SCRIPT_UNDER_TEST" --nonsense
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "the real repository documents satisfy the check" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}


### PR DESCRIPTION
# README and performance-baseline now match the shipped adaptive read default

## Summary

`README.md` documented a **fixed 2 MiB** `NEAT_SCORER_READ_BYTES` default and
told production hosts to `export NEAT_SCORER_READ_BYTES=33554432`, while
`docs/performance-baseline.md` recorded "the global default stays 2 MiB and no
auto-tuner ships". Both contradicted the shipped code and `AGENTS.md`:
`rust_scorer/src/read_tuning.rs` defaults corpora with records ≥ 8000 B
(production ≈ 9848 B) to **32 MiB** reads when the env var is unset. Closes #504.

Changes:

- **README** — the section is now "Large-record hosts: adaptive
  `NEAT_SCORER_READ_BYTES` default", stating the record-size adaptive default
  (2 MiB / 32 MiB by threshold), that the env var still overrides, and that any
  value clamps to the 64 MiB `MAX_READ_BYTES` cap and rounds down to whole
  records. `read_tuning.rs` is linked as the constants' home; the #307 sweep
  table is kept as supporting evidence under a "Why 32 MiB" sub-heading. The
  Issue #204 malformed-value section notes that the default quoted in the
  warning is the adaptive one.
- **`docs/performance-baseline.md`** — the dated "Decision (Issue #307)" text is
  left **unedited** per that document's own convention; a supersession banner is
  appended beneath the heading (mirroring the Issue #211 banner in
  `docs/gpu-scoring-design.md`).
- **New gate** — `scripts/check-read-bytes-docs.sh` parses
  `LARGE_RECORD_BYTES_THRESHOLD`, `LARGE_RECORD_DEFAULT_READ_BYTES`,
  `DEFAULT_READ_BYTES` and `MAX_READ_BYTES` from `read_tuning.rs` and fails if
  either document omits them, revives the superseded "left at 2 MiB" advice, or
  overwrites (rather than appends to) the historical baseline decision. Run from
  `quality.sh`; enforced in CI through the existing `bats tests/scripts` step.

## Evidence

Documentation/CLI change — no web interface to screenshot. The gate script is
the evidence that the docs now agree with the code:

```text
📚 Validating read-chunk docs match read_tuning.rs constants (Issue #504)...
OK   README documents the large-record threshold (LARGE_RECORD_BYTES_THRESHOLD): 8000
OK   README documents the adaptive large-record default (LARGE_RECORD_DEFAULT_READ_BYTES): 32 MiB
OK   README documents the small-record default (DEFAULT_READ_BYTES): 2 MiB
OK   README documents the clamp cap (MAX_READ_BYTES): 64 MiB
OK   README documents the constants' home (read_tuning.rs): read_tuning
OK   README documents the env override: NEAT_SCORER_READ_BYTES
OK   performance-baseline keeps its historical 2 MiB decision text
OK   performance-baseline decision carries a supersession note pointing at read_tuning
README and performance-baseline agree with the shipped read_tuning constants.
```

Behaviour the README now describes (added as a Mermaid flowchart in the README):

```mermaid
flowchart TD
    A[Scoring path needs a read chunk] --> B{NEAT_SCORER_READ_BYTES set?}
    B -- yes --> C[Use the env value]
    B -- no --> D{record_bytes >= 8000?}
    D -- yes --> E[32 MiB default]
    D -- no --> F[2 MiB default]
    C --> G[Clamp to record_bytes..64 MiB cap]
    E --> G
    F --> G
    G --> H[Round down to a whole number of records]
```

`./quality.sh < /dev/null` passes end-to-end (shellcheck, all validators, the
full bats suite, cargo fmt/clippy/build/test/doc/release): **"✅ All quality
checks passed!"**.

## Test Plan

New `tests/scripts/read_bytes_docs.bats` (12 tests, TDD — written first and
failing until the docs were fixed) exercises the validator against synthetic
fixtures plus the real tree:

- passes on documents aligned with the shipped constants;
- fails when the README omits the 8000 B threshold, the 32 MiB adaptive default,
  or the 64 MiB cap;
- fails when the README does not name `read_tuning` as the constants' home;
- fails when the README revives the superseded "left at 2 MiB" advice;
- fails when the README section is missing entirely;
- fails when the baseline decision carries no supersession note, or when its
  historical 2 MiB text was overwritten instead of annotated;
- reports missing files and unknown flags loudly (exit 1 / usage exit 2);
- **the real repository documents satisfy the check** — this test failed before
  the doc fix and passes after it.

No production code changed, so the existing Rust suite is unaffected and was
re-run unchanged by `quality.sh`.



## Milestone
This PR is part of the **Docs 20260804** milestone and targets the `milestone/docs-20260804` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msej82kx-7da553`<!-- vibe-worker-issue-504 -->