### PR TITLE
🟠 Realign the README CI section with the workflows it describes (Issue #506)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,12 +1058,16 @@ covered end-to-end by `tests/scripts/milestone_branch_filter.bats`. The workflow
 `scripts/check-cargo-quality-workflow.sh` (invoked from `quality.sh`) and
 covered end-to-end by `tests/scripts/cargo_quality_workflow.bats`.
 
-ShellCheck runs in exactly one place: `ci.yml`'s `shell-checks` job invokes
-`ludeeus/action-shellcheck@2.0.0` alongside the `bash -n` syntax check and
-the bats helper-test suite, and feeds the `ci-required` aggregator that
-branch protection gates on. A standalone `shellcheck.yml` previously ran the
-identical invocation, doubling the maintenance surface (Issue #157); it was
-removed so the ShellCheck configuration lives in a single home. The dedup
+ShellCheck runs in exactly one place: `ci.yml`'s `shell-checks` job runs the
+[`koalaman/shellcheck`](https://github.com/koalaman/shellcheck) binary
+**pre-installed on the `ubuntu-latest` runner** directly — no third-party
+wrapper action enters the supply chain (PR #184 dropped the wrapper, whose
+unauthenticated release-asset download also failed the job on a transient
+error) — alongside the `bash -n` syntax check and the bats helper-test suite,
+and feeds the `ci-required` aggregator that branch protection gates on. A
+standalone `shellcheck.yml` previously ran the identical invocation, doubling
+the maintenance surface (Issue #157); it was removed so the ShellCheck
+configuration lives in a single home. The dedup
 invariant is enforced by `scripts/check-shellcheck-dedup.sh` (invoked from
 `quality.sh`) and covered end-to-end by
 `tests/scripts/shellcheck_dedup.bats`, which fail if a second workflow
@@ -1187,9 +1191,13 @@ the SHA and the comment in the same PR, and note the changelog highlights
 in the PR description.
 
 The same script also enforces the Node 24 deprecation policy from the
-trailing comment: minimum majors, tracked Node 20 exceptions
-(`actions/dependency-review-action@v4`, `rustsec/audit-check@v2` — no
-Node 24 release upstream yet), and a composite/shell allow-list. The
+trailing comment: minimum majors, the single remaining tracked Node 20
+exception (`rustsec/audit-check@v2` — no Node 24 tag upstream yet, so the pin
+is the `master` HEAD commit that already declares `using: node24`), and a
+composite/shell allow-list. `actions/dependency-review-action` is no longer an
+exception (Issue #136): the validator requires major **5**, and both
+`dependency-review.yml` and `security.yml` pin `v5.0.0`, which ships on
+Node 24. The
 policy lives in `scripts/check-workflow-action-versions.sh` and is
 covered end-to-end by `tests/scripts/workflow_action_versions.bats`.
 `quality.sh` invokes the script so any unpinned or outdated `uses:`

--- a/docs/archive/pr-summaries/pr-summary-506.md
+++ b/docs/archive/pr-summaries/pr-summary-506.md
@@ -1,0 +1,88 @@
+# Realign the README CI section with the workflows it describes (Issue #506)
+
+## Summary
+
+Two claims in the README's CI section had drifted from the workflows they
+document, in the exact section a security reviewer reads to learn which
+third-party code executes in CI. Closes #506.
+
+1. **ShellCheck wrapper.** The README said `ci.yml`'s `shell-checks` job
+   "invokes `ludeeus/action-shellcheck@2.0.0`". PR #184 replaced that wrapper
+   with the `shellcheck` binary pre-installed on the `ubuntu-latest` runner
+   (`.github/workflows/ci.yml`), and no workflow references the wrapper any
+   more — so the README claimed a removed action was still in the supply chain.
+   The paragraph now describes the direct `koalaman/shellcheck` binary
+   invocation and states that no third-party wrapper enters the supply chain.
+   The single-home/dedup invariant (`scripts/check-shellcheck-dedup.sh`) is
+   unchanged.
+2. **Node 20 exception list.** The README named
+   `actions/dependency-review-action@v4` as a tracked Node 20 exception, while
+   `scripts/check-workflow-action-versions.sh` requires major **5** and both
+   `dependency-review.yml` and `security.yml` pin `v5.0.0` (Node 24). The
+   README even contradicted itself, documenting the standalone workflow as
+   running `@v5`. `rustsec/audit-check@v2` is now named as the single remaining
+   exception, matching the validator.
+
+To stop the same drift recurring, `scripts/check-readme-ci-alignment.sh`
+(already the README ↔ CI validator, Issue #212) gained two guards derived from
+the source of truth rather than from a hard-coded copy of the prose:
+
+- The README may not name `ludeeus/action-shellcheck` unless a workflow under
+  `.github/workflows/` actually invokes it.
+- Every human-readable `owner/action@vN` reference in the README must be at or
+  above the major that `check-workflow-action-versions.sh` requires for that
+  action. SHA pins (`@5f6978fa…`) are deliberately not parsed as versions.
+
+Docs-only change: no workflow files, Rust sources or CI behaviour were touched.
+
+## Evidence
+
+No UI or performance surface — this is a documentation correction plus a shell
+validator. Evidence is the validator itself, which fails on the pre-fix README
+and passes on the corrected one:
+
+```text
+$ ./scripts/check-readme-ci-alignment.sh   # before the README fix
+FAIL README names ludeeus/action-shellcheck, but no workflow invokes that wrapper (Issue #506)
+FAIL README names actions/dependency-review-action@v4 but
+     actions/dependency-review-action requires major >= 5 (Issue #506)
+README CI documentation has drifted from the workflows it describes.
+
+$ ./scripts/check-readme-ci-alignment.sh   # after
+README 'matches CI' block matches the CI quality job.
+```
+
+`./quality.sh` passes end to end (exit 0, "✅ All quality checks passed!"),
+including the 16-test `readme_ci_alignment.bats` suite.
+
+```mermaid
+flowchart LR
+    wf[".github/workflows/*.yml<br/>no ludeeus wrapper"] --> chk
+    val["check-workflow-action-versions.sh<br/>required: majors"] --> chk
+    chk{"check-readme-ci-alignment.sh"} --> rd["README CI section"]
+    chk -- drift --> fail["quality.sh fails"]
+```
+
+## Test Plan
+
+Added to `tests/scripts/readme_ci_alignment.bats` (all exercise the real
+validator against synthetic README/workflow/validator fixtures):
+
+- `fails when the README names a wrapper action no workflow invokes` —
+  regression test for claim 1; fails against the pre-fix README wording.
+- `allows the wrapper in the README while a workflow still uses it` — the guard
+  is derived from the workflows, not a blanket ban on the string.
+- `fails when the README understates a required action major` — regression test
+  for claim 2 (`@v4` against a `required:5` floor).
+- `passes when the README names the required action major` — `@v5` plus the
+  genuine `rustsec/audit-check@v2` exception.
+- `ignores SHA-pinned uses: references when checking majors` — guards against
+  reading `@5f6978fa…` as "major 5".
+- `reports an error when the workflows directory is missing` and
+  `reports an error when the action-version validator is missing` — the checks
+  fail loud rather than silently skipping when an input is absent.
+
+The pre-existing `the real repository README satisfies the alignment check`
+test now covers both new invariants against the committed README; it failed
+before the README edits and passes after them. No existing test was removed,
+weakened or commented out.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.44"
+version = "1.1.45"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-readme-ci-alignment.sh
+++ b/scripts/check-readme-ci-alignment.sh
@@ -1,24 +1,36 @@
 #!/usr/bin/env bash
-# check-readme-ci-alignment.sh — Issue #212.
+# check-readme-ci-alignment.sh — Issues #212, #506.
 #
-# Guards against drift between the README "step-by-step (matches CI)" command
-# block and the CI `quality` job in .github/workflows/ci.yml. A contributor
-# copy-pasting the README block to "reproduce CI" must run the same gate CI
-# runs — no weaker, no different.
+# Guards against drift between the README's CI documentation and the workflows
+# it describes. Three invariants:
 #
-# The check extracts the fenced bash block that follows the
-# "Or step-by-step (matches CI):" heading in README.md, collapses line
-# continuations and whitespace, and asserts every canonical CI quality command
-# is present. It does NOT parse ci.yml — the canonical command list below is
-# the single source of truth, kept deliberately small and explicit so a drift
-# in either file is obvious in review.
+#   1. (Issue #212) The "step-by-step (matches CI)" command block must run the
+#      same gate the CI `quality` job runs — no weaker, no different. The check
+#      extracts the fenced bash block that follows the
+#      "Or step-by-step (matches CI):" heading, collapses line continuations and
+#      whitespace, and asserts every canonical CI quality command is present. It
+#      does NOT parse ci.yml — the canonical command list below is the single
+#      source of truth, kept deliberately small and explicit so a drift in
+#      either file is obvious in review.
+#   2. (Issue #506) The README must not present `ludeeus/action-shellcheck` as
+#      part of the supply chain once no workflow invokes that wrapper. PR #184
+#      switched `ci.yml`'s `shell-checks` job to the runner's pre-installed
+#      `shellcheck` binary; a README still naming the wrapper sends a security
+#      reviewer to audit third-party code that no longer executes.
+#   3. (Issue #506) Every `owner/action@vN` reference in the README must be at
+#      or above the major that `scripts/check-workflow-action-versions.sh`
+#      requires. Understating a major (e.g. calling
+#      `actions/dependency-review-action@v4` a tracked Node 20 exception when
+#      the validator requires the Node 24 v5 line) misrepresents the repo's
+#      actual runtime posture.
 #
 # Usage:
-#   check-readme-ci-alignment.sh [--readme PATH]
+#   check-readme-ci-alignment.sh [--readme PATH] [--workflows DIR]
+#                                [--versions-script PATH]
 #
 # Exit codes:
-#   0  README block matches every canonical CI quality command
-#   1  one or more commands missing, or the block could not be found
+#   0  README matches the workflows it documents
+#   1  one or more invariants violated, or the matches-CI block was not found
 #   2  usage error
 
 set -euo pipefail
@@ -26,20 +38,34 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 README="$REPO_ROOT/README.md"
+WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+VERSIONS_SCRIPT="$SCRIPT_DIR/check-workflow-action-versions.sh"
+
+USAGE="Usage: $0 [--readme PATH] [--workflows DIR] [--versions-script PATH]"
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --readme)
-      [ $# -ge 2 ] || { echo "Usage: $0 [--readme PATH]" >&2; exit 2; }
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
       README="$2"
       shift 2
       ;;
+    --workflows)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      WORKFLOWS_DIR="$2"
+      shift 2
+      ;;
+    --versions-script)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      VERSIONS_SCRIPT="$2"
+      shift 2
+      ;;
     -h|--help)
-      echo "Usage: $0 [--readme PATH]"
+      echo "$USAGE"
       exit 0
       ;;
     *)
-      echo "Usage: $0 [--readme PATH]" >&2
+      echo "$USAGE" >&2
       exit 2
       ;;
   esac
@@ -105,8 +131,63 @@ if [[ "$collapsed" == *"cargo check"* ]]; then
   fail=1
 fi
 
+# --- Issue #506: the README must not advertise a wrapper action no workflow
+# runs. `ci.yml`'s shell-checks job calls the runner's pre-installed
+# `shellcheck` binary (PR #184), so `ludeeus/action-shellcheck` is out of the
+# supply chain and must not be described as still in it.
+if [ -d "$WORKFLOWS_DIR" ]; then
+  if grep -rqE 'uses:[[:space:]]*ludeeus/action-shellcheck@' "$WORKFLOWS_DIR"; then
+    echo "OK   ludeeus/action-shellcheck is still used by a workflow"
+  elif grep -q 'ludeeus/action-shellcheck' "$README"; then
+    echo "FAIL README names ludeeus/action-shellcheck, but no workflow invokes that wrapper (Issue #506)" >&2
+    fail=1
+  else
+    echo "OK   README does not claim the removed ludeeus/action-shellcheck wrapper"
+  fi
+else
+  echo "FAIL workflows directory not found: $WORKFLOWS_DIR" >&2
+  fail=1
+fi
+
+# --- Issue #506: every `owner/action@vN` the README names must be at or above
+# the major floor that check-workflow-action-versions.sh enforces. The
+# validator's `required:N` table is the single source of truth for the Node 24
+# policy, so a README naming an older major (e.g. a stale Node 20 exception)
+# understates the runtime the workflows actually pin.
+required_major_for() {
+  local action="$1" escaped line
+  escaped="${action//./\\.}"
+  line="$(grep -E "^[[:space:]]*${escaped}\)[[:space:]]*echo \"required:[0-9]+\"" "$VERSIONS_SCRIPT" || true)"
+  [ -n "$line" ] || return 1
+  printf '%s\n' "$line" | sed -E 's/.*required:([0-9]+).*/\1/' | head -n 1
+}
+
+if [ ! -f "$VERSIONS_SCRIPT" ]; then
+  echo "FAIL action-version validator not found: $VERSIONS_SCRIPT" >&2
+  fail=1
+else
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    action="${ref%%@*}"
+    version="${ref#*@}"
+    major="${version#v}"
+    major="${major%%.*}"
+    floor="$(required_major_for "$action")" || continue
+    if [ "$major" -lt "$floor" ]; then
+      echo "FAIL README names $ref but $action requires major >= $floor (Issue #506)" >&2
+      fail=1
+    else
+      echo "OK   README $ref satisfies the >= v$floor floor"
+    fi
+  # Only human-readable version refs (`@vN`, `@vN.N.N`, `@N.N.N`) are checked.
+  # A 40-character SHA pin never starts with `v` and never contains a dot, so
+  # this alternation cannot mistake `@5f6978fa…` for "major 5".
+  done < <(grep -oE '[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@(v[0-9]+(\.[0-9]+)*|[0-9]+(\.[0-9]+)+)' \
+    "$README" | sort -u)
+fi
+
 if [ "$fail" -ne 0 ]; then
