### PR TITLE
Extract the guard-script CLI harness into scripts/lib/check-harness.sh (Issue #512)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,57 @@ quarantine-gated bumps go through [`./bump-deps.sh`](./bump-deps.sh) instead.
 
 Keep re-running `./quality.sh < /dev/null` until it passes cleanly.
 
+### Guard-script harness
+
+Every `scripts/check-*.sh` validator shares one CLI contract, and that contract
+lives in a single place: [`scripts/lib/check-harness.sh`](./scripts/lib/check-harness.sh)
+(Issue #512). The harness owns the `--FLAG PATH` / `-h` argument loop,
+default-target resolution relative to the repo root, the "file not found" guard
+(`exit 2`), and the accumulate-and-report protocol — an `OK` line on stdout, a
+`FAIL` line on stderr, `EXIT_CODE=1` without aborting so a run lists every
+violation. Only
+the per-script rule checks live in the individual validators.
+
+```mermaid
+flowchart LR
+    A["scripts/check-*.sh"] -->|source| H["scripts/lib/check-harness.sh"]
+    H --> P["parse_check_args<br/>--FLAG / -h / exit 2"]
+    H --> G["check_require_file<br/>check_require_dir"]
+    H --> R["ok / fail / EXIT_CODE"]
+    A --> C["per-script rule checks"]
+    C --> R
+```
+
+Writing a new validator:
+
+```bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
+usage() { cat <<'EOF'
+Usage: check-thing.sh [--workflow PATH]
+EOF
+}
+
+parse_check_args --workflow ".github/workflows/thing.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
+check_subject "$WORKFLOW"   # prefixes every OK/FAIL line with the file
+
+# ... per-script rule checks calling ok "…" / fail "…" ...
+
+exit "$EXIT_CODE"
+```
+
+`shellcheck` must be run with `-x` so it follows the `# shellcheck source=`
+directive; `quality.sh` already does. The matching BATS contract assertions
+(`assert_missing_target_rejected`, `assert_unknown_flag_rejected`) live in
+[`tests/scripts/test_helper.bash`](./tests/scripts/test_helper.bash) — `load
+'test_helper'` rather than restating them per suite.
+
 ## Coding standards
 
 - **Australian English** throughout code, comments, and documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.48"
+version = "1.1.49"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-512.md
+++ b/docs/archive/pr-summaries/pr-summary-512.md
@@ -1,0 +1,176 @@
+# PR Summary — Issue #512
+
+## Summary
+
+Every `scripts/check-*.sh` validator inlined the same ~50-line CLI harness: a
+`usage()` heredoc, a `--FLAG PATH` / `-h` argument loop with `exit 2` on an
+unknown flag, default-path resolution via `SCRIPT_DIR`, the "file not found"
+guard, and the `EXIT_CODE`/`fail()`/`ok()` accumulate-and-report protocol. The
+copies had already drifted — `fail()` existed in three different signatures
+(`$WORKFLOW` interpolated, subject as `$1`, no subject at all).
+
+That contract now lives once in **`scripts/lib/check-harness.sh`**, sourced by
+**28 validators**. The per-script rule checks — the part that genuinely differs
+— stay exactly where they were. The mirrored duplication in the test suite is
+gone too: the two harness-contract tests re-stated in 30 `.bats` files now come
+from **`tests/scripts/test_helper.bash`**.
+
+Net effect across 64 files: **1,052 lines removed, 765 added** — and most of the
+additions are the new harness, its 12 tests, and the CONTRIBUTING section.
+
+Closes #512.
+
+## What the harness owns
+
+| Helper | Replaces |
+| --- | --- |
+| `parse_check_args <flag> <default> "$@"` | the copy-pasted `while`/`case` loop plus `SCRIPT_DIR` default resolution |
+| `check_unknown_arg` / `check_flag_value` | `echo "Unknown argument…"; usage >&2; exit 2` and the missing-value guards |
+| `check_require_file` / `check_require_dir` | `if [[ ! -f … ]]; then echo "… not found: …"; exit 2; fi` |
+| `check_repo_path` | `"$SCRIPT_DIR/../<path>"` |
+| `ok` / `fail` / `EXIT_CODE` | the three divergent report-protocol copies |
+| `check_subject` | the per-script `FAIL $WORKFLOW:` prefix |
+
+```mermaid
+flowchart LR
+    subgraph before["Before — ~30 copies"]
+        V1["check-sbom-workflow.sh<br/>usage + argloop + guard + ok/fail"]
+        V2["check-ci-permissions.sh<br/>usage + argloop + guard + ok/fail"]
+        V3["…27 more"]
+    end
+    subgraph after["After"]
+        H["scripts/lib/check-harness.sh<br/>argloop · guard · ok/fail"]
+        W1["check-sbom-workflow.sh<br/>rule checks only"] -->|source| H
+        W2["check-ci-permissions.sh<br/>rule checks only"] -->|source| H
+        W3["…26 more"] -->|source| H
+    end
+    before -.->|Issue #512| after
+```
+
+### Deviation from the suggested fix
+
+The issue suggested `ok`/`fail` take the subject as an argument. Two of the
+three existing signatures do *not* have a single subject (`check-rust-lints.sh`
+and `check-neat-core-composite-action.sh` name a different file in each
+message), so forcing an argument would have changed their output and churned
+244 call sites. Instead the subject is a harness variable set by
+`check_subject` — one call per script, or `local CHECK_SUBJECT="$wf"` inside the
+per-file loop of the three multi-file validators. That absorbs all three
+variants with **byte-identical output** and no call-site churn.
+
+No real per-caller branching emerged during extraction, so the issue stands as
+fixed rather than closed-as-not-applicable.
+
+## Evidence
+
+This is a shell/CLI change with no web interface, so there is no screenshot.
+Evidence is behavioural:
+
+**1. Output is byte-identical before and after.** Each converted validator was
+run from a `git worktree` at the pre-change commit and from the working tree,
+with the repo root normalised; every one matched exactly (stdout, stderr and
+exit code):
+
+```text
+$ for f in <all 28 converted validators>; do
+    diff <(cd /tmp/base512 && ./scripts/$f.sh 2>&1 …) <(./scripts/$f.sh 2>&1 …)
+  done
+COMPARE_DONE          # no diffs
+```
+
+**2. The full BATS suite passes** — 533 tests, including the 12 new harness
+tests:
+
+```text
+$ bats tests/scripts < /dev/null
+1..533
+exit=0
+```
+
+**3. The full local gate passes:**
+
+```text
+$ ./quality.sh < /dev/null
+✅ All quality checks passed!
+```
+
+**4. CI's ShellCheck invocation is clean** (simulated locally with the exact
+workflow flags — `SHELLCHECK_OPTS="-s bash" shellcheck --severity=warning`
+over every `*.sh`): `CI_SHELLCHECK_OK`.
+
+## Test Plan
+
+### Added
+
+- `tests/scripts/check_harness.bats` — 12 tests driving the harness end-to-end
+  through throwaway validator scripts (behaviour, not source inspection):
+  - default target resolves relative to the repo root;
+  - an explicit flag overrides the default;
+  - `--help` prints usage, exits 0;
+  - an unknown flag names the argument, prints usage, exits 2;
+  - a flag with no value fails with a message instead of an unbound-variable
+    error under `set -u`;
+  - a missing target exits 2 with a not-found message;
+  - a satisfied rule prints `OK` on stdout and exits 0;
+  - a violated rule prints `FAIL` on **stderr** and exits 1;
+  - failures accumulate rather than aborting on the first;
+  - an empty subject drops the prefix;
+  - `check_require_dir` guards a missing directory;
+  - an empty default leaves the target unset for caller-side resolution.
+- `tests/scripts/test_helper.bash` — `assert_missing_target_rejected` and
+  `assert_unknown_flag_rejected`, the two contract assertions that were
+  re-stated verbatim in 30 suites.
+
+### Modified
+
+- 30 `.bats` files now `load 'test_helper'` and call the shared assertions
+  instead of restating the two harness-contract tests. **No test was removed,
+  disabled, or weakened** — the same script is invoked with the same arguments
+  and the same assertions run; suites with stricter expectations keep their own
+  extra checks (`run` exports `$status`/`$output` to the caller).
+
+### Unchanged and still passing
+
+All existing per-script rule tests (521 of the 533) pass untouched, which is
+what pins the refactor: they exercise each validator's real behaviour against
+fixture workflows.
+
+## Files touched
+
+- **New:** `scripts/lib/check-harness.sh`, `tests/scripts/check_harness.bats`,
+  `tests/scripts/test_helper.bash`.
+- **Converted (28):** `check-actionlint-workflow`, `check-auto-format-workflow`,
+  `check-bot-push-token`, `check-cargo-audit-workflow`,
+  `check-cargo-quality-workflow`, `check-ci-job-graph`, `check-ci-permissions`,
+  `check-ci-push-trigger`, `check-codeowners`,
+  `check-dependency-review-workflow`, `check-gitleaks-workflow`,
+  `check-markdown-lint-workflow`, `check-milestone-branch-filter`,
+  `check-neat-core-composite-action`, `check-persist-credentials`,
+  `check-prebuilt-tool-install`, `check-push-step-hardening`,
+  `check-run-block-safety`, `check-rust-lints`, `check-rust-toolchain`,
+  `check-sbom-workflow`, `check-security-policy`, `check-semgrep-workflow`,
+  `check-shellcheck-dedup`, `check-workflow-action-versions`,
+  `check-workflow-concurrency`, `check-workflow-paths`,
+  `check-workflow-timeouts`.
+- **`quality.sh`** — runs `shellcheck -x` so the `# shellcheck source=` directive
+  is followed and the harness is analysed in context. CI's own step uses
+  `--severity=warning` and passes both with and without `-x`; no workflow change
+  is needed (the worker has no `workflow` OAuth scope — see
+  [Human escalation](../../../CONTRIBUTING.md#human-escalation)).
+- **`CONTRIBUTING.md`** — new "Guard-script harness" subsection under
+  [Local gate](../../../CONTRIBUTING.md#local-gate) with a Mermaid diagram and a
+  worked template for writing a new validator.
+- **`Cargo.lock`** — incidental `rust_scorer` version resync (1.1.48 → 1.1.49)
+  produced by running the gate; no dependency change.
+
+## Security self-check
+
+- **Input validation** — `parse_check_args` rejects unknown flags (`exit 2`) and
+  guards missing flag values, which previously tripped an unbound-variable error
+  under `set -u`. Targets are validated with `check_require_file` /
+  `check_require_dir` before use.
+- **Injection surface** — no new shell interpolation of untrusted input; the
+  harness quotes every expansion and adds no `eval`.
+- **Secrets** — none staged; no hidden files outside the allowlist.
+- **Error handling** — failures stay loud: `fail` writes to stderr and sets
+  `EXIT_CODE=1`, guards exit 2, and no error path is swallowed.

--- a/quality.sh
+++ b/quality.sh
@@ -22,7 +22,9 @@ fi
 SHELLCHECK_FAILED=0
 while IFS= read -r script; do
   echo "  shellcheck: $script"
-  if ! shellcheck -s bash "$script"; then
+  # -x follows `# shellcheck source=` directives so the shared guard-script
+  # harness (scripts/lib/check-harness.sh, Issue #512) is analysed in context.
+  if ! shellcheck -x -s bash "$script"; then
     SHELLCHECK_FAILED=1
   fi
 done < <(find . -name "*.sh" -type f -not -path "./target/*" -not -path "./.git/*")

--- a/scripts/check-auto-format-workflow.sh
+++ b/scripts/check-auto-format-workflow.sh
@@ -17,6 +17,10 @@
 #      checks without the "Approve and run" gate (Issue #435).
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-auto-format-workflow.sh [--workflow PATH]
@@ -31,43 +35,10 @@ Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/auto-format.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $WORKFLOW: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $WORKFLOW: $*"
-}
+parse_check_args --workflow ".github/workflows/auto-format.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
+check_subject "$WORKFLOW"
 
 # 1. pull_request trigger present.
 if grep -qE '^[[:space:]]*pull_request:' "$WORKFLOW"; then

--- a/scripts/check-bot-push-token.sh
+++ b/scripts/check-bot-push-token.sh
@@ -27,6 +27,10 @@
 #      (and keep clearing the Issue #435 approval gate) before the App exists.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-bot-push-token.sh [--workflow PATH]
@@ -43,42 +47,18 @@ otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      if [[ $# -lt 2 ]]; then
-        echo "Missing value for --workflow" >&2
-        usage >&2
-        exit 2
-      fi
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
+parse_check_args --workflow "" "$@"
+WORKFLOW="$CHECK_TARGET"
 
 WORKFLOWS=()
 if [[ -n "$WORKFLOW" ]]; then
   WORKFLOWS=("$WORKFLOW")
 else
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOWS=(
-    "$SCRIPT_DIR/../.github/workflows/auto-format.yml"
-    "$SCRIPT_DIR/../.github/workflows/version-increment.yml"
+    "$(check_repo_path ".github/workflows/auto-format.yml")"
+    "$(check_repo_path ".github/workflows/version-increment.yml")"
   )
 fi
-
-EXIT_CODE=0
 
 validate_workflow() {
   local wf="$1"

--- a/scripts/check-ci-job-graph.sh
+++ b/scripts/check-ci-job-graph.sh
@@ -24,6 +24,10 @@
 # pulling in a YAML parser. Designed for reuse from BATS tests.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-ci-job-graph.sh [--workflow PATH]
@@ -39,43 +43,10 @@ with a descriptive message otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $WORKFLOW: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $WORKFLOW: $*"
-}
+parse_check_args --workflow ".github/workflows/ci.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
+check_subject "$WORKFLOW"
 
 # Emit a JSON-ish report of each job's top-level keys (`needs`, `if`) using a
 # minimal Python scanner — same approach as check-workflow-paths.sh.

--- a/scripts/check-ci-permissions.sh
+++ b/scripts/check-ci-permissions.sh
@@ -30,6 +30,10 @@
 # `.github/workflows/ci.yml` relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-ci-permissions.sh [--workflow PATH]
@@ -45,43 +49,10 @@ non-zero with a descriptive message otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $WORKFLOW: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $WORKFLOW: $*"
-}
+parse_check_args --workflow ".github/workflows/ci.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
+check_subject "$WORKFLOW"
 
 # Emit a TSV report describing the workflow-level permissions block and the
 # `security` job's job-level permissions block. A minimal Python scanner walks

--- a/scripts/check-ci-push-trigger.sh
+++ b/scripts/check-ci-push-trigger.sh
@@ -19,6 +19,10 @@
 # tests and `quality.sh`.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-ci-push-trigger.sh [--workflow PATH]
@@ -34,34 +38,9 @@ when the push branch filter lists `Develop`.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
-fi
+parse_check_args --workflow ".github/workflows/ci.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
 
 # Detect whether a `push:` trigger exists at all, and extract its `branches`
 # list (one entry per line) if present. The scanner walks the `on:` map,

--- a/scripts/check-codeowners.sh
+++ b/scripts/check-codeowners.sh
@@ -22,6 +22,10 @@
 # CODEOWNERS file at the first recognised path relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-codeowners.sh [--codeowners PATH]
@@ -37,53 +41,19 @@ Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
-CODEOWNERS=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --codeowners)
-      CODEOWNERS="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
+parse_check_args --codeowners "" "$@"
+CODEOWNERS="$CHECK_TARGET"
 if [[ -z "$CODEOWNERS" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  REPO_ROOT="$SCRIPT_DIR/.."
   for candidate in "CODEOWNERS" ".github/CODEOWNERS" "docs/CODEOWNERS"; do
-    if [[ -f "$REPO_ROOT/$candidate" ]]; then
-      CODEOWNERS="$REPO_ROOT/$candidate"
+    if [[ -f "$(check_repo_path "$candidate")" ]]; then
+      CODEOWNERS="$(check_repo_path "$candidate")"
       break
     fi
   done
-  if [[ -z "$CODEOWNERS" ]]; then
-    echo "CODEOWNERS not found at any recognised path: CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS" >&2
-    exit 2
-  fi
+  [[ -n "$CODEOWNERS" ]] || check_die 2 "CODEOWNERS not found at any recognised path: CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS"
 fi
-
-if [[ ! -f "$CODEOWNERS" ]]; then
-  echo "CODEOWNERS file not found: $CODEOWNERS" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $CODEOWNERS: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $CODEOWNERS: $*"
-}
+check_require_file "$CODEOWNERS" "CODEOWNERS file"
+check_subject "$CODEOWNERS"
 
 # Does a CODEOWNERS pattern cover .github/workflows/ ?
 # CODEOWNERS uses gitignore-style globs; we accept the patterns that

--- a/scripts/check-gitleaks-workflow.sh
+++ b/scripts/check-gitleaks-workflow.sh
@@ -19,6 +19,10 @@
 # `.github/workflows/gitleaks.yml` relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-gitleaks-workflow.sh [--workflow PATH]
@@ -33,43 +37,10 @@ script header. Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/gitleaks.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $WORKFLOW: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $WORKFLOW: $*"
-}
+parse_check_args --workflow ".github/workflows/gitleaks.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
+check_subject "$WORKFLOW"
 
 content="$(cat "$WORKFLOW")"
 

--- a/scripts/check-milestone-branch-filter.sh
+++ b/scripts/check-milestone-branch-filter.sh
@@ -15,6 +15,10 @@
 # tests.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-milestone-branch-filter.sh [--workflow PATH]
@@ -29,34 +33,9 @@ Exits 0 when the workflow's on.pull_request.branches filter includes a
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/ci.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
-fi
+parse_check_args --workflow ".github/workflows/ci.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
 
 # Extract the `on.pull_request.branches` list, one entry per line. The scanner
 # walks the `on:` map, descends into `pull_request:`, then collects the

--- a/scripts/check-neat-core-composite-action.sh
+++ b/scripts/check-neat-core-composite-action.sh
@@ -20,6 +20,10 @@
 # Designed for reuse from BATS tests and quality.sh.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-neat-core-composite-action.sh [--action PATH] [--workflows DIR]
@@ -42,33 +46,28 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --action)
       ACTION="${2:-}"
-      [[ -n "$ACTION" ]] || { echo "--action requires a path argument" >&2; exit 2; }
+      [[ -n "$ACTION" ]] || check_die 2 "--action requires a path argument"
       shift 2
       ;;
     --workflows)
       WORKFLOWS_DIR="${2:-}"
-      [[ -n "$WORKFLOWS_DIR" ]] || { echo "--workflows requires a directory argument" >&2; exit 2; }
+      [[ -n "$WORKFLOWS_DIR" ]] || check_die 2 "--workflows requires a directory argument"
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
     *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
+      check_unknown_arg "$1"
       ;;
   esac
 done
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-[[ -n "$ACTION" ]] || ACTION="$SCRIPT_DIR/../.github/actions/setup-neat-core/action.yml"
-[[ -n "$WORKFLOWS_DIR" ]] || WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
+[[ -n "$ACTION" ]] || ACTION="$(check_repo_path ".github/actions/setup-neat-core/action.yml")"
+[[ -n "$WORKFLOWS_DIR" ]] || WORKFLOWS_DIR="$(check_repo_path ".github/workflows")"
 
-EXIT_CODE=0
-fail() { echo "FAIL $*" >&2; EXIT_CODE=1; }
-ok() { echo "OK   $*"; }
+# Every message names its own file, so ok/fail carry no subject prefix.
 
 # --- 1 & 2: the composite action exists and is well formed. -----------------
 if [[ ! -f "$ACTION" ]]; then
@@ -102,10 +101,7 @@ else
 fi
 
 # --- 3 & 4: workflows go through the composite, none inline the checkout. ----
-if [[ ! -d "$WORKFLOWS_DIR" ]]; then
-  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
-  exit 2
-fi
+check_require_dir "$WORKFLOWS_DIR"
 
 inline_hits="$(grep -rln 'repository:[[:space:]]*stSoftwareAU/NEAT-AI-core' \
   --include='*.yml' --include='*.yaml' "$WORKFLOWS_DIR" || true)"

--- a/scripts/check-persist-credentials.sh
+++ b/scripts/check-persist-credentials.sh
@@ -21,6 +21,10 @@
 # repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-persist-credentials.sh [--workflow PATH]
@@ -38,29 +42,8 @@ message otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      if [[ $# -lt 2 ]]; then
-        echo "Missing value for --workflow" >&2
-        usage >&2
-        exit 2
-      fi
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
+parse_check_args --workflow "" "$@"
+WORKFLOW="$CHECK_TARGET"
 
 # Build the list of workflows to validate. An explicit --workflow overrides the
 # default set; otherwise every guarded workflow is checked in one run
@@ -69,16 +52,13 @@ WORKFLOWS=()
 if [[ -n "$WORKFLOW" ]]; then
   WORKFLOWS=("$WORKFLOW")
 else
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOWS=(
-    "$SCRIPT_DIR/../.github/workflows/ci.yml"
-    "$SCRIPT_DIR/../.github/workflows/security.yml"
-    "$SCRIPT_DIR/../.github/workflows/semgrep.yml"
-    "$SCRIPT_DIR/../.github/workflows/cargo-quality.yml"
+    "$(check_repo_path ".github/workflows/ci.yml")"
+    "$(check_repo_path ".github/workflows/security.yml")"
+    "$(check_repo_path ".github/workflows/semgrep.yml")"
+    "$(check_repo_path ".github/workflows/cargo-quality.yml")"
   )
 fi
-
-EXIT_CODE=0
 
 validate_workflow() {
   local WORKFLOW="$1"

--- a/scripts/check-prebuilt-tool-install.sh
+++ b/scripts/check-prebuilt-tool-install.sh
@@ -28,6 +28,10 @@
 #     `.github/workflows` relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-prebuilt-tool-install.sh [--workflow PATH --tool NAME] [--workflows DIR]
@@ -54,61 +58,55 @@ WORKFLOWS_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --workflow)
+      check_flag_value --workflow $#
       WORKFLOW="$2"
       shift 2
       ;;
     --tool)
+      check_flag_value --tool $#
       TOOL="$2"
       shift 2
       ;;
     --workflows)
+      check_flag_value --workflows $#
       WORKFLOWS_DIR="$2"
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
     *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
+      check_unknown_arg "$1"
       ;;
   esac
 done
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $1: $2" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $1: $2"
-}
 
 # Validate a single (workflow file, tool) pair against the two rules.
 check_pair() {
   local file="$1"
   local tool="$2"
+  # Each ok/fail line is about this workflow file.
+  local CHECK_SUBJECT="$file"
 
   if [[ ! -f "$file" ]]; then
-    fail "$file" "workflow file not found"
+    fail "workflow file not found"
     return
   fi
 
   # Rule 1: no source compile via `cargo install <tool>`.
   if grep -qE "cargo[[:space:]]+install[[:space:]]+${tool}([[:space:]]|$)" "$file"; then
-    fail "$file" "compiles $tool from source via 'cargo install $tool' — use a prebuilt binary"
+    fail "compiles $tool from source via 'cargo install $tool' — use a prebuilt binary"
   else
-    ok "$file" "no 'cargo install $tool' source compile"
+    ok "no 'cargo install $tool' source compile"
   fi
 
   # Rule 2: prebuilt install via taiki-e/install-action with a matching tool.
   if grep -qE 'uses:[[:space:]]*taiki-e/install-action@' "$file" \
     && grep -qE "tool:[[:space:]]*${tool}([[:space:]]|,|$)" "$file"; then
-    ok "$file" "installs $tool via prebuilt taiki-e/install-action"
+    ok "installs $tool via prebuilt taiki-e/install-action"
   else
-    fail "$file" "no prebuilt taiki-e/install-action step for $tool"
+    fail "no prebuilt taiki-e/install-action step for $tool"
   fi
 }
 
