### PR TITLE
Unify the actions/checkout pin rule in one shared helper (Issue #511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,6 +1207,29 @@ covered end-to-end by `tests/scripts/workflow_action_versions.bats`.
 `quality.sh` invokes the script so any unpinned or outdated `uses:`
 reference fails the local gate before CI (Issues #24 and #100).
 
+Six per-workflow validators (`check-actionlint-workflow.sh`,
+`check-cargo-audit-workflow.sh`, `check-cargo-quality-workflow.sh`,
+`check-dependency-review-workflow.sh`, `check-markdown-lint-workflow.sh` and
+`check-sbom-workflow.sh`) additionally assert that their own workflow has a
+pinned `actions/checkout` step. That rule used to be an inline `grep` block in
+each script and had drifted into three generations of the same regex, so a
+future bump to a SHA starting with a hex letter would have failed two gates
+spuriously. Issue #511 extracted it into a single helper,
+`require_pinned_checkout`, in `scripts/lib/workflow-checks.sh` — the one place
+the acceptance rule (`vN` or a 40-character SHA, branch refs disallowed) now
+lives. The helper is covered by `tests/scripts/workflow_checks_lib.bats`.
+
+```mermaid
+flowchart LR
+    L["scripts/lib/workflow-checks.sh<br/>require_pinned_checkout"]
+    A[check-actionlint-workflow.sh] --> L
+    B[check-cargo-audit-workflow.sh] --> L
+    C[check-cargo-quality-workflow.sh] --> L
+    D[check-dependency-review-workflow.sh] --> L
+    E[check-markdown-lint-workflow.sh] --> L
+    F[check-sbom-workflow.sh] --> L
+```
+
 ## How to bench
 
 `rust_scorer` ships a Criterion suite (Issue #36) covering the forward-only

--- a/docs/archive/pr-summaries/pr-summary-511.md
+++ b/docs/archive/pr-summaries/pr-summary-511.md
@@ -1,0 +1,73 @@
+# PR Summary — Issue #511
+
+## Summary
+
+The `actions/checkout` pin-acceptance rule ("a numeric major `vN` or a 40-char
+SHA; branch refs disallowed") was re-implemented as an inline `checkout_line`
+grep block in six workflow validators, and the copies had drifted into three
+generations of the regex: the canonical `(v[0-9]+|[0-9a-f]{40})\b`, the
+pre-#136 narrow `v?[0-9]+` (cargo-quality, markdown-lint) and a hybrid with no
+word-boundary anchor (actionlint). The drift was a latent CI breakage — the two
+stale gates accept today's checkout pin only by accident (it starts with `93`),
+so the next Dependabot bump to a SHA starting with a hex letter (6 of 16 first
+characters) would have failed them spuriously on an unrelated PR.
+
+This extracts the rule into one helper, `require_pinned_checkout`, in a new
+`scripts/lib/workflow-checks.sh`, sourced by all six validators. It is a plain
+call, not a parameterised super-helper: every site enforces the identical rule,
+so the helper takes no per-caller flags. Two behaviours were tightened while
+unifying, both in the strict direction:
+
+- **All checkout steps must be pinned**, not just one. The canonical `grep -q`
+  form passed when *any* line matched; `sbom.yml` checks out two repositories,
+  so its inverted `grep -qv` branch was the only site already getting this
+  right. The helper now matches the strict reading everywhere.
+- **The `\b` anchor is enforced everywhere**, so a 41-character hex ref is no
+  longer accepted on its first 40 characters (the actionlint hybrid's gap).
+
+Failure modes are loud (Issue #3234): a missing library aborts the validator
+with exit 2 rather than an unnoticed `source` failure, and the helper refuses to
+run — again with exit 2 — when its argument or the caller's `ok`/`fail`
+contract is missing, so a broken call can never be reported as a pass.
+
+Closes #511.
+
+## Evidence
+
+Backend/shell-only change — no web interface to screenshot. Verification is the
+BATS suites plus the full local gate.
+
+```mermaid
+flowchart LR
+    L["scripts/lib/workflow-checks.sh<br/>require_pinned_checkout<br/>one canonical pin regex"]
+    A[check-actionlint-workflow.sh] --> L
+    B[check-cargo-audit-workflow.sh] --> L
+    C[check-cargo-quality-workflow.sh] --> L
+    D[check-dependency-review-workflow.sh] --> L
+    E[check-markdown-lint-workflow.sh] --> L
+    F[check-sbom-workflow.sh] --> L
+```
+
+`./quality.sh < /dev/null` passes end to end (exit 0, 539 BATS tests, 0
+failures), including shellcheck over the new library and every validator.
+
+## Test Plan
+
+- **Added** `tests/scripts/workflow_checks_lib.bats` — 14 tests calling
+  `require_pinned_checkout` directly against synthetic workflow YAML: accepts
+  `vN`, a digit-leading SHA, a hex-letter-leading SHA and a SHA with a trailing
+  `# vN` comment; rejects a branch ref, a truncated SHA, a 41-char hex ref and a
+  tag that merely starts with a digit; reports a missing checkout step; requires
+  *every* checkout step to be pinned; and exits 2 on a missing argument, an
+  unreadable workflow, or a caller that has not defined `ok`/`fail`.
+- **Added** regression tests to the previously stale validators — a
+  hex-letter-leading 40-char SHA is now accepted by
+  `tests/scripts/cargo_quality_workflow.bats` and
+  `tests/scripts/markdown_lint_workflow.bats` (both fail against the pre-#136
+  regex), and an over-long hex ref is rejected by
+  `tests/scripts/actionlint_workflow.bats` (fails against the unanchored
+  hybrid).
+- **Added** `tests/scripts/sbom_workflow.bats` coverage for one pinned plus one
+  unpinned checkout step, locking in the strict multi-checkout reading.
+- **Unchanged and still passing**: every existing checkout test in the six
+  validator suites. No test was removed or commented out.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.49"
+version = "1.1.50"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-actionlint-workflow.sh
+++ b/scripts/check-actionlint-workflow.sh
@@ -5,8 +5,8 @@
 #   1. Trigger on pull_request so every change is linted before merge.
 #   2. Declare an explicit `permissions:` block (least privilege —
 #      `contents: read` is sufficient because actionlint only reads source).
-#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy —
-#      see scripts/check-workflow-action-versions.sh).
+#   3. Pin `actions/checkout` to a numeric major version or a 40-char SHA
+#      (Node 24 policy — see scripts/check-workflow-action-versions.sh).
 #   4. Install the actionlint binary at a pinned version (the official
 #      download-actionlint.bash installer fetched from a version-pinned
 #      upstream ref — no third-party wrapper action).
@@ -23,6 +23,17 @@
 # can exercise it against fixtures. When called with no argument it validates
 # `.github/workflows/actionlint.yml` relative to the repo root.
 set -euo pipefail
+
+# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
+# rule lives in one place instead of six inline copies that drift apart.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
+if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
+  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
+  exit 2
+fi
+# shellcheck source=lib/workflow-checks.sh disable=SC1091
+source "$WORKFLOW_CHECKS_LIB"
 
 usage() {
   cat <<'EOF'
@@ -59,7 +70,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOW="$SCRIPT_DIR/../.github/workflows/actionlint.yml"
 fi
 
@@ -93,16 +103,10 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 3. actions/checkout pinned to a numeric major (vN) or SHA. Branch refs
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
+#    shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs
 #    disallowed (SHA pins carry a trailing `# vN` label).
-checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
-if [[ -z "$checkout_line" ]]; then
-  fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qE 'actions/checkout@([0-9a-f]{40}|v?[0-9]+)'; then
-  ok "actions/checkout pinned to a numeric major or SHA"
-else
-  fail "actions/checkout is not pinned — branch refs disallowed"
-fi
+require_pinned_checkout "$WORKFLOW"
 
 # 4. actionlint must be installed. The official installer is
 #    download-actionlint.bash; require a reference to it so the binary is

--- a/scripts/check-cargo-audit-workflow.sh
+++ b/scripts/check-cargo-audit-workflow.sh
@@ -7,7 +7,8 @@
 #      even on quiet branches (the lockfile does not change but the
 #      advisory database does).
 #   3. Declare an explicit `permissions:` block (least privilege).
-#   4. Pin `actions/checkout` to a numeric major version (Node 24 policy).
+#   4. Pin `actions/checkout` to a numeric major version or a 40-char SHA
+#      (Node 24 policy).
 #   5. Install a Rust toolchain via `dtolnay/rust-toolchain` so cargo-audit
 #      can be installed and run.
 #   6. Invoke cargo-audit — either directly (`cargo audit` after a
@@ -21,6 +22,17 @@
 # can exercise it against fixtures. When called with no argument it validates
 # `.github/workflows/cargo-audit.yml` relative to the repo root.
 set -euo pipefail
+
+# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
+# rule lives in one place instead of six inline copies that drift apart.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
+if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
+  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
+  exit 2
+fi
+# shellcheck source=lib/workflow-checks.sh disable=SC1091
+source "$WORKFLOW_CHECKS_LIB"
 
 usage() {
   cat <<'EOF'
@@ -56,7 +68,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOW="$SCRIPT_DIR/../.github/workflows/cargo-audit.yml"
 fi
 
@@ -98,19 +109,12 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 4. actions/checkout pinned to a numeric major (vN) or a 40-char SHA.
-# Branch refs (e.g. `@main`) disallowed. Issue #136 widened the regex from
-# `v?[0-9]+` so SHAs starting with hex letters a–f are accepted too —
-# rustsec/audit-check has been bumped to commit `858dc40…` and that lesson
-# applies preemptively to actions/checkout here.
-checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
-if [[ -z "$checkout_line" ]]; then
-  fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qE 'actions/checkout@(v[0-9]+|[0-9a-f]{40})\b'; then
-  ok "actions/checkout pinned to a numeric major or 40-char SHA"
-else
-  fail "actions/checkout is not pinned — branch refs disallowed"
-fi
+# 4. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
+# shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs
+# (e.g. `@main`) disallowed. Issue #136 widened the regex from `v?[0-9]+` so
+# SHAs starting with hex letters a–f are accepted too; keeping that rule in one
+# place is why Issue #511 extracted the helper.
+require_pinned_checkout "$WORKFLOW"
 
 # 5. Rust toolchain provisioned via dtolnay/rust-toolchain.
 if grep -qE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$WORKFLOW"; then

--- a/scripts/check-cargo-quality-workflow.sh
+++ b/scripts/check-cargo-quality-workflow.sh
@@ -4,7 +4,8 @@
 # The cargo-quality workflow must:
 #   1. Trigger on pull_request so every change is fmt + clippy checked.
 #   2. Declare an explicit `permissions:` block (least privilege).
-#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy).
+#   3. Pin `actions/checkout` to a numeric major version or a 40-char SHA
+#      (Node 24 policy).
 #   4. Install a Rust toolchain via `dtolnay/rust-toolchain` with the
 #      `rustfmt` and `clippy` components.
 #   5. Invoke `cargo fmt --check` (any flag form) so unformatted code fails CI.
@@ -18,6 +19,17 @@
 # can exercise it against fixtures. When called with no argument it validates
 # `.github/workflows/cargo-quality.yml` relative to the repo root.
 set -euo pipefail
+
+# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
+# rule lives in one place instead of six inline copies that drift apart.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
+if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
+  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
+  exit 2
+fi
+# shellcheck source=lib/workflow-checks.sh disable=SC1091
+source "$WORKFLOW_CHECKS_LIB"
 
 usage() {
   cat <<'EOF'
@@ -54,7 +66,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOW="$SCRIPT_DIR/../.github/workflows/cargo-quality.yml"
 fi
 
@@ -88,15 +99,10 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 3. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
-checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
-if [[ -z "$checkout_line" ]]; then
-  fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
-  ok "actions/checkout pinned to a numeric major"
-else
-  fail "actions/checkout is not pinned — branch refs disallowed"
-fi
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
+#    shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs
+#    disallowed.
+require_pinned_checkout "$WORKFLOW"
 
 # 4. Rust toolchain provisioned via dtolnay/rust-toolchain with rustfmt +
 #    clippy components.

--- a/scripts/check-dependency-review-workflow.sh
+++ b/scripts/check-dependency-review-workflow.sh
@@ -10,7 +10,8 @@
 #      permissions (e.g. `pull-requests: write`) are only required when
 #      enabling PR comment summaries, which the standalone workflow leaves
 #      to the reusable security workflow.
-#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy).
+#   3. Pin `actions/checkout` to a numeric major version or a 40-char SHA
+#      (Node 24 policy).
 #   4. Invoke `actions/dependency-review-action`, also pinned to a numeric
 #      major (the version policy in
 #      `scripts/check-workflow-action-versions.sh` tracks the current
@@ -27,6 +28,17 @@
 # can exercise it against fixtures. When called with no argument it validates
 # `.github/workflows/dependency-review.yml` relative to the repo root.
 set -euo pipefail
+
+# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
+# rule lives in one place instead of six inline copies that drift apart.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
+if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
+  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
+  exit 2
+fi
+# shellcheck source=lib/workflow-checks.sh disable=SC1091
+source "$WORKFLOW_CHECKS_LIB"
 
 usage() {
   cat <<'EOF'
@@ -63,7 +75,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOW="$SCRIPT_DIR/../.github/workflows/dependency-review.yml"
 fi
 
@@ -97,16 +108,10 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA.
-# Branch refs (e.g. `@main`) disallowed.
-checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
-if [[ -z "$checkout_line" ]]; then
-  fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qE 'actions/checkout@(v[0-9]+|[0-9a-f]{40})\b'; then
-  ok "actions/checkout pinned to a numeric major or 40-char SHA"
-else
-  fail "actions/checkout is not pinned — branch refs disallowed"
-fi
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
+# shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs
+# (e.g. `@main`) disallowed.
+require_pinned_checkout "$WORKFLOW"
 
 # 4. actions/dependency-review-action present and pinned to a numeric major
 # or a 40-char SHA. Issue #136 widened this from `v?[0-9]+` to also accept

--- a/scripts/check-markdown-lint-workflow.sh
+++ b/scripts/check-markdown-lint-workflow.sh
@@ -5,8 +5,8 @@
 #   1. Trigger on pull_request so every change is linted before merge.
 #   2. Declare an explicit `permissions:` block (least privilege —
 #      `contents: read` is sufficient because markdownlint only reads source).
-#   3. Pin `actions/checkout` to a numeric major version (Node 24 policy —
-#      see scripts/check-workflow-action-versions.sh).
+#   3. Pin `actions/checkout` to a numeric major version or a 40-char SHA
+#      (Node 24 policy — see scripts/check-workflow-action-versions.sh).
 #   4. Provision Node via `actions/setup-node` pinned to a numeric major.
 #   5. Install and invoke `markdownlint-cli2` so the lint gate actually runs.
 #
@@ -14,6 +14,17 @@
 # can exercise it against fixtures. When called with no argument it validates
 # `.github/workflows/markdown-lint.yml` relative to the repo root.
 set -euo pipefail
+
+# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
+# rule lives in one place instead of six inline copies that drift apart.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
+if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
+  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
+  exit 2
+fi
+# shellcheck source=lib/workflow-checks.sh disable=SC1091
+source "$WORKFLOW_CHECKS_LIB"
 
 usage() {
   cat <<'EOF'
@@ -50,7 +61,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOW="$SCRIPT_DIR/../.github/workflows/markdown-lint.yml"
 fi
 
@@ -84,15 +94,10 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 3. actions/checkout pinned to a numeric major (vN). Branch refs disallowed.
-checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
-if [[ -z "$checkout_line" ]]; then
-  fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qE 'actions/checkout@v?[0-9]+'; then
-  ok "actions/checkout pinned to a numeric major"
-else
-  fail "actions/checkout is not pinned — branch refs disallowed"
-fi
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
+#    shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs
+#    disallowed.
+require_pinned_checkout "$WORKFLOW"
 
 # 4. actions/setup-node pinned to a numeric major (vN). Branch refs disallowed.
 setup_node_line="$(grep -nE 'uses:[[:space:]]*actions/setup-node@' "$WORKFLOW" || true)"

--- a/scripts/check-sbom-workflow.sh
+++ b/scripts/check-sbom-workflow.sh
@@ -24,6 +24,17 @@
 # `.github/workflows/sbom.yml` relative to the repo root.
 set -euo pipefail
 
+# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
+# rule lives in one place instead of six inline copies that drift apart.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
+if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
+  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
+  exit 2
+fi
+# shellcheck source=lib/workflow-checks.sh disable=SC1091
+source "$WORKFLOW_CHECKS_LIB"
+
 usage() {
   cat <<'EOF'
 Usage: check-sbom-workflow.sh [--workflow PATH]
@@ -58,7 +69,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOW="$SCRIPT_DIR/../.github/workflows/sbom.yml"
 fi
 
@@ -93,15 +103,9 @@ else
   fail "no 'permissions: contents: read' block — least-privilege required"
 fi
 
-# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA.
-checkout_line="$(grep -nE 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW" || true)"
-if [[ -z "$checkout_line" ]]; then
-  fail "actions/checkout step missing — workflow cannot fetch the repo"
-elif echo "$checkout_line" | grep -qvE 'actions/checkout@(v[0-9]+|[0-9a-f]{40})\b'; then
-  fail "actions/checkout is not pinned — branch refs disallowed"
-else
-  ok "actions/checkout pinned to a numeric major or 40-char SHA"
-fi
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
+#    shared rule in scripts/lib/workflow-checks.sh (Issue #511).
+require_pinned_checkout "$WORKFLOW"
 
 # 4. Rust toolchain provisioned via dtolnay/rust-toolchain.
 if grep -qE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$WORKFLOW"; then

--- a/scripts/lib/workflow-checks.sh
+++ b/scripts/lib/workflow-checks.sh
@@ -1,0 +1,66 @@
+# Shared workflow-validation helpers (Issue #511).
+#
+# Sourced by the per-workflow validators under `scripts/`. It carries rules that
+# every one of them enforces identically, so a change to the rule is a change to
+# one line rather than six copies that drift apart. Issue #511 was filed after
+# the `actions/checkout` pin rule had already split into three generations of
+# the same regex.
+#
+# Contract for callers: define `ok <message>` and `fail <message>` before
+# calling a helper (every validator already does — `fail` sets `EXIT_CODE=1`).
+# The helpers report through those functions so output stays uniform, and abort
+# with exit status 2 when the contract or an argument is wrong rather than
+# silently reporting a pass.
+#
+# This file is sourced, not executed — it deliberately has no shebang and sets
+# no shell options of its own.
+
+# Accepted `actions/checkout` pin forms: a numeric major (`v5`) or a full
+# 40-character commit SHA. The trailing `\b` is load-bearing — without it a
+# 41-character ref would match on its first 40 characters. Branch refs (`main`),
+# truncated SHAs and tags that merely start with a digit are rejected.
+#
+# `scripts/check-workflow-action-versions.sh` enforces the strictly stronger
+# SHA-only rule across every workflow; this helper is the per-workflow gate that
+# also catches a checkout step going missing entirely.
+CHECKOUT_PIN_RE='^(v[0-9]+|[0-9a-f]{40})\b'
+
+# require_pinned_checkout <workflow>
+#
+# Reports OK when the workflow has at least one `actions/checkout` step and
+# every such step is pinned to an accepted form; reports FAIL otherwise.
+require_pinned_checkout() {
+  local workflow="${1:-}"
+
+  if [[ -z "$workflow" ]]; then
+    echo "require_pinned_checkout: a workflow path argument is required" >&2
+    return 2
+  fi
+  if [[ ! -r "$workflow" ]]; then
+    echo "require_pinned_checkout: workflow not readable: $workflow" >&2
+    return 2
+  fi
+  if ! declare -F ok >/dev/null || ! declare -F fail >/dev/null; then
+    echo "require_pinned_checkout: caller must define ok() and fail() first" >&2
+    return 2
+  fi
+
+  local line ref
+  local -a refs=()
+  local -a unpinned=()
+  while IFS= read -r line; do
+    ref="${line##*actions/checkout@}"
+    refs+=("$ref")
+    if ! printf '%s\n' "$ref" | grep -qE "$CHECKOUT_PIN_RE"; then
+      unpinned+=("$ref")
+    fi
+  done < <(grep -oE 'uses:[[:space:]]*actions/checkout@[^[:space:]]+' "$workflow" || true)
+
+  if [[ "${#refs[@]}" -eq 0 ]]; then
+    fail "actions/checkout step missing — workflow cannot fetch the repo"
+  elif [[ "${#unpinned[@]}" -gt 0 ]]; then
+    fail "actions/checkout is not pinned — branch refs disallowed: ${unpinned[*]}"
+  else
+    ok "actions/checkout pinned to a numeric major or 40-char SHA"
+  fi
+}

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -106,6 +106,16 @@ PY
   [[ "$output" == *"not pinned"* ]]
 }
 
+@test "rejects an over-long hex checkout ref (Issue #511)" {
+  # The hybrid regex this validator used to carry had no `\b` anchor, so a
+  # 41-character ref matched on its first 40 characters and passed.
+  write_actionlint_workflow "$TMP_WF/actionlint.yml"
+  sed -i.bak 's|actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5|actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd0|' "$TMP_WF/actionlint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/actionlint.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not pinned"* ]]
+}
+
 @test "fails when actions/checkout step is missing" {
   write_actionlint_workflow "$TMP_WF/actionlint.yml"
   sed -i.bak '/actions\/checkout/d' "$TMP_WF/actionlint.yml"

--- a/tests/scripts/cargo_quality_workflow.bats
+++ b/tests/scripts/cargo_quality_workflow.bats
@@ -94,6 +94,16 @@ PY
   [[ "$output" == *"not pinned"* ]]
 }
 
+@test "accepts a 40-char checkout SHA starting with a hex letter (Issue #511)" {
+  # The pre-#136 `v?[0-9]+` regex this validator used to carry rejected SHAs
+  # whose leading character is a-f. The shared helper accepts them.
+  write_quality_workflow "$TMP_WF/cargo-quality.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@a1d282b9c3e4f5061728394a5b6c7d8e9f001122|' "$TMP_WF/cargo-quality.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-quality.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+}
+
 @test "fails when dtolnay/rust-toolchain is missing" {
   write_quality_workflow "$TMP_WF/cargo-quality.yml"
   sed -i.bak '/dtolnay\/rust-toolchain/d' "$TMP_WF/cargo-quality.yml"

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -166,6 +166,16 @@ PY
   [[ "$output" == *"not pinned"* ]]
 }
 
+@test "accepts a 40-char checkout SHA starting with a hex letter (Issue #511)" {
+  # The pre-#136 `v?[0-9]+` regex this validator used to carry rejected SHAs
+  # whose leading character is a-f. The shared helper accepts them.
+  write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
+  sed -i.bak 's|actions/checkout@v5|actions/checkout@a1d282b9c3e4f5061728394a5b6c7d8e9f001122|' "$TMP_WF/markdown-lint.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/markdown-lint.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+}
+
 @test "fails when actions/setup-node is unpinned" {
   write_markdown_lint_workflow "$TMP_WF/markdown-lint.yml"
   sed -i.bak 's|actions/setup-node@v4|actions/setup-node@main|' "$TMP_WF/markdown-lint.yml"

--- a/tests/scripts/sbom_workflow.bats
+++ b/tests/scripts/sbom_workflow.bats
@@ -145,6 +145,16 @@ PY
   [[ "$output" == *"not pinned"* ]]
 }
 
+@test "fails when only one of several checkout steps is unpinned (Issue #511)" {
+  # sbom.yml checks out two repositories; every checkout step must be pinned,
+  # not merely one of them.
+  write_sbom_workflow "$TMP_WF/sbom.yml"
+  perl -0pi -e 's|actions/checkout\@v5|actions/checkout\@main|' "$TMP_WF/sbom.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/sbom.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not pinned"* ]]
+}
+
 @test "fails when dtolnay/rust-toolchain is missing" {
   write_sbom_workflow "$TMP_WF/sbom.yml"
   sed -i.bak '/dtolnay\/rust-toolchain/d' "$TMP_WF/sbom.yml"

--- a/tests/scripts/workflow_checks_lib.bats
+++ b/tests/scripts/workflow_checks_lib.bats
@@ -1,0 +1,182 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/workflow-checks.sh — Issue #511.
+#
+# The `actions/checkout` pin-acceptance rule used to be re-implemented inline in
+# six workflow validators and had drifted into three generations of the regex.
+# These tests exercise the single shared helper directly: a caller sources the
+# library, defines the `ok`/`fail` reporting contract, and calls
+# `require_pinned_checkout` against synthetic workflow YAML.
+
+setup() {
+  LIB="${BATS_TEST_DIRNAME}/../../scripts/lib/workflow-checks.sh"
+  TMP_WF="$(mktemp -d)"
+  export LIB TMP_WF
+}
+
+teardown() {
+  rm -rf "$TMP_WF"
+}
+
+# Write a minimal workflow whose checkout step uses $1 as the ref.
+write_workflow_with_ref() {
+  cat >"$TMP_WF/wf.yml" <<EOF
+name: Example
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@$1
+EOF
+}
+
+# Run require_pinned_checkout in a subshell that provides the ok/fail contract
+# the six validators define, mirroring how they call the helper.
+run_helper() {
+  run bash -c '
+    set -euo pipefail
+    EXIT_CODE=0
+    fail() { echo "FAIL: $*" >&2; EXIT_CODE=1; }
+    ok()   { echo "OK   : $*"; }
+    source "$1"
+    require_pinned_checkout "$2"
+    exit "$EXIT_CODE"
+  ' bash "$LIB" "$1"
+}
+
+@test "accepts a numeric major version pin" {
+  write_workflow_with_ref "v5"
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK   "* ]]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+}
+
+@test "accepts a 40-char SHA whose first character is a hex letter (Issue #136)" {
+  # The pre-#136 `v?[0-9]+` regex rejected these; two validators still carried
+  # it before Issue #511 unified the rule.
+  write_workflow_with_ref "a1d282b9c3e4f5061728394a5b6c7d8e9f001122"
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+}
+
+@test "accepts a 40-char SHA whose first character is a digit" {
+  write_workflow_with_ref "93cb6efe18208431cddfb8368fd83d5badbf9bfd"
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+}
+
+@test "accepts a SHA pin carrying a trailing version comment" {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@a1d282b9c3e4f5061728394a5b6c7d8e9f001122  # v5
+EOF
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"actions/checkout pinned"* ]]
+}
+
+@test "rejects a branch ref" {
+  write_workflow_with_ref "main"
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout"* ]]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "rejects a truncated (short) SHA" {
+  write_workflow_with_ref "a1d282b"
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "rejects an over-long hex ref (the word-boundary anchor)" {
+  # 41 hex characters — a 40-char prefix match without the `\b` anchor would
+  # wrongly accept this.
+  write_workflow_with_ref "a1d282b9c3e4f5061728394a5b6c7d8e9f0011223"
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "rejects a tag ref that merely starts with digits" {
+  write_workflow_with_ref "5-latest-branch"
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not pinned"* ]]
+}
+
+@test "reports a missing checkout step" {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+jobs:
+  build:
+    steps:
+      - run: echo hello
+EOF
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actions/checkout step missing"* ]]
+}
+
+@test "every checkout step must be pinned, not just one" {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@main
+EOF
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not pinned"* ]]
+  [[ "$output" == *"main"* ]]
+}
+
+@test "passes when several checkout steps are all pinned" {
+  cat >"$TMP_WF/wf.yml" <<'EOF'
+name: Example
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@a1d282b9c3e4f5061728394a5b6c7d8e9f001122
+EOF
+  run_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 1 ]
+}
+
+@test "fails loudly when called without a workflow argument" {
+  run bash -c '
+    set -uo pipefail
+    fail() { :; }
+    ok() { :; }
+    source "$1"
+    require_pinned_checkout
+  ' bash "$LIB"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"workflow path"* ]]
+}
+
+@test "fails loudly when the workflow file is unreadable" {
+  run_helper "$TMP_WF/does-not-exist.yml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not readable"* ]]
+}
+
+@test "fails loudly when the caller has not defined ok/fail" {
+  write_workflow_with_ref "v5"
+  run bash -c '
+    set -uo pipefail
+    source "$1"
+    require_pinned_checkout "$2"
+  ' bash "$LIB" "$TMP_WF/wf.yml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"ok()"* ]]
+}


### PR DESCRIPTION
# PR Summary — Issue #511

## Summary

The `actions/checkout` pin-acceptance rule ("a numeric major `vN` or a 40-char
SHA; branch refs disallowed") was re-implemented as an inline `checkout_line`
grep block in six workflow validators, and the copies had drifted into three
generations of the regex: the canonical `(v[0-9]+|[0-9a-f]{40})\b`, the
pre-#136 narrow `v?[0-9]+` (cargo-quality, markdown-lint) and a hybrid with no
word-boundary anchor (actionlint). The drift was a latent CI breakage — the two
stale gates accept today's checkout pin only by accident (it starts with `93`),
so the next Dependabot bump to a SHA starting with a hex letter (6 of 16 first
characters) would have failed them spuriously on an unrelated PR.

This extracts the rule into one helper, `require_pinned_checkout`, in a new
`scripts/lib/workflow-checks.sh`, sourced by all six validators. It is a plain
call, not a parameterised super-helper: every site enforces the identical rule,
so the helper takes no per-caller flags. Two behaviours were tightened while
unifying, both in the strict direction:

- **All checkout steps must be pinned**, not just one. The canonical `grep -q`
  form passed when *any* line matched; `sbom.yml` checks out two repositories,
  so its inverted `grep -qv` branch was the only site already getting this
  right. The helper now matches the strict reading everywhere.
- **The `\b` anchor is enforced everywhere**, so a 41-character hex ref is no
  longer accepted on its first 40 characters (the actionlint hybrid's gap).

Failure modes are loud (Issue #3234): a missing library aborts the validator
with exit 2 rather than an unnoticed `source` failure, and the helper refuses to
run — again with exit 2 — when its argument or the caller's `ok`/`fail`
contract is missing, so a broken call can never be reported as a pass.

Closes #511.

## Evidence

Backend/shell-only change — no web interface to screenshot. Verification is the
BATS suites plus the full local gate.

```mermaid
flowchart LR
    L["scripts/lib/workflow-checks.sh<br/>require_pinned_checkout<br/>one canonical pin regex"]
    A[check-actionlint-workflow.sh] --> L
    B[check-cargo-audit-workflow.sh] --> L
    C[check-cargo-quality-workflow.sh] --> L
    D[check-dependency-review-workflow.sh] --> L
    E[check-markdown-lint-workflow.sh] --> L
    F[check-sbom-workflow.sh] --> L
```

`./quality.sh < /dev/null` passes end to end (exit 0, 539 BATS tests, 0
failures), including shellcheck over the new library and every validator.

## Test Plan

- **Added** `tests/scripts/workflow_checks_lib.bats` — 14 tests calling
  `require_pinned_checkout` directly against synthetic workflow YAML: accepts
  `vN`, a digit-leading SHA, a hex-letter-leading SHA and a SHA with a trailing
  `# vN` comment; rejects a branch ref, a truncated SHA, a 41-char hex ref and a
  tag that merely starts with a digit; reports a missing checkout step; requires
  *every* checkout step to be pinned; and exits 2 on a missing argument, an
  unreadable workflow, or a caller that has not defined `ok`/`fail`.
- **Added** regression tests to the previously stale validators — a
  hex-letter-leading 40-char SHA is now accepted by
  `tests/scripts/cargo_quality_workflow.bats` and
  `tests/scripts/markdown_lint_workflow.bats` (both fail against the pre-#136
  regex), and an over-long hex ref is rejected by
  `tests/scripts/actionlint_workflow.bats` (fails against the unanchored
  hybrid).
- **Added** `tests/scripts/sbom_workflow.bats` coverage for one pinned plus one
  unpinned checkout step, locking in the strict multi-checkout reading.
- **Unchanged and still passing**: every existing checkout test in the six
  validator suites. No test was removed or commented out.



## Milestone
This PR is part of the **Docs 20260804** milestone and targets the `milestone/docs-20260804` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msf5viz1-df7bf7`<!-- vibe-worker-issue-511 -->