-  echo "README 'matches CI' block has drifted from the CI quality job." >&2
+  echo "README CI documentation has drifted from the workflows it describes." >&2
   exit 1
 fi
 

--- a/tests/scripts/readme_ci_alignment.bats
+++ b/tests/scripts/readme_ci_alignment.bats
@@ -134,3 +134,124 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" != *"FAIL"* ]]
 }
+
+# --- Issue #506: README ↔ workflow alignment for the CI section.
+
+# Workflow fixture whose shell-checks job runs the runner's pre-installed
+# shellcheck binary — i.e. the current ci.yml, with no wrapper action.
+write_binary_shellcheck_workflow() {
+  mkdir -p "$TMP_DIR/workflows"
+  cat >"$TMP_DIR/workflows/ci.yml" <<'EOF'
+name: CI
+jobs:
+  shell-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run ShellCheck (pre-installed on the runner)
+        run: shellcheck --severity=style script.sh
+EOF
+}
+
+# Minimal stand-in for check-workflow-action-versions.sh's `required:` table.
+write_versions_script() {
+  cat >"$TMP_DIR/versions.sh" <<'EOF'
+#!/usr/bin/env bash
+case "$action" in
+    actions/dependency-review-action) echo "required:5" ;;
+    rustsec/audit-check)              echo "required:2" ;;
+esac
+EOF
+}
+
+@test "fails when the README names a wrapper action no workflow invokes (Issue #506)" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  write_binary_shellcheck_workflow
+  write_versions_script
+  printf 'The shell-checks job invokes `ludeeus/action-shellcheck@2.0.0`.\n' \
+    >>"$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md" \
+    --workflows "$TMP_DIR/workflows" --versions-script "$TMP_DIR/versions.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ludeeus/action-shellcheck"* ]]
+  [[ "$output" == *"no workflow invokes"* ]]
+}
+
+@test "allows the wrapper in the README while a workflow still uses it (Issue #506)" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  write_versions_script
+  mkdir -p "$TMP_DIR/workflows"
+  cat >"$TMP_DIR/workflows/ci.yml" <<'EOF'
+name: CI
+jobs:
+  shell-checks:
+    steps:
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
+EOF
+  printf 'The shell-checks job invokes `ludeeus/action-shellcheck@2.0.0`.\n' \
+    >>"$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md" \
+    --workflows "$TMP_DIR/workflows" --versions-script "$TMP_DIR/versions.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when the README understates a required action major (Issue #506)" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  write_binary_shellcheck_workflow
+  write_versions_script
+  printf 'Tracked Node 20 exception: `actions/dependency-review-action@v4`.\n' \
+    >>"$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md" \
+    --workflows "$TMP_DIR/workflows" --versions-script "$TMP_DIR/versions.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/dependency-review-action@v4"* ]]
+  [[ "$output" == *"major >= 5"* ]]
+}
+
+@test "passes when the README names the required action major (Issue #506)" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  write_binary_shellcheck_workflow
+  write_versions_script
+  printf 'Runs `actions/dependency-review-action@v5`; exception: `rustsec/audit-check@v2`.\n' \
+    >>"$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md" \
+    --workflows "$TMP_DIR/workflows" --versions-script "$TMP_DIR/versions.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+# A SHA pin such as `@5f6978fa…` starts with a digit; it must not be read as
+# "major 5" and compared against the action's floor.
+@test "ignores SHA-pinned uses: references when checking majors (Issue #506)" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  write_binary_shellcheck_workflow
+  cat >"$TMP_DIR/versions.sh" <<'EOF'
+#!/usr/bin/env bash
+case "$action" in
+    peter-evans/create-pull-request)  echo "required:8" ;;
+esac
+EOF
+  printf 'uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8\n' \
+    >>"$TMP_DIR/README.md"
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md" \
+    --workflows "$TMP_DIR/workflows" --versions-script "$TMP_DIR/versions.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "reports an error when the workflows directory is missing (Issue #506)" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  write_versions_script
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md" \
+    --workflows "$TMP_DIR/no-such-dir" --versions-script "$TMP_DIR/versions.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"workflows directory not found"* ]]
+}
+
+@test "reports an error when the action-version validator is missing (Issue #506)" {
+  write_aligned_readme "$TMP_DIR/README.md"
+  write_binary_shellcheck_workflow
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md" \
+    --workflows "$TMP_DIR/workflows" --versions-script "$TMP_DIR/nope.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"validator not found"* ]]
+}