@@ -122,15 +120,8 @@ if [[ -n "$WORKFLOW" || -n "$TOOL" ]]; then
   exit "$EXIT_CODE"
 fi
 
-if [[ -z "$WORKFLOWS_DIR" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
-fi
-
-if [[ ! -d "$WORKFLOWS_DIR" ]]; then
-  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
-  exit 2
-fi
+[[ -n "$WORKFLOWS_DIR" ]] || WORKFLOWS_DIR="$(check_repo_path ".github/workflows")"
+check_require_dir "$WORKFLOWS_DIR"
 
 # Canonical (workflow, tool) pairs. bash 3.2 has no associative arrays, so a
 # parallel-indexed pair list is used.

--- a/scripts/check-push-step-hardening.sh
+++ b/scripts/check-push-step-hardening.sh
@@ -27,6 +27,10 @@
 # credentials available to workflow-executed code.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-push-step-hardening.sh [--workflow PATH]
@@ -42,42 +46,18 @@ by earlier PR-head steps. Exits non-zero otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      if [[ $# -lt 2 ]]; then
-        echo "Missing value for --workflow" >&2
-        usage >&2
-        exit 2
-      fi
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
+parse_check_args --workflow "" "$@"
+WORKFLOW="$CHECK_TARGET"
 
 WORKFLOWS=()
 if [[ -n "$WORKFLOW" ]]; then
   WORKFLOWS=("$WORKFLOW")
 else
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   WORKFLOWS=(
-    "$SCRIPT_DIR/../.github/workflows/auto-format.yml"
-    "$SCRIPT_DIR/../.github/workflows/version-increment.yml"
+    "$(check_repo_path ".github/workflows/auto-format.yml")"
+    "$(check_repo_path ".github/workflows/version-increment.yml")"
   )
 fi
-
-EXIT_CODE=0
 
 validate_workflow() {
   local wf="$1"

--- a/scripts/check-run-block-safety.sh
+++ b/scripts/check-run-block-safety.sh
@@ -26,6 +26,10 @@
 # relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-run-block-safety.sh [--workflows DIR]
@@ -41,25 +45,8 @@ Exits 1 (listing each offender as `file:line`) when any such block does not.
 EOF
 }
 
-WORKFLOWS_DIR=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflows)
-      WORKFLOWS_DIR="${2:-}"
-      [[ -n "$WORKFLOWS_DIR" ]] || { echo "--workflows requires a directory argument" >&2; exit 2; }
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
+parse_check_args --workflows "" "$@"
+WORKFLOWS_DIR="$CHECK_TARGET"
 
 # In default mode also scan local composite actions: the NEAT-AI-core sibling
 # symlink block now lives in `.github/actions/setup-neat-core/action.yml`
@@ -67,9 +54,8 @@ done
 # --workflows override scans only that directory (keeps test fixtures isolated).
 ACTIONS_DIR=""
 if [[ -z "$WORKFLOWS_DIR" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
-  ACTIONS_DIR="$SCRIPT_DIR/../.github/actions"
+  WORKFLOWS_DIR="$(check_repo_path ".github/workflows")"
+  ACTIONS_DIR="$(check_repo_path ".github/actions")"
 fi
 
 if [[ ! -d "$WORKFLOWS_DIR" ]]; then

--- a/scripts/check-rust-lints.sh
+++ b/scripts/check-rust-lints.sh
@@ -23,6 +23,10 @@
 # real repository files relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-rust-lints.sh [--manifest PATH] [--lib PATH]
@@ -44,50 +48,32 @@ LIB=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --manifest)
+      check_flag_value --manifest $#
       MANIFEST="$2"
       shift 2
       ;;
     --lib)
+      check_flag_value --lib $#
       LIB="$2"
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
     *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
+      check_unknown_arg "$1"
       ;;
   esac
 done
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -z "$MANIFEST" ]]; then
-  MANIFEST="$SCRIPT_DIR/../Cargo.toml"
-fi
-if [[ -z "$LIB" ]]; then
-  LIB="$SCRIPT_DIR/../rust_scorer/src/lib.rs"
-fi
+[[ -n "$MANIFEST" ]] || MANIFEST="$(check_repo_path "Cargo.toml")"
+[[ -n "$LIB" ]] || LIB="$(check_repo_path "rust_scorer/src/lib.rs")"
 
-if [[ ! -f "$MANIFEST" ]]; then
-  echo "Cargo.toml not found: $MANIFEST" >&2
-  exit 2
-fi
-if [[ ! -f "$LIB" ]]; then
-  echo "library root not found: $LIB" >&2
-  exit 2
-fi
+check_require_file "$MANIFEST" "Cargo.toml"
+check_require_file "$LIB" "library root"
 
-EXIT_CODE=0
-fail() {
-  echo "FAIL $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $*"
-}
+# Every message names its own file, so ok/fail carry no subject prefix.
 
 # Extract the body of the [workspace.lints.rust] table: every line from the
 # header up to (but not including) the next table header. Keeps rule checks

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -16,6 +16,10 @@
 # `rust-toolchain.toml` relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-rust-toolchain.sh [--toolchain PATH]
@@ -30,43 +34,10 @@ Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
-TOOLCHAIN=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --toolchain)
-      TOOLCHAIN="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$TOOLCHAIN" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  TOOLCHAIN="$SCRIPT_DIR/../rust-toolchain.toml"
-fi
-
-if [[ ! -f "$TOOLCHAIN" ]]; then
-  echo "rust-toolchain.toml not found: $TOOLCHAIN" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $TOOLCHAIN: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $TOOLCHAIN: $*"
-}
+parse_check_args --toolchain "rust-toolchain.toml" "$@"
+TOOLCHAIN="$CHECK_TARGET"
+check_require_file "$TOOLCHAIN" "rust-toolchain.toml"
+check_subject "$TOOLCHAIN"
 
 # 1. A [toolchain] table is present.
 if grep -qE '^\[toolchain\]' "$TOOLCHAIN"; then

