### PR TITLE
Unify the least-privilege permissions rule in one helper (Issue #514)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.50"
+version = "1.1.51"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -1219,15 +1219,24 @@ spuriously. Issue #511 extracted it into a single helper,
 the acceptance rule (`vN` or a 40-character SHA, branch refs disallowed) now
 lives. The helper is covered by `tests/scripts/workflow_checks_lib.bats`.
 
+The least-privilege `permissions:` rule — the workflow declares a bare top-level
+`permissions:` key and grants `contents: read` — was the same story one step
+earlier: seven validators (the six above plus
+`check-semgrep-workflow.sh`) carried a byte-identical six-line `grep` pair, so
+any change to the acceptance rule needed seven identical edits. Issue #514
+extracted it into `require_readonly_permissions` in the same library, alongside
+the checkout rule.
+
 ```mermaid
 flowchart LR
-    L["scripts/lib/workflow-checks.sh<br/>require_pinned_checkout"]
+    L["scripts/lib/workflow-checks.sh<br/>require_pinned_checkout<br/>require_readonly_permissions"]
     A[check-actionlint-workflow.sh] --> L
     B[check-cargo-audit-workflow.sh] --> L
     C[check-cargo-quality-workflow.sh] --> L
     D[check-dependency-review-workflow.sh] --> L
     E[check-markdown-lint-workflow.sh] --> L
     F[check-sbom-workflow.sh] --> L
+    G["check-semgrep-workflow.sh<br/>(permissions rule only)"] --> L
 ```
 
 ## How to bench

--- a/docs/archive/pr-summaries/pr-summary-514.md
+++ b/docs/archive/pr-summaries/pr-summary-514.md
@@ -1,0 +1,72 @@
+# Unify the least-privilege permissions rule in one helper (Issue #514)
+
+## Summary
+
+The least-privilege permissions check — "the workflow declares a bare top-level
+`permissions:` key and grants `contents: read`" — was a byte-identical six-line
+`grep` pair in seven workflow validators. Every future change to the acceptance
+rule (recognising an inline one-liner form, tolerating an extra narrow scope,
+tightening the second grep so an unrelated indented `contents: read` cannot
+satisfy it) would have needed seven identical edits, or the validators would
+silently enforce different policies.
+
+Extracted `require_readonly_permissions <workflow>` into the existing shared
+`scripts/lib/workflow-checks.sh` — the library Issue #511 created for the
+`actions/checkout` pin rule — and replaced all seven copies with a single call.
+Semantics and the `OK`/`FAIL` message text are unchanged, so the per-validator
+BATS suites pass untouched. `check-semgrep-workflow.sh` was the only one of the
+seven not already sourcing the library; it now does.
+
+Closes #514.
+
+## Evidence
+
+Backend/CLI change with no web interface, so no screenshot. Evidence is the
+BATS suites: 10 new tests against the helper, plus the seven validators' own
+suites (94 tests) passing unchanged, and a clean `./quality.sh`.
+
+```mermaid
+flowchart LR
+    L["scripts/lib/workflow-checks.sh<br/>require_pinned_checkout<br/>require_readonly_permissions"]
+    A[check-actionlint-workflow.sh] --> L
+    B[check-cargo-audit-workflow.sh] --> L
+    C[check-cargo-quality-workflow.sh] --> L
+    D[check-dependency-review-workflow.sh] --> L
+    E[check-markdown-lint-workflow.sh] --> L
+    F[check-sbom-workflow.sh] --> L
+    G["check-semgrep-workflow.sh<br/>(permissions rule only)"] --> L
+```
+
+The helper keeps the two independent greps the inline copies used, and now
+documents that looseness in one place rather than seven — tightening it is a
+single edit.
+
+## Test Plan
+
+Ten tests added to `tests/scripts/workflow_checks_lib.bats`, each sourcing the
+library, defining the `ok`/`fail` contract and calling the helper against
+synthetic workflow YAML:
+
+- accepts a bare top-level block granting `contents: read`
+- rejects a job-level-only block (top-level key required)
+- fails when no `permissions:` block is declared
+- rejects the blanket `permissions: write-all` shorthand
+- fails when the block declares no `contents: read` scope
+- tolerates trailing whitespace after the bare key
+- reports exactly one `OK` line per call
+- fails loudly (exit 2) with no workflow argument, on an unreadable workflow,
+  and when the caller has not defined `ok`/`fail`
+
+The pre-existing `require_pinned_checkout` tests were kept as-is; their
+`run_helper` now delegates to a shared `run_lib` used by both helpers.
+
+Regression coverage for the seven call sites is the existing per-validator
+"fails when the permissions block is missing" test in each of
+`actionlint_workflow.bats`, `cargo_audit_workflow.bats`,
+`cargo_quality_workflow.bats`, `dependency_review_workflow.bats`,
+`markdown_lint_workflow.bats`, `sbom_workflow.bats` and
+`semgrep_workflow.bats` — all pass without modification, which is the proof
+that semantics did not change.
+
+`./quality.sh` passes cleanly (shellcheck, cargo-deny, fmt, clippy, build,
+test, rustdoc, release build).

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.51"
+version = "1.1.52"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-actionlint-workflow.sh
+++ b/scripts/check-actionlint-workflow.sh
@@ -24,8 +24,9 @@
 # `.github/workflows/actionlint.yml` relative to the repo root.
 set -euo pipefail
 
-# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
-# rule lives in one place instead of six inline copies that drift apart.
+# Shared workflow-validation helpers (Issues #511, #514) — the `actions/checkout`
+# pin rule and the least-privilege `permissions:` rule each live in one place
+# instead of inline copies that drift apart.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
 if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
@@ -95,13 +96,9 @@ else
   fail "workflow is not triggered on pull_request"
 fi
 
-# 2. Explicit permissions block (least privilege).
-if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
-  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
-  ok "permissions block grants only contents: read"
-else
-  fail "no 'permissions: contents: read' block — least-privilege required"
-fi
+# 2. Explicit permissions block (least privilege), via the shared rule in
+#    scripts/lib/workflow-checks.sh (Issue #514).
+require_readonly_permissions "$WORKFLOW"
 
 # 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
 #    shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs

--- a/scripts/check-cargo-audit-workflow.sh
+++ b/scripts/check-cargo-audit-workflow.sh
@@ -23,8 +23,9 @@
 # `.github/workflows/cargo-audit.yml` relative to the repo root.
 set -euo pipefail
 
-# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
-# rule lives in one place instead of six inline copies that drift apart.
+# Shared workflow-validation helpers (Issues #511, #514) — the `actions/checkout`
+# pin rule and the least-privilege `permissions:` rule each live in one place
+# instead of inline copies that drift apart.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
 if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
@@ -101,13 +102,9 @@ else
   fail "no schedule (cron) trigger — weekly audit run required"
 fi
 
-# 3. Explicit permissions block (least privilege).
-if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
-  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
-  ok "permissions block grants only contents: read"
-else
-  fail "no 'permissions: contents: read' block — least-privilege required"
-fi
+# 3. Explicit permissions block (least privilege), via the shared rule in
+#    scripts/lib/workflow-checks.sh (Issue #514).
+require_readonly_permissions "$WORKFLOW"
 
 # 4. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
 # shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs

--- a/scripts/check-cargo-quality-workflow.sh
+++ b/scripts/check-cargo-quality-workflow.sh
@@ -20,8 +20,9 @@
 # `.github/workflows/cargo-quality.yml` relative to the repo root.
 set -euo pipefail
 
-# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
-# rule lives in one place instead of six inline copies that drift apart.
+# Shared workflow-validation helpers (Issues #511, #514) — the `actions/checkout`
+# pin rule and the least-privilege `permissions:` rule each live in one place
+# instead of inline copies that drift apart.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
 if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
@@ -91,13 +92,9 @@ else
   fail "workflow is not triggered on pull_request"
 fi
 
-# 2. Explicit permissions block (least privilege).
-if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
-  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
-  ok "permissions block grants only contents: read"
-else
-  fail "no 'permissions: contents: read' block — least-privilege required"
-fi
+# 2. Explicit permissions block (least privilege), via the shared rule in
+#    scripts/lib/workflow-checks.sh (Issue #514).
+require_readonly_permissions "$WORKFLOW"
 
 # 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
 #    shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs

--- a/scripts/check-dependency-review-workflow.sh
+++ b/scripts/check-dependency-review-workflow.sh
@@ -29,8 +29,9 @@
 # `.github/workflows/dependency-review.yml` relative to the repo root.
 set -euo pipefail
 
-# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
-# rule lives in one place instead of six inline copies that drift apart.
+# Shared workflow-validation helpers (Issues #511, #514) — the `actions/checkout`
+# pin rule and the least-privilege `permissions:` rule each live in one place
+# instead of inline copies that drift apart.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
 if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
@@ -100,13 +101,9 @@ else
   fail "workflow is not triggered on pull_request"
 fi
 
-# 2. Explicit permissions block (least privilege).
-if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
-  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
-  ok "permissions block grants only contents: read"
-else
-  fail "no 'permissions: contents: read' block — least-privilege required"
-fi
+# 2. Explicit permissions block (least privilege), via the shared rule in
+#    scripts/lib/workflow-checks.sh (Issue #514).
+require_readonly_permissions "$WORKFLOW"
 
 # 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
 # shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs

--- a/scripts/check-markdown-lint-workflow.sh
+++ b/scripts/check-markdown-lint-workflow.sh
@@ -15,8 +15,9 @@
 # `.github/workflows/markdown-lint.yml` relative to the repo root.
 set -euo pipefail
 
-# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
-# rule lives in one place instead of six inline copies that drift apart.
+# Shared workflow-validation helpers (Issues #511, #514) — the `actions/checkout`
+# pin rule and the least-privilege `permissions:` rule each live in one place
+# instead of inline copies that drift apart.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
 if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
@@ -86,13 +87,9 @@ else
   fail "workflow is not triggered on pull_request"
 fi
 
-# 2. Explicit permissions block (least privilege).
-if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
-  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
-  ok "permissions block grants only contents: read"
-else
-  fail "no 'permissions: contents: read' block — least-privilege required"
-fi
+# 2. Explicit permissions block (least privilege), via the shared rule in
+#    scripts/lib/workflow-checks.sh (Issue #514).
+require_readonly_permissions "$WORKFLOW"
 
 # 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
 #    shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs

--- a/scripts/check-sbom-workflow.sh
+++ b/scripts/check-sbom-workflow.sh
@@ -24,8 +24,9 @@
 # `.github/workflows/sbom.yml` relative to the repo root.
 set -euo pipefail
 
-# Shared workflow-validation helpers (Issue #511) — the `actions/checkout` pin
-# rule lives in one place instead of six inline copies that drift apart.
+# Shared workflow-validation helpers (Issues #511, #514) — the `actions/checkout`
+# pin rule and the least-privilege `permissions:` rule each live in one place
+# instead of inline copies that drift apart.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
 if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
@@ -95,13 +96,9 @@ else
   fail "no build trigger — pull_request, push, release or workflow_dispatch required"
 fi
 
-# 2. Explicit permissions block (least privilege).
-if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
-  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
-  ok "permissions block grants only contents: read"
-else
-  fail "no 'permissions: contents: read' block — least-privilege required"
-fi
+# 2. Explicit permissions block (least privilege), via the shared rule in
+#    scripts/lib/workflow-checks.sh (Issue #514).
+require_readonly_permissions "$WORKFLOW"
 
 # 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
 #    shared rule in scripts/lib/workflow-checks.sh (Issue #511).

--- a/scripts/check-semgrep-workflow.sh
+++ b/scripts/check-semgrep-workflow.sh
@@ -30,6 +30,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/check-harness.sh
 source "$SCRIPT_DIR/lib/check-harness.sh"
+# Shared workflow-validation helpers (Issues #511, #514).
+WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
+if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
+  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
+  exit 2
+fi
+# shellcheck source=lib/workflow-checks.sh disable=SC1091
+source "$WORKFLOW_CHECKS_LIB"
 
 usage() {
   cat <<'EOF'
@@ -59,13 +67,9 @@ else
   fail "workflow is not triggered on pull_request"
 fi
 
-# 2. Explicit permissions block (least privilege).
-if grep -qE '^permissions:[[:space:]]*$' "$WORKFLOW" \
-  && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$WORKFLOW"; then
-  ok "permissions block grants only contents: read"
-else
-  fail "no 'permissions: contents: read' block — least-privilege required"
-fi
+# 2. Explicit permissions block (least privilege), via the shared rule in
+#    scripts/lib/workflow-checks.sh (Issue #514).
+require_readonly_permissions "$WORKFLOW"
 
 # 3. Semgrep entry point: either pinned container image OR pinned action.
 container_line="$(grep -nE '^[[:space:]]+image:[[:space:]]*semgrep/semgrep' "$WORKFLOW" || true)"

--- a/scripts/lib/workflow-checks.sh
+++ b/scripts/lib/workflow-checks.sh
@@ -1,4 +1,4 @@
-# Shared workflow-validation helpers (Issue #511).
+# Shared workflow-validation helpers (Issues #511, #514).
 #
 # Sourced by the per-workflow validators under `scripts/`. It carries rules that
 # every one of them enforces identically, so a change to the rule is a change to
@@ -62,5 +62,41 @@ require_pinned_checkout() {
     fail "actions/checkout is not pinned — branch refs disallowed: ${unpinned[*]}"
   else
     ok "actions/checkout pinned to a numeric major or 40-char SHA"
+  fi
+}
+
+# require_readonly_permissions <workflow>
+#
+# The least-privilege rule (Issue #514): the workflow declares a bare top-level
+# `permissions:` key and grants `contents: read` beneath it. A bare key is
+# required so the blanket `permissions: write-all` shorthand is rejected — an
+# inline `permissions: {contents: read}` one-liner is not accepted either, and
+# no workflow in this repo uses one.
+#
+# Known looseness, deliberately kept when the seven inline copies were unified:
+# the two greps are independent, so an indented `contents: read` anywhere in the
+# file satisfies the second one. Tightening it to "inside the top-level block"
+# is now a single edit here.
+require_readonly_permissions() {
+  local workflow="${1:-}"
+
+  if [[ -z "$workflow" ]]; then
+    echo "require_readonly_permissions: a workflow path argument is required" >&2
+    return 2
+  fi
+  if [[ ! -r "$workflow" ]]; then
+    echo "require_readonly_permissions: workflow not readable: $workflow" >&2
+    return 2
+  fi
+  if ! declare -F ok >/dev/null || ! declare -F fail >/dev/null; then
+    echo "require_readonly_permissions: caller must define ok() and fail() first" >&2
+    return 2
+  fi
+
+  if grep -qE '^permissions:[[:space:]]*$' "$workflow" \
+    && grep -qE '^[[:space:]]+contents:[[:space:]]*read' "$workflow"; then
+    ok "permissions block grants only contents: read"
+  else
+    fail "no 'permissions: contents: read' block — least-privilege required"
   fi
 }

--- a/tests/scripts/workflow_checks_lib.bats
+++ b/tests/scripts/workflow_checks_lib.bats
@@ -1,11 +1,12 @@
 #!/usr/bin/env bats
-# Tests for scripts/lib/workflow-checks.sh — Issue #511.
+# Tests for scripts/lib/workflow-checks.sh — Issues #511, #514.
 #
 # The `actions/checkout` pin-acceptance rule used to be re-implemented inline in
 # six workflow validators and had drifted into three generations of the regex.
-# These tests exercise the single shared helper directly: a caller sources the
-# library, defines the `ok`/`fail` reporting contract, and calls
-# `require_pinned_checkout` against synthetic workflow YAML.
+# The least-privilege `permissions:` rule was a byte-identical copy in seven of
+# them (Issue #514). These tests exercise the single shared helpers directly: a
+# caller sources the library, defines the `ok`/`fail` reporting contract, and
+# calls the helper against synthetic workflow YAML.
 
 setup() {
   LIB="${BATS_TEST_DIRNAME}/../../scripts/lib/workflow-checks.sh"
@@ -28,18 +29,31 @@ jobs:
 EOF
 }
 
-# Run require_pinned_checkout in a subshell that provides the ok/fail contract
-# the six validators define, mirroring how they call the helper.
-run_helper() {
+# Run a helper in a subshell that provides the ok/fail contract the validators
+# define, mirroring how they call it.
+run_lib() {
   run bash -c '
     set -euo pipefail
     EXIT_CODE=0
     fail() { echo "FAIL: $*" >&2; EXIT_CODE=1; }
     ok()   { echo "OK   : $*"; }
     source "$1"
-    require_pinned_checkout "$2"
+    "$2" "$3"
     exit "$EXIT_CODE"
-  ' bash "$LIB" "$1"
+  ' bash "$LIB" "$1" "$2"
+}
+
+run_helper() {
+  run_lib require_pinned_checkout "$1"
+}
+
+run_permissions_helper() {
+  run_lib require_readonly_permissions "$1"
+}
+
+# Write a workflow whose body is $1, used for the permissions cases.
+write_workflow() {
+  printf '%s\n' "$1" >"$TMP_WF/wf.yml"
 }
 
 @test "accepts a numeric major version pin" {
@@ -176,6 +190,118 @@ EOF
     set -uo pipefail
     source "$1"
     require_pinned_checkout "$2"
+  ' bash "$LIB" "$TMP_WF/wf.yml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"ok()"* ]]
+}
+
+# --- require_readonly_permissions (Issue #514) --------------------------------
+
+@test "permissions: accepts a bare block granting contents: read" {
+  write_workflow 'name: Example
+permissions:
+  contents: read
+jobs:
+  build:
+    steps:
+      - run: echo hello'
+  run_permissions_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+}
+
+@test "permissions: rejects a job-level-only block (top-level key required)" {
+  write_workflow 'name: Example
+jobs:
+  build:
+    permissions:
+      contents: read
+    steps:
+      - run: echo hello'
+  run_permissions_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"least-privilege required"* ]]
+}
+
+@test "permissions: fails when no permissions block is declared" {
+  write_workflow 'name: Example
+jobs:
+  build:
+    steps:
+      - run: echo hello'
+  run_permissions_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no 'permissions: contents: read' block"* ]]
+  [[ "$output" == *"least-privilege required"* ]]
+}
+
+@test "permissions: rejects the blanket write-all shorthand" {
+  write_workflow 'name: Example
+permissions: write-all
+jobs:
+  build:
+    steps:
+      - run: echo hello'
+  run_permissions_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"least-privilege required"* ]]
+}
+
+@test "permissions: fails when the block declares no contents: read scope" {
+  write_workflow 'name: Example
+permissions:
+  issues: write
+jobs:
+  build:
+    steps:
+      - run: echo hello'
+  run_permissions_helper "$TMP_WF/wf.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"least-privilege required"* ]]
+}
+
+@test "permissions: tolerates trailing whitespace after the bare key" {
+  printf 'name: Example\npermissions:   \n  contents: read\n' >"$TMP_WF/wf.yml"
+  run_permissions_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"permissions block grants only contents: read"* ]]
+}
+
+@test "permissions: reports exactly one line per call" {
+  write_workflow 'name: Example
+permissions:
+  contents: read'
+  run_permissions_helper "$TMP_WF/wf.yml"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 1 ]
+}
+
+@test "permissions: fails loudly when called without a workflow argument" {
+  run bash -c '
+    set -uo pipefail
+    fail() { :; }
+    ok() { :; }
+    source "$1"
+    require_readonly_permissions
+  ' bash "$LIB"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"workflow path"* ]]
+}
+
+@test "permissions: fails loudly when the workflow file is unreadable" {
+  run_permissions_helper "$TMP_WF/does-not-exist.yml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not readable"* ]]
+}
+
+@test "permissions: fails loudly when the caller has not defined ok/fail" {
+  write_workflow 'name: Example
+permissions:
+  contents: read'
+  run bash -c '
+    set -uo pipefail
+    source "$1"
+    require_readonly_permissions "$2"
   ' bash "$LIB" "$TMP_WF/wf.yml"
   [ "$status" -eq 2 ]
   [[ "$output" == *"ok()"* ]]


### PR DESCRIPTION
# Unify the least-privilege permissions rule in one helper (Issue #514)

## Summary

The least-privilege permissions check — "the workflow declares a bare top-level
`permissions:` key and grants `contents: read`" — was a byte-identical six-line
`grep` pair in seven workflow validators. Every future change to the acceptance
rule (recognising an inline one-liner form, tolerating an extra narrow scope,
tightening the second grep so an unrelated indented `contents: read` cannot
satisfy it) would have needed seven identical edits, or the validators would
silently enforce different policies.

Extracted `require_readonly_permissions <workflow>` into the existing shared
`scripts/lib/workflow-checks.sh` — the library Issue #511 created for the
`actions/checkout` pin rule — and replaced all seven copies with a single call.
Semantics and the `OK`/`FAIL` message text are unchanged, so the per-validator
BATS suites pass untouched. `check-semgrep-workflow.sh` was the only one of the
seven not already sourcing the library; it now does.

Closes #514.

## Evidence

Backend/CLI change with no web interface, so no screenshot. Evidence is the
BATS suites: 10 new tests against the helper, plus the seven validators' own
suites (94 tests) passing unchanged, and a clean `./quality.sh`.

```mermaid
flowchart LR
    L["scripts/lib/workflow-checks.sh<br/>require_pinned_checkout<br/>require_readonly_permissions"]
    A[check-actionlint-workflow.sh] --> L
    B[check-cargo-audit-workflow.sh] --> L
    C[check-cargo-quality-workflow.sh] --> L
    D[check-dependency-review-workflow.sh] --> L
    E[check-markdown-lint-workflow.sh] --> L
    F[check-sbom-workflow.sh] --> L
    G["check-semgrep-workflow.sh<br/>(permissions rule only)"] --> L
```

The helper keeps the two independent greps the inline copies used, and now
documents that looseness in one place rather than seven — tightening it is a
single edit.

## Test Plan

Ten tests added to `tests/scripts/workflow_checks_lib.bats`, each sourcing the
library, defining the `ok`/`fail` contract and calling the helper against
synthetic workflow YAML:

- accepts a bare top-level block granting `contents: read`
- rejects a job-level-only block (top-level key required)
- fails when no `permissions:` block is declared
- rejects the blanket `permissions: write-all` shorthand
- fails when the block declares no `contents: read` scope
- tolerates trailing whitespace after the bare key
- reports exactly one `OK` line per call
- fails loudly (exit 2) with no workflow argument, on an unreadable workflow,
  and when the caller has not defined `ok`/`fail`

The pre-existing `require_pinned_checkout` tests were kept as-is; their
`run_helper` now delegates to a shared `run_lib` used by both helpers.

Regression coverage for the seven call sites is the existing per-validator
"fails when the permissions block is missing" test in each of
`actionlint_workflow.bats`, `cargo_audit_workflow.bats`,
`cargo_quality_workflow.bats`, `dependency_review_workflow.bats`,
`markdown_lint_workflow.bats`, `sbom_workflow.bats` and
`semgrep_workflow.bats` — all pass without modification, which is the proof
that semantics did not change.

`./quality.sh` passes cleanly (shellcheck, cargo-deny, fmt, clippy, build,
test, rustdoc, release build).



## Milestone
This PR is part of the **Docs 20260804** milestone and targets the `milestone/docs-20260804` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msf84jnj-3b31f1`<!-- vibe-worker-issue-514 -->