### PR DESCRIPTION
# Realign the README CI section with the workflows it describes (Issue #506)

## Summary

Two claims in the README's CI section had drifted from the workflows they
document, in the exact section a security reviewer reads to learn which
third-party code executes in CI. Closes #506.

1. **ShellCheck wrapper.** The README said `ci.yml`'s `shell-checks` job
   "invokes `ludeeus/action-shellcheck@2.0.0`". PR #184 replaced that wrapper
   with the `shellcheck` binary pre-installed on the `ubuntu-latest` runner
   (`.github/workflows/ci.yml`), and no workflow references the wrapper any
   more — so the README claimed a removed action was still in the supply chain.
   The paragraph now describes the direct `koalaman/shellcheck` binary
   invocation and states that no third-party wrapper enters the supply chain.
   The single-home/dedup invariant (`scripts/check-shellcheck-dedup.sh`) is
   unchanged.
2. **Node 20 exception list.** The README named
   `actions/dependency-review-action@v4` as a tracked Node 20 exception, while
   `scripts/check-workflow-action-versions.sh` requires major **5** and both
   `dependency-review.yml` and `security.yml` pin `v5.0.0` (Node 24). The
   README even contradicted itself, documenting the standalone workflow as
   running `@v5`. `rustsec/audit-check@v2` is now named as the single remaining
   exception, matching the validator.

