### PR TITLE
Reword private-repo identifiers in pr-summary-510.md (PR #521 CI fix)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-510.md
+++ b/docs/archive/pr-summaries/pr-summary-510.md
@@ -26,9 +26,10 @@ change only — no runtime behaviour changed.
   elides the private name as **…** and labels each row by the role the name
   played, so the mapping stays readable without reproducing it.
 - **`docs/archive/pr-summaries/pr-summary-452.md`** — the three lower-case
-  identifiers (`…_grq_scale_…`, `…_for_grq_records`, `grq-scale.json`) are now
-  described as "the two private-repo-prefixed test names" and "the
-  private-repo-prefixed fixture", keeping only the post-rename identifiers.
+  identifiers (two private-repo-prefixed test names — a scale case and a
+  record-size case — plus a private-repo-prefixed fixture filename) are now
+  described by that role rather than quoted, keeping only the post-rename
+  identifiers.
 - **`scripts/check-docs-private-repo-refs.sh`** — deleted the three-file
   exemption from `in_scope()`; `PRIVATE_PATTERN` gained
   `(^|[^[:alnum:]])…([^[:alnum:]]|$)` boundaries and the grep gained `-i`, so


### PR DESCRIPTION
## Summary

The **Shell Script Quality** check on #521 failed, and #521 merged into `milestone/docs-20260804` before the fix landed — so the failure now lives on the milestone branch.

Root cause: `docs/archive/pr-summaries/pr-summary-510.md` (added by #521) quoted the three lower-case private-repo identifiers verbatim while describing the rewording. #521 also removed the guard's carve-out and made `scripts/check-docs-private-repo-refs.sh` case-insensitive, so its own summary file is now in scope and flagged — `bats tests/scripts` failed on `the shipped CHANGELOG and docs pass the guard`.

Fix: describe those identifiers by role (scale case, record-size case, fixture filename) instead of quoting them. Documentation wording only.

## Verification

- `./scripts/check-docs-private-repo-refs.sh` → `✅ CHANGELOG and docs free of private repo references`
- `bats tests/scripts/docs_private_repo_refs.bats < /dev/null` → 12/12 passing
- `./quality.sh < /dev/null` → `✅ All quality checks passed!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)