--- a/scripts/check-security-policy.sh
+++ b/scripts/check-security-policy.sh
@@ -23,6 +23,10 @@
 # policy file at the first recognised path relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-security-policy.sh [--security-policy PATH]
@@ -38,53 +42,19 @@ Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
-POLICY=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --security-policy)
-      POLICY="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
+parse_check_args --security-policy "" "$@"
+POLICY="$CHECK_TARGET"
 if [[ -z "$POLICY" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  REPO_ROOT="$SCRIPT_DIR/.."
   for candidate in "SECURITY.md" ".github/SECURITY.md" "docs/SECURITY.md"; do
-    if [[ -f "$REPO_ROOT/$candidate" ]]; then
-      POLICY="$REPO_ROOT/$candidate"
+    if [[ -f "$(check_repo_path "$candidate")" ]]; then
+      POLICY="$(check_repo_path "$candidate")"
       break
     fi
   done
-  if [[ -z "$POLICY" ]]; then
-    echo "SECURITY.md not found at any recognised path: SECURITY.md, .github/SECURITY.md, docs/SECURITY.md" >&2
-    exit 2
-  fi
+  [[ -n "$POLICY" ]] || check_die 2 "SECURITY.md not found at any recognised path: SECURITY.md, .github/SECURITY.md, docs/SECURITY.md"
 fi
-
-if [[ ! -f "$POLICY" ]]; then
-  echo "Security policy file not found: $POLICY" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $POLICY: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $POLICY: $*"
-}
+check_require_file "$POLICY" "Security policy file"
+check_subject "$POLICY"
 
 content="$(cat "$POLICY")"
 

--- a/scripts/check-semgrep-workflow.sh
+++ b/scripts/check-semgrep-workflow.sh
@@ -27,6 +27,10 @@
 # `.github/workflows/semgrep.yml` relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-semgrep-workflow.sh [--workflow PATH]
@@ -41,43 +45,10 @@ Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOW" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/semgrep.yml"
-fi
-
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
-fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $WORKFLOW: $*" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $WORKFLOW: $*"
-}
+parse_check_args --workflow ".github/workflows/semgrep.yml" "$@"
+WORKFLOW="$CHECK_TARGET"
+check_require_file "$WORKFLOW"
+check_subject "$WORKFLOW"
 
 # 1. Triggered on pull_request events.
 if grep -qE '^on:[[:space:]]*$' "$WORKFLOW" && grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW"; then

--- a/scripts/check-shellcheck-dedup.sh
+++ b/scripts/check-shellcheck-dedup.sh
@@ -22,6 +22,10 @@
 # `.github/workflows` relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-shellcheck-dedup.sh [--workflows DIR]
@@ -38,34 +42,9 @@ or duplicated across more than one workflow file.
 EOF
 }
 
-WORKFLOWS_DIR=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflows)
-      WORKFLOWS_DIR="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "$WORKFLOWS_DIR" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
-fi
-
-if [[ ! -d "$WORKFLOWS_DIR" ]]; then
-  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
-  exit 2
-fi
+parse_check_args --workflows ".github/workflows" "$@"
+WORKFLOWS_DIR="$CHECK_TARGET"
+check_require_dir "$WORKFLOWS_DIR"
 
 # Collect every workflow file that *invokes* ShellCheck. A workflow counts when
 # it either references the action on a `uses:` line (ignoring leading `- `) or

--- a/scripts/check-workflow-action-versions.sh
+++ b/scripts/check-workflow-action-versions.sh
@@ -46,6 +46,10 @@
 # Designed for reuse from BATS tests and `quality.sh`.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-workflow-action-versions.sh [--workflows DIR]
@@ -60,24 +64,8 @@ compatibility policy. Exits non-zero with a descriptive message otherwise.
 EOF
 }
 
-WORKFLOWS_DIR=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflows)
-      WORKFLOWS_DIR="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
+parse_check_args --workflows "" "$@"
+WORKFLOWS_DIR="$CHECK_TARGET"
 
 # In default mode also scan local composite actions: the SHA-pinned
 # `actions/checkout` for NEAT-AI-core now lives in
@@ -86,15 +74,11 @@ done
 # directory (keeps test fixtures isolated).
 ACTIONS_DIR=""
 if [[ -z "$WORKFLOWS_DIR" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
-  ACTIONS_DIR="$SCRIPT_DIR/../.github/actions"
+  WORKFLOWS_DIR="$(check_repo_path ".github/workflows")"
+  ACTIONS_DIR="$(check_repo_path ".github/actions")"
 fi
 
-if [[ ! -d "$WORKFLOWS_DIR" ]]; then
-  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
-  exit 2
-fi
+check_require_dir "$WORKFLOWS_DIR"
 
 # Look up the policy for a given action. Prints one of:
 #   required:<N>    — action must be pinned at @vN or newer (Node 24 bump)
@@ -187,7 +171,6 @@ parse_label_major() {
 
 SHA_RE='^[0-9a-f]{40}$'
 
-EXIT_CODE=0
 FOUND_ANY=0
 
 while IFS= read -r workflow; do

--- a/scripts/check-workflow-concurrency.sh
+++ b/scripts/check-workflow-concurrency.sh
@@ -27,6 +27,10 @@
 # root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-workflow-concurrency.sh [--workflow PATH]
@@ -43,36 +47,13 @@ descriptive message otherwise.
 EOF
 }
 
-WORKFLOW=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflow)
-      WORKFLOW="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $1: ${*:2}" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $1: ${*:2}"
-}
+parse_check_args --workflow "" "$@"
+WORKFLOW="$CHECK_TARGET"
 
 check_workflow() {
   local wf="$1"
+  # Each ok/fail line is about this workflow file.
+  local CHECK_SUBJECT="$wf"
 
   if [[ ! -f "$wf" ]]; then
     echo "Workflow file not found: $wf" >&2
@@ -82,31 +63,30 @@ check_workflow() {
 
   # 1. Top-level concurrency: block.
   if ! grep -qE '^concurrency:[[:space:]]*$' "$wf"; then
-    fail "$wf" "no top-level 'concurrency:' block — overlapping runs will pile up"
+    fail "no top-level 'concurrency:' block — overlapping runs will pile up"
     return
   fi
-  ok "$wf" "declares a top-level concurrency block"
+  ok "declares a top-level concurrency block"
 
   # 2. group: keyed by the ref so there is one in-flight run per branch/PR.
   if grep -qE '^[[:space:]]+group:[[:space:]]*.*\$\{\{[[:space:]]*github\.ref[[:space:]]*\}\}' "$wf"; then
-    ok "$wf" "concurrency group is keyed by github.ref"
+    ok "concurrency group is keyed by github.ref"
   else
-    fail "$wf" "concurrency group is not keyed by \${{ github.ref }}"
+    fail "concurrency group is not keyed by \${{ github.ref }}"
   fi
 
   # 3. cancel-in-progress: true so superseded runs are cancelled.
   if grep -qE '^[[:space:]]+cancel-in-progress:[[:space:]]*true[[:space:]]*$' "$wf"; then
-    ok "$wf" "cancel-in-progress is true"
+    ok "cancel-in-progress is true"
   else
-    fail "$wf" "cancel-in-progress is not set to true — superseded runs would keep running"
+    fail "cancel-in-progress is not set to true — superseded runs would keep running"
   fi
 }
 
 if [[ -n "$WORKFLOW" ]]; then
   check_workflow "$WORKFLOW"
 else
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WF_DIR="$SCRIPT_DIR/../.github/workflows"
+  WF_DIR="$(check_repo_path ".github/workflows")"
   # Pile-up-prone workflows that must declare a concurrency group (Issue #156).
   PILE_UP_PRONE=(
     ci.yml

--- a/scripts/check-workflow-paths.sh
+++ b/scripts/check-workflow-paths.sh
@@ -17,6 +17,10 @@
 # Designed for reuse from BATS tests and `quality.sh`.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-workflow-paths.sh [--workflows DIR]
@@ -32,24 +36,8 @@ with a descriptive message otherwise.
 EOF
 }
 
-WORKFLOWS_DIR=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --workflows)
-      WORKFLOWS_DIR="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
-      ;;
-  esac
-done
+parse_check_args --workflows "" "$@"
+WORKFLOWS_DIR="$CHECK_TARGET"
 
 # In default mode also scan local composite actions: the NEAT-AI-core checkout
 # + sibling symlink now lives in `.github/actions/setup-neat-core/action.yml`