To stop the same drift recurring, `scripts/check-readme-ci-alignment.sh`
(already the README ↔ CI validator, Issue #212) gained two guards derived from
the source of truth rather than from a hard-coded copy of the prose:

- The README may not name `ludeeus/action-shellcheck` unless a workflow under
  `.github/workflows/` actually invokes it.
- Every human-readable `owner/action@vN` reference in the README must be at or
  above the major that `check-workflow-action-versions.sh` requires for that
  action. SHA pins (`@5f6978fa…`) are deliberately not parsed as versions.

Docs-only change: no workflow files, Rust sources or CI behaviour were touched.

## Evidence

No UI or performance surface — this is a documentation correction plus a shell
validator. Evidence is the validator itself, which fails on the pre-fix README
and passes on the corrected one:

```text
$ ./scripts/check-readme-ci-alignment.sh   # before the README fix
FAIL README names ludeeus/action-shellcheck, but no workflow invokes that wrapper (Issue #506)
FAIL README names actions/dependency-review-action@v4 but
     actions/dependency-review-action requires major >= 5 (Issue #506)
README CI documentation has drifted from the workflows it describes.

$ ./scripts/check-readme-ci-alignment.sh   # after
README 'matches CI' block matches the CI quality job.
```

`./quality.sh` passes end to end (exit 0, "✅ All quality checks passed!"),
including the 16-test `readme_ci_alignment.bats` suite.

```mermaid
flowchart LR
    wf[".github/workflows/*.yml<br/>no ludeeus wrapper"] --> chk
    val["check-workflow-action-versions.sh<br/>required: majors"] --> chk
    chk{"check-readme-ci-alignment.sh"} --> rd["README CI section"]
    chk -- drift --> fail["quality.sh fails"]
```

## Test Plan

Added to `tests/scripts/readme_ci_alignment.bats` (all exercise the real
validator against synthetic README/workflow/validator fixtures):

- `fails when the README names a wrapper action no workflow invokes` —
  regression test for claim 1; fails against the pre-fix README wording.
- `allows the wrapper in the README while a workflow still uses it` — the guard
  is derived from the workflows, not a blanket ban on the string.
- `fails when the README understates a required action major` — regression test
  for claim 2 (`@v4` against a `required:5` floor).
- `passes when the README names the required action major` — `@v5` plus the
  genuine `rustsec/audit-check@v2` exception.
- `ignores SHA-pinned uses: references when checking majors` — guards against
  reading `@5f6978fa…` as "major 5".
- `reports an error when the workflows directory is missing` and
  `reports an error when the action-version validator is missing` — the checks
  fail loud rather than silently skipping when an input is absent.

The pre-existing `the real repository README satisfies the alignment check`
test now covers both new invariants against the committed README; it failed
before the README edits and passes after them. No existing test was removed,
weakened or commented out.



## Milestone
This PR is part of the **Docs 20260804** milestone and targets the `milestone/docs-20260804` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mseqkqie-ba1859`<!-- vibe-worker-issue-506 -->