@@ -57,17 +45,12 @@ done
 # --workflows override scans only that directory (keeps test fixtures isolated).
 ACTIONS_DIR=""
 if [[ -z "$WORKFLOWS_DIR" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WORKFLOWS_DIR="$SCRIPT_DIR/../.github/workflows"
-  ACTIONS_DIR="$SCRIPT_DIR/../.github/actions"
+  WORKFLOWS_DIR="$(check_repo_path ".github/workflows")"
+  ACTIONS_DIR="$(check_repo_path ".github/actions")"
 fi
 
-if [[ ! -d "$WORKFLOWS_DIR" ]]; then
-  echo "Workflows directory not found: $WORKFLOWS_DIR" >&2
-  exit 2
-fi
+check_require_dir "$WORKFLOWS_DIR"
 
-EXIT_CODE=0
 FOUND_ANY=0
 
 # Iterate .yml and .yaml workflow files; python3 parses each one and emits

--- a/scripts/check-workflow-timeouts.sh
+++ b/scripts/check-workflow-timeouts.sh
@@ -24,6 +24,10 @@
 # `*.yml`/`*.yaml` file under `.github/workflows/` relative to the repo root.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
 usage() {
   cat <<'EOF'
 Usage: check-workflow-timeouts.sh [--workflow PATH]...
@@ -44,49 +48,38 @@ WORKFLOWS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --workflow)
-      [[ $# -ge 2 ]] || { echo "--workflow requires a PATH argument" >&2; exit 2; }
+      check_flag_value --workflow $#
       WORKFLOWS+=("$2")
       shift 2
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
     *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
+      check_unknown_arg "$1"
       ;;
   esac
 done
 
 if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  WF_DIR="$SCRIPT_DIR/../.github/workflows"
+  WF_DIR="$(check_repo_path ".github/workflows")"
   while IFS= read -r f; do
     WORKFLOWS+=("$f")
   done < <(find "$WF_DIR" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
 fi
 
 if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then
-  echo "No workflow files to validate" >&2
-  exit 2
+  check_die 2 "No workflow files to validate"
 fi
-
-EXIT_CODE=0
-fail() {
-  echo "FAIL $1: ${*:2}" >&2
-  EXIT_CODE=1
-}
-ok() {
-  echo "OK   $1: ${*:2}"
-}
 
 # Maximum permitted timeout — GitHub caps a job at 360 minutes regardless.
 MAX_TIMEOUT=360
 
 validate_workflow() {
   local wf="$1"
+  # Each ok/fail line is about this workflow file.
+  local CHECK_SUBJECT="$wf"
 
   if [[ ! -f "$wf" ]]; then
     echo "Workflow file not found: $wf" >&2
@@ -184,7 +177,7 @@ PY
   )"
 
   if [[ -z "$report" ]]; then
-    fail "$wf" "no jobs found — cannot verify timeouts"
+    fail "no jobs found — cannot verify timeouts"
     return
   fi
 
@@ -193,28 +186,28 @@ PY
     if [[ "$is_reusable" == "1" ]]; then
       # Reusable-call jobs must not declare timeout-minutes.
       if [[ "$has_timeout" == "1" ]]; then
-        fail "$wf" "job '$name' calls a reusable workflow and must not declare timeout-minutes (set it in the called workflow's jobs)"
+        fail "job '$name' calls a reusable workflow and must not declare timeout-minutes (set it in the called workflow's jobs)"
       else
-        ok "$wf" "job '$name' is a reusable-workflow call (timeout belongs in the called workflow)"
+        ok "job '$name' is a reusable-workflow call (timeout belongs in the called workflow)"
       fi
       continue
     fi
 
     if [[ "$has_timeout" != "1" ]]; then
-      fail "$wf" "job '$name' has no timeout-minutes — it inherits GitHub's 360-minute default"
+      fail "job '$name' has no timeout-minutes — it inherits GitHub's 360-minute default"
       continue
     fi
 
     if [[ ! "$value" =~ ^[0-9]+$ ]]; then
-      fail "$wf" "job '$name' timeout-minutes must be a positive integer (found: '$value')"
+      fail "job '$name' timeout-minutes must be a positive integer (found: '$value')"
       continue
     fi
     if [[ "$value" -lt 1 || "$value" -gt "$MAX_TIMEOUT" ]]; then
-      fail "$wf" "job '$name' timeout-minutes must be between 1 and $MAX_TIMEOUT (found: $value)"
+      fail "job '$name' timeout-minutes must be between 1 and $MAX_TIMEOUT (found: $value)"
       continue
     fi
 
-    ok "$wf" "job '$name' declares timeout-minutes: $value"
+    ok "job '$name' declares timeout-minutes: $value"
   done <<< "$report"
 }
 

--- a/scripts/lib/check-harness.sh
+++ b/scripts/lib/check-harness.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Shared CLI harness for the `scripts/check-*.sh` guard scripts (Issue #512).
+#
+# This file is *sourced*, never executed. It owns the contract every validator
+# shares — the `--FLAG PATH` / `-h` argument loop, default-target resolution
+# relative to the repo root, the "file not found" guard, and the
+# accumulate-and-report protocol (`OK   `/`FAIL ` prefixes, failures on stderr,
+# `EXIT_CODE=1` without aborting the run). The per-script rule checks — the part
+# that genuinely differs — stay in the individual scripts.
+#
+# Contract for a sourcing script:
+#   * define `usage()` before calling `parse_check_args` (the harness prints it
+#     for `-h/--help` and for an unknown flag);
+#   * set `CHECK_SUBJECT` to the file each `ok`/`fail` line is about, or leave
+#     it empty when the message names its own subject;
+#   * end with `exit "$EXIT_CODE"`.
+#
+# Changing the CLI contract — a new flag, machine-readable output, a different
+# exit-code convention — is a single edit here rather than ~30 copy-pasted ones.
+
+# EXIT_CODE, CHECK_* and the functions below are consumed by the sourcing
+# script, so ShellCheck cannot see their use from inside this file.
+# shellcheck disable=SC2034
+
+# Absolute path to the repository root (the parent of `scripts/`).
+CHECK_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Subject prefixed to every `ok`/`fail` line. Empty means "no subject prefix".
+CHECK_SUBJECT=""
+
+# Accumulated status: flipped to 1 by `fail`, so a run reports every violation
+# rather than aborting on the first one.
+EXIT_CODE=0
+
+# Target resolved by `parse_check_args`.
+CHECK_TARGET=""
+
+# check_die <exit-code> <message...> — report on stderr and stop.
+check_die() {
+  local code="$1"
+  shift
+  echo "$*" >&2
+  exit "$code"
+}
+
+# check_unknown_arg <arg> — the shared unknown-flag contract: name the offending
+# argument, print the usage block on stderr, exit 2.
+check_unknown_arg() {
+  echo "Unknown argument: $1" >&2
+  usage >&2
+  exit 2
+}
+
+# check_flag_value <flag> <remaining-arg-count> — guard a flag that needs a
+# value, so a bare `--workflow` fails with a message instead of an unbound
+# variable error under `set -u`.
+check_flag_value() {
+  [[ "$2" -ge 2 ]] || check_die 2 "$1 requires a PATH argument"
+}
+
+# check_repo_path <relative-path> — absolute path to a repo-relative file.
+check_repo_path() {
+  echo "$CHECK_REPO_ROOT/$1"
+}
+
+# check_require_file <path> [label] — the shared "not found" guard.
+check_require_file() {
+  [[ -f "$1" ]] || check_die 2 "${2:-Workflow file} not found: $1"
+}
+
+# check_require_dir <path> [label] — directory flavour of the guard above.
+check_require_dir() {
+  [[ -d "$1" ]] || check_die 2 "${2:-Workflows directory} not found: $1"
+}
+
+# parse_check_args <flag> <default-relative-path> "$@" — the single-target
+# argument loop shared by most validators. Sets `CHECK_TARGET` to the flag's
+# value, or to `<repo root>/<default-relative-path>` when the flag is absent.
+# Pass an empty default when the caller resolves its own fallback.
+parse_check_args() {
+  local flag="$1" default="$2"
+  shift 2
+  CHECK_TARGET=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      "$flag")
+        check_flag_value "$flag" $#
+        CHECK_TARGET="$2"
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        check_unknown_arg "$1"
+        ;;
+    esac
+  done
+  if [[ -z "$CHECK_TARGET" && -n "$default" ]]; then
+    CHECK_TARGET="$(check_repo_path "$default")"
+  fi
+}
+
+# ok <message...> — record a satisfied rule on stdout.
+ok() {
+  echo "OK   ${CHECK_SUBJECT:+$CHECK_SUBJECT: }$*"
+}
+
+# fail <message...> — record a violated rule on stderr and remember the failure.
+fail() {
+  echo "FAIL ${CHECK_SUBJECT:+$CHECK_SUBJECT: }$*" >&2
+  EXIT_CODE=1
+}
+
+# check_subject <subject> — set the file each subsequent `ok`/`fail` line is
+# about. Pass an empty string to drop the prefix.
+check_subject() {
+  CHECK_SUBJECT="$1"
+}

--- a/tests/scripts/actionlint_workflow.bats
+++ b/tests/scripts/actionlint_workflow.bats
@@ -5,6 +5,8 @@
 # workflow YAML in temporary directories so behaviour (exit codes, reported
 # failures) is verified end-to-end without mutating the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-actionlint-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -169,15 +171,11 @@ PY
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository actionlint workflow satisfies every rule" {

--- a/tests/scripts/auto_format.bats
+++ b/tests/scripts/auto_format.bats
@@ -8,6 +8,8 @@
 # job — the script takes the resulting working tree as-is and reports on it,
 # which keeps these tests hermetic (no Rust toolchain required).
 
+load 'test_helper'
+
 setup() {
   AUTO_FORMAT="${BATS_TEST_DIRNAME}/../../scripts/auto-format.sh"
   WF_CHECK="${BATS_TEST_DIRNAME}/../../scripts/check-auto-format-workflow.sh"
@@ -81,9 +83,7 @@ teardown() {
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$AUTO_FORMAT" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$AUTO_FORMAT"
 }
 
 @test "missing mode prints usage and exits non-zero" {

--- a/tests/scripts/cargo_audit_workflow.bats
+++ b/tests/scripts/cargo_audit_workflow.bats
@@ -5,6 +5,8 @@
 # workflow YAML in temporary directories so behaviour (exit codes, reported
 # failures) is verified end-to-end without mutating the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-cargo-audit-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -169,15 +171,11 @@ EOF
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository cargo-audit workflow satisfies every rule" {

--- a/tests/scripts/cargo_quality_workflow.bats
+++ b/tests/scripts/cargo_quality_workflow.bats
@@ -5,6 +5,8 @@
 # workflow YAML in temporary directories so behaviour (exit codes, reported
 # failures) is verified end-to-end without mutating the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-cargo-quality-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -159,15 +161,11 @@ PY
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository cargo-quality workflow satisfies every rule" {

--- a/tests/scripts/check_harness.bats
+++ b/tests/scripts/check_harness.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/check-harness.sh — Issue #512.
+#
+# The harness is sourced, not executed, so every test drives it through a
+# throwaway validator script written into a temp directory. That exercises the
+# real contract end-to-end — argument parsing, the not-found guard, and the
+# OK/FAIL accumulate-and-report protocol — via exit codes and output rather
+# than by inspecting the library source.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  HARNESS="${BATS_TEST_DIRNAME}/../../scripts/lib/check-harness.sh"
+  TMP_DIR="$(mktemp -d)"
+  export HARNESS TMP_DIR
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Write a minimal validator that uses the whole harness: usage(), the
+# single-target argument loop, the not-found guard, and one ok/fail rule.
+write_validator() {
+  local script="$TMP_DIR/validator.sh"
+  cat >"$script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=scripts/lib/check-harness.sh
+source "$HARNESS"
+
+usage() {
+  cat <<'USAGE'
+Usage: validator.sh [--workflow PATH]
+USAGE
+}
+
+parse_check_args --workflow "README.md" "\$@"
+check_require_file "\$CHECK_TARGET"
+CHECK_SUBJECT="\$CHECK_TARGET"
+
+echo "TARGET=\$CHECK_TARGET"
+if grep -q 'good' "\$CHECK_TARGET"; then
+  ok "contains the marker"
+else
+  fail "missing the marker"
+fi
+exit "\$EXIT_CODE"
+EOF
+  chmod +x "$script"
+  echo "$script"
+}
+
+@test "resolves the default target relative to the repo root" {
+  script="$(write_validator)"
+  run "$script"
+  [ "$status" -eq 0 ] || [ "$status" -eq 1 ]
+  [[ "$output" == *"TARGET=/"* ]]
+  [[ "$output" == *"/README.md"* ]]
+}
+
+@test "an explicit flag overrides the default target" {
+  script="$(write_validator)"
+  echo "good" >"$TMP_DIR/target.txt"
+  run "$script" --workflow "$TMP_DIR/target.txt"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=$TMP_DIR/target.txt"* ]]
+}
+
+@test "--help prints usage and exits zero" {
+  script="$(write_validator)"
+  run "$script" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: validator.sh"* ]]
+}
+
+@test "an unknown flag names the argument, prints usage and exits 2" {
+  script="$(write_validator)"
+  run "$script" --nonsense
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Unknown argument: --nonsense"* ]]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "a flag with no value fails with a message instead of an unbound variable" {
+  script="$(write_validator)"
+  run "$script" --workflow
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--workflow requires a PATH argument"* ]]
+}
+
+@test "a missing target file exits 2 with a not-found message" {
+  script="$(write_validator)"
+  run "$script" --workflow "$TMP_DIR/does-not-exist.yml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found: $TMP_DIR/does-not-exist.yml"* ]]
+}
+
+@test "a satisfied rule reports OK on stdout and exits zero" {
+  script="$(write_validator)"
+  echo "good" >"$TMP_DIR/target.txt"
+  run "$script" --workflow "$TMP_DIR/target.txt"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK   $TMP_DIR/target.txt: contains the marker"* ]]
+}
+
+@test "a violated rule reports FAIL on stderr and exits 1" {
+  script="$(write_validator)"
+  echo "bad" >"$TMP_DIR/target.txt"
+  run --separate-stderr "$script" --workflow "$TMP_DIR/target.txt"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"FAIL $TMP_DIR/target.txt: missing the marker"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "failures accumulate rather than aborting on the first one" {
+  script="$TMP_DIR/multi.sh"
+  cat >"$script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "$HARNESS"
+usage() { echo "Usage: multi.sh"; }
+CHECK_SUBJECT="subject"
+fail "first violation"
+fail "second violation"
+ok "third rule holds"
+exit "\$EXIT_CODE"
+EOF
+  chmod +x "$script"
+  run "$script"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL subject: first violation"* ]]
+  [[ "$output" == *"FAIL subject: second violation"* ]]
+  [[ "$output" == *"OK   subject: third rule holds"* ]]
+}
+
+@test "an empty subject drops the prefix from OK and FAIL lines" {
+  script="$TMP_DIR/nosubject.sh"
+  cat >"$script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "$HARNESS"
+usage() { echo "Usage: nosubject.sh"; }
+ok "rule holds"
+fail "rule broken"
+exit "\$EXIT_CODE"
+EOF
+  chmod +x "$script"
+  run "$script"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"OK   rule holds"* ]]
+  [[ "$output" == *"FAIL rule broken"* ]]
+}
+
+@test "check_require_dir guards a missing directory with a labelled message" {
+  script="$TMP_DIR/dir.sh"
+  cat >"$script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "$HARNESS"
+usage() { echo "Usage: dir.sh"; }
+check_require_dir "$TMP_DIR/absent" "Workflows directory"
+exit 0
+EOF
+  chmod +x "$script"
+  run "$script"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Workflows directory not found: $TMP_DIR/absent"* ]]
+}
+
+@test "an empty default leaves the target unset for caller-side resolution" {
+  script="$TMP_DIR/nodefault.sh"
+  cat >"$script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "$HARNESS"
+usage() { echo "Usage: nodefault.sh"; }
+parse_check_args --codeowners "" "\$@"
+echo "TARGET=[\$CHECK_TARGET]"
+exit 0
+EOF
+  chmod +x "$script"
+  run "$script"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=[]"* ]]
+}

--- a/tests/scripts/ci_permissions.bats
+++ b/tests/scripts/ci_permissions.bats
@@ -6,6 +6,8 @@
 # against the real repo workflow so the enforced rules and the shipped
 # workflow cannot drift apart.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-ci-permissions.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -160,15 +162,11 @@ EOF
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository ci.yml satisfies every least-privilege rule" {

--- a/tests/scripts/ci_push_trigger.bats
+++ b/tests/scripts/ci_push_trigger.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without depending on the real workflow file's state.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-ci-push-trigger.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -125,15 +127,11 @@ EOF
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "the repository CI workflow does not re-trigger on push to Develop" {

--- a/tests/scripts/codeowners.bats
+++ b/tests/scripts/codeowners.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without mutating the real CODEOWNERS file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-codeowners.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -86,15 +88,11 @@ EOF
 }
 
 @test "reports an error when the CODEOWNERS file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/does-not-exist"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --codeowners "$TMP_CO/does-not-exist"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository CODEOWNERS satisfies every rule" {

--- a/tests/scripts/dependency_review_workflow.bats
+++ b/tests/scripts/dependency_review_workflow.bats
@@ -5,6 +5,8 @@
 # workflow YAML in temporary directories so behaviour (exit codes, reported
 # failures) is verified end-to-end without mutating the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-dependency-review-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -128,15 +130,11 @@ PY
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository dependency-review workflow satisfies every rule" {

--- a/tests/scripts/gitleaks_workflow.bats
+++ b/tests/scripts/gitleaks_workflow.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without touching the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-gitleaks-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -161,15 +163,11 @@ EOF
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository gitleaks workflow satisfies every hardening rule" {

--- a/tests/scripts/markdown_lint_workflow.bats
+++ b/tests/scripts/markdown_lint_workflow.bats
@@ -5,6 +5,8 @@
 # workflow YAML in temporary directories so behaviour (exit codes, reported
 # failures) is verified end-to-end without mutating the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-markdown-lint-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -219,15 +221,11 @@ PY
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository markdown-lint workflow satisfies every rule" {

--- a/tests/scripts/milestone_branch_filter.bats
+++ b/tests/scripts/milestone_branch_filter.bats
@@ -5,6 +5,8 @@
 # in temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without depending on the real workflow file's state.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-milestone-branch-filter.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -98,15 +100,11 @@ EOF
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "the repository CI workflow gates milestone PRs" {

--- a/tests/scripts/neat_core_composite_action.bats
+++ b/tests/scripts/neat_core_composite_action.bats
@@ -5,6 +5,8 @@
 # fixtures in temporary directories, plus assertions against the real repo so
 # the enforced rule and the shipped files cannot drift apart.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-neat-core-composite-action.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -141,9 +143,7 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository satisfies the composite-action guard" {

--- a/tests/scripts/neat_core_version_gate.bats
+++ b/tests/scripts/neat_core_version_gate.bats
@@ -10,6 +10,8 @@
 # directory so behaviour (exit codes, messages) is verified end-to-end without
 # touching the real baseline file or the sibling clone.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-neat-core-version.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -159,9 +161,7 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository baseline matches the sibling neat-core when present" {

--- a/tests/scripts/persist_credentials.bats
+++ b/tests/scripts/persist_credentials.bats
@@ -6,6 +6,8 @@
 # repo security.yml so the enforced rule and the shipped workflow cannot drift
 # apart.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-persist-credentials.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -136,15 +138,11 @@ EOF
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository ci.yml disables credential persistence everywhere (Issue #378)" {

--- a/tests/scripts/prebuilt_tool_install.bats
+++ b/tests/scripts/prebuilt_tool_install.bats
@@ -6,6 +6,8 @@
 # synthetic workflow YAML, so the real workflows can change without coupling
 # the unit tests to their exact contents.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-prebuilt-tool-install.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -99,9 +101,7 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "validates a directory of canonical workflows" {

--- a/tests/scripts/readme_ci_alignment.bats
+++ b/tests/scripts/readme_ci_alignment.bats
@@ -6,6 +6,8 @@
 # directory exercise the pass/fail behaviour (exit codes, reported output) so
 # the real README is not mutated by the tests.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-readme-ci-alignment.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -118,9 +120,7 @@ EOF
 }
 
 @test "reports an error when the README file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/does-not-exist.md"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/does-not-exist.md"
 }
 
 @test "unknown flag prints usage and exits non-zero" {

--- a/tests/scripts/run_block_safety.bats
+++ b/tests/scripts/run_block_safety.bats
@@ -7,6 +7,8 @@
 # repository keeps every risk-bearing multi-line run: block under
 # `set -euo pipefail`.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-run-block-safety.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -142,15 +144,11 @@ EOF
 }
 
 @test "reports an error when the workflows directory does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/missing"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/missing"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository keeps every risk-bearing run: block safe" {

--- a/tests/scripts/rust_lints.bats
+++ b/tests/scripts/rust_lints.bats
@@ -5,6 +5,8 @@
 # fixtures in temporary directories so behaviour (exit codes, reported
 # failures) is verified end-to-end without mutating the real manifests.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-rust-lints.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -147,9 +149,7 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository manifest and lib satisfy every rule" {

--- a/tests/scripts/rust_toolchain.bats
+++ b/tests/scripts/rust_toolchain.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is verified
 # end-to-end without mutating the real rust-toolchain.toml file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-rust-toolchain.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -90,15 +92,11 @@ EOF
 }
 
 @test "reports an error when the file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --toolchain "$TMP_TC/does-not-exist.toml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --toolchain "$TMP_TC/does-not-exist.toml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository rust-toolchain.toml satisfies every rule" {

--- a/tests/scripts/sbom_workflow.bats
+++ b/tests/scripts/sbom_workflow.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without mutating the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-sbom-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -196,15 +198,11 @@ PY
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository SBOM workflow satisfies every rule" {

--- a/tests/scripts/security_policy.bats
+++ b/tests/scripts/security_policy.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without mutating the real SECURITY.md file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-security-policy.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -178,15 +180,11 @@ EOF
 }
 
 @test "reports an error when the policy file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --security-policy "$TMP_SEC/does-not-exist"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --security-policy "$TMP_SEC/does-not-exist"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository SECURITY.md satisfies every rule" {

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without mutating the real workflow file.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-semgrep-workflow.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -236,15 +238,11 @@ PY
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository semgrep workflow satisfies every rule" {

--- a/tests/scripts/shellcheck_dedup.bats
+++ b/tests/scripts/shellcheck_dedup.bats
@@ -6,6 +6,8 @@
 # verified end-to-end without mutating the real workflow files. Also asserts
 # the real repository keeps ShellCheck in exactly one workflow.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-shellcheck-dedup.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -126,15 +128,11 @@ EOF
 }
 
 @test "reports an error when the workflows directory does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/missing"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/missing"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository keeps ShellCheck in exactly one workflow" {

--- a/tests/scripts/spell_check.bats
+++ b/tests/scripts/spell_check.bats
@@ -5,6 +5,8 @@
 # behaviour (exit codes, reported typos, ignore list) is verified end-to-end
 # without touching the real repository content.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/spell-check.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -78,9 +80,7 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository passes the spell check" {

--- a/tests/scripts/test_helper.bash
+++ b/tests/scripts/test_helper.bash
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared BATS assertions for the guard-script CLI harness — Issue #512.
+#
+# Every `scripts/check-*.sh` validator sources `scripts/lib/check-harness.sh`
+# and therefore shares one CLI contract: a missing target exits non-zero with a
+# "not found" message, and an unknown flag exits non-zero after printing the
+# usage block. Those two contract tests were re-stated verbatim in 30-odd .bats
+# files; they now live here, so a change to the contract is a single edit.
+#
+# `run` exports `$status` and `$output` to the calling test, so a suite with a
+# stricter expectation can call the assertion and then add its own checks.
+#
+# Load from a .bats file with:  load 'test_helper'
+
+# assert_missing_target_rejected <script> [args...] — the shared not-found guard.
+assert_missing_target_rejected() {
+  run "$@"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+# assert_unknown_flag_rejected <script> — the shared unknown-flag contract.
+assert_unknown_flag_rejected() {
+  run "$1" --nonsense
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}

--- a/tests/scripts/version_increment.bats
+++ b/tests/scripts/version_increment.bats
@@ -3,6 +3,8 @@
 # Exercises the script with real temporary git repositories so behaviour
 # (exit codes, version strings, commit side-effects) is verified end-to-end.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/version-increment.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -114,7 +116,5 @@ teardown() {
 }
 
 @test "unknown flag prints usage" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }

--- a/tests/scripts/workflow_action_versions.bats
+++ b/tests/scripts/workflow_action_versions.bats
@@ -5,6 +5,8 @@
 # policy behaviour (exit codes, reported failures) is verified end-to-end
 # without relying on the real repo workflows staying static.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-workflow-action-versions.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -238,9 +240,7 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository workflows satisfy the Node 24 compat policy" {

--- a/tests/scripts/workflow_concurrency.bats
+++ b/tests/scripts/workflow_concurrency.bats
@@ -5,6 +5,8 @@
 # temporary directories so behaviour (exit codes, reported failures) is
 # verified end-to-end without mutating the real workflow files.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-workflow-concurrency.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -96,15 +98,11 @@ PY
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "every pile-up-prone repository workflow declares a concurrency group" {

--- a/tests/scripts/workflow_job_graph.bats
+++ b/tests/scripts/workflow_job_graph.bats
@@ -5,6 +5,8 @@
 # temporary directories, plus one assertion against the real repo workflow
 # so the enforced graph and the shipped workflow cannot drift apart.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-ci-job-graph.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -249,9 +251,7 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "real repository ci.yml satisfies the job graph rules" {

--- a/tests/scripts/workflow_neat_ai_core_path.bats
+++ b/tests/scripts/workflow_neat_ai_core_path.bats
@@ -5,6 +5,8 @@
 # directories so behaviour (exit codes, reported failures) is verified
 # end-to-end without touching the real .github/workflows tree.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-workflow-paths.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -149,9 +151,7 @@ EOF
 }
 
 @test "reports an error when the workflows directory does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/does-not-exist"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflows "$TMP_WF/does-not-exist"
 }
 
 @test "real repository workflows all satisfy the path strategy" {
@@ -163,7 +163,5 @@ EOF
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }

--- a/tests/scripts/workflow_timeouts.bats
+++ b/tests/scripts/workflow_timeouts.bats
@@ -6,6 +6,8 @@
 # repo workflows so the enforced rule and the shipped workflows cannot drift
 # apart.
 
+load 'test_helper'
+
 setup() {
   SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-workflow-timeouts.sh"
   [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
@@ -142,15 +144,11 @@ EOF
 }
 
 @test "reports an error when the workflow file does not exist" {
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not found"* ]]
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF_DIR/does-not-exist.yml"
 }
 
 @test "unknown flag prints usage and exits non-zero" {
-  run "$SCRIPT_UNDER_TEST" --nonsense
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage"* ]]
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
 }
 
 @test "every real repository workflow job declares a sane timeout" {


### PR DESCRIPTION
# PR Summary — Issue #512

## Summary

Every `scripts/check-*.sh` validator inlined the same ~50-line CLI harness: a
`usage()` heredoc, a `--FLAG PATH` / `-h` argument loop with `exit 2` on an
unknown flag, default-path resolution via `SCRIPT_DIR`, the "file not found"
guard, and the `EXIT_CODE`/`fail()`/`ok()` accumulate-and-report protocol. The
copies had already drifted — `fail()` existed in three different signatures
(`$WORKFLOW` interpolated, subject as `$1`, no subject at all).

That contract now lives once in **`scripts/lib/check-harness.sh`**, sourced by
**28 validators**. The per-script rule checks — the part that genuinely differs
— stay exactly where they were. The mirrored duplication in the test suite is
gone too: the two harness-contract tests re-stated in 30 `.bats` files now come
from **`tests/scripts/test_helper.bash`**.

Net effect across 64 files: **1,052 lines removed, 765 added** — and most of the
additions are the new harness, its 12 tests, and the CONTRIBUTING section.

Closes #512.

## What the harness owns

| Helper | Replaces |
| --- | --- |
| `parse_check_args <flag> <default> "$@"` | the copy-pasted `while`/`case` loop plus `SCRIPT_DIR` default resolution |
| `check_unknown_arg` / `check_flag_value` | `echo "Unknown argument…"; usage >&2; exit 2` and the missing-value guards |
| `check_require_file` / `check_require_dir` | `if [[ ! -f … ]]; then echo "… not found: …"; exit 2; fi` |
| `check_repo_path` | `"$SCRIPT_DIR/../<path>"` |
| `ok` / `fail` / `EXIT_CODE` | the three divergent report-protocol copies |
| `check_subject` | the per-script `FAIL $WORKFLOW:` prefix |

```mermaid
flowchart LR
    subgraph before["Before — ~30 copies"]
        V1["check-sbom-workflow.sh<br/>usage + argloop + guard + ok/fail"]
        V2["check-ci-permissions.sh<br/>usage + argloop + guard + ok/fail"]
        V3["…27 more"]
    end
    subgraph after["After"]
        H["scripts/lib/check-harness.sh<br/>argloop · guard · ok/fail"]
        W1["check-sbom-workflow.sh<br/>rule checks only"] -->|source| H
        W2["check-ci-permissions.sh<br/>rule checks only"] -->|source| H
        W3["…26 more"] -->|source| H
    end
    before -.->|Issue #512| after
```

### Deviation from the suggested fix

The issue suggested `ok`/`fail` take the subject as an argument. Two of the
three existing signatures do *not* have a single subject (`check-rust-lints.sh`
and `check-neat-core-composite-action.sh` name a different file in each
message), so forcing an argument would have changed their output and churned
244 call sites. Instead the subject is a harness variable set by
`check_subject` — one call per script, or `local CHECK_SUBJECT="$wf"` inside the
per-file loop of the three multi-file validators. That absorbs all three
variants with **byte-identical output** and no call-site churn.

No real per-caller branching emerged during extraction, so the issue stands as
fixed rather than closed-as-not-applicable.

## Evidence

This is a shell/CLI change with no web interface, so there is no screenshot.
Evidence is behavioural:

**1. Output is byte-identical before and after.** Each converted validator was
run from a `git worktree` at the pre-change commit and from the working tree,
with the repo root normalised; every one matched exactly (stdout, stderr and
exit code):

```text
$ for f in <all 28 converted validators>; do
    diff <(cd /tmp/base512 && ./scripts/$f.sh 2>&1 …) <(./scripts/$f.sh 2>&1 …)
  done
COMPARE_DONE          # no diffs
```

**2. The full BATS suite passes** — 533 tests, including the 12 new harness
tests:

```text
$ bats tests/scripts < /dev/null
1..533
exit=0
```

**3. The full local gate passes:**

```text
$ ./quality.sh < /dev/null
✅ All quality checks passed!
```

**4. CI's ShellCheck invocation is clean** (simulated locally with the exact
workflow flags — `SHELLCHECK_OPTS="-s bash" shellcheck --severity=warning`
over every `*.sh`): `CI_SHELLCHECK_OK`.

## Test Plan

### Added

- `tests/scripts/check_harness.bats` — 12 tests driving the harness end-to-end
  through throwaway validator scripts (behaviour, not source inspection):
  - default target resolves relative to the repo root;
  - an explicit flag overrides the default;
  - `--help` prints usage, exits 0;
  - an unknown flag names the argument, prints usage, exits 2;
  - a flag with no value fails with a message instead of an unbound-variable
    error under `set -u`;
  - a missing target exits 2 with a not-found message;
  - a satisfied rule prints `OK` on stdout and exits 0;
  - a violated rule prints `FAIL` on **stderr** and exits 1;
  - failures accumulate rather than aborting on the first;
  - an empty subject drops the prefix;
  - `check_require_dir` guards a missing directory;
  - an empty default leaves the target unset for caller-side resolution.
- `tests/scripts/test_helper.bash` — `assert_missing_target_rejected` and
  `assert_unknown_flag_rejected`, the two contract assertions that were
  re-stated verbatim in 30 suites.

### Modified

- 30 `.bats` files now `load 'test_helper'` and call the shared assertions
  instead of restating the two harness-contract tests. **No test was removed,
  disabled, or weakened** — the same script is invoked with the same arguments
  and the same assertions run; suites with stricter expectations keep their own
  extra checks (`run` exports `$status`/`$output` to the caller).

### Unchanged and still passing

All existing per-script rule tests (521 of the 533) pass untouched, which is
what pins the refactor: they exercise each validator's real behaviour against
fixture workflows.

## Files touched

- **New:** `scripts/lib/check-harness.sh`, `tests/scripts/check_harness.bats`,
  `tests/scripts/test_helper.bash`.
- **Converted (28):** `check-actionlint-workflow`, `check-auto-format-workflow`,
  `check-bot-push-token`, `check-cargo-audit-workflow`,
  `check-cargo-quality-workflow`, `check-ci-job-graph`, `check-ci-permissions`,
  `check-ci-push-trigger`, `check-codeowners`,
  `check-dependency-review-workflow`, `check-gitleaks-workflow`,
  `check-markdown-lint-workflow`, `check-milestone-branch-filter`,
  `check-neat-core-composite-action`, `check-persist-credentials`,
  `check-prebuilt-tool-install`, `check-push-step-hardening`,
  `check-run-block-safety`, `check-rust-lints`, `check-rust-toolchain`,
  `check-sbom-workflow`, `check-security-policy`, `check-semgrep-workflow`,
  `check-shellcheck-dedup`, `check-workflow-action-versions`,
  `check-workflow-concurrency`, `check-workflow-paths`,
  `check-workflow-timeouts`.
- **`quality.sh`** — runs `shellcheck -x` so the `# shellcheck source=` directive
  is followed and the harness is analysed in context. CI's own step uses
  `--severity=warning` and passes both with and without `-x`; no workflow change
  is needed (the worker has no `workflow` OAuth scope — see
  [Human escalation](../../../CONTRIBUTING.md#human-escalation)).
- **`CONTRIBUTING.md`** — new "Guard-script harness" subsection under
  [Local gate](../../../CONTRIBUTING.md#local-gate) with a Mermaid diagram and a
  worked template for writing a new validator.
- **`Cargo.lock`** — incidental `rust_scorer` version resync (1.1.48 → 1.1.49)
  produced by running the gate; no dependency change.

## Security self-check

- **Input validation** — `parse_check_args` rejects unknown flags (`exit 2`) and
  guards missing flag values, which previously tripped an unbound-variable error
  under `set -u`. Targets are validated with `check_require_file` /
  `check_require_dir` before use.
- **Injection surface** — no new shell interpolation of untrusted input; the
  harness quotes every expansion and adds no `eval`.
- **Secrets** — none staged; no hidden files outside the allowlist.
- **Error handling** — failures stay loud: `fail` writes to stderr and sets
  `EXIT_CODE=1`, guards exit 2, and no error path is swallowed.



## Milestone
This PR is part of the **Docs 20260804** milestone and targets the `milestone/docs-20260804` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msf84jnj-3b31f1`<!-- vibe-worker-issue-512 -->