### PR TITLE
Bulk little-endian unpack via copy_nonoverlapping (#539)

### DIFF
--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.55"
+version = "1.1.56"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/benches/scoring.rs
+++ b/rust_scorer/benches/scoring.rs
@@ -413,10 +413,9 @@ fn bench_score_from_creature_dir(c: &mut Criterion) {
 
 /// Local copy of the production unpack inner loop. Kept in this bench file so
 /// the micro-bench does not require widening the crate's public surface; the
-/// implementation matches `multi_score::unpack_f32s_le` and
-/// `stream_score::unpack_f32s_le` byte-for-byte (single-source-of-truth lives
-/// in those modules; this duplicate is documented and exists only inside the
-/// bench harness).
+/// implementation matches [`crate::stream_io::unpack_f32s_le`] byte-for-byte
+/// (single-source-of-truth lives there; this duplicate is documented and exists
+/// only inside the bench harness).
 fn unpack_f32s_le_bench(src: &[u8], dst: &mut Vec<f32>, n: usize) {
     debug_assert_eq!(src.len(), n * 4);
     dst.clear();
@@ -427,14 +426,11 @@ fn unpack_f32s_le_bench(src: &[u8], dst: &mut Vec<f32>, n: usize) {
     #[cfg(target_endian = "little")]
     {
         // SAFETY: `src.len() == n * 4`, capacity ≥ `n` after the reserve above;
-        // every element [0, n) is initialised before `set_len(n)`.
+        // little-endian bulk copy is bit-identical to per-element `from_bits`
+        // (Issue #539). Source and destination do not overlap.
         unsafe {
-            let out_ptr = dst.as_mut_ptr();
-            let p = src.as_ptr();
-            for i in 0..n {
-                let bits = p.add(i * 4).cast::<u32>().read_unaligned();
-                out_ptr.add(i).write(f32::from_bits(bits));
-            }
+            let out_ptr = dst.as_mut_ptr().cast::<u8>();
+            std::ptr::copy_nonoverlapping(src.as_ptr(), out_ptr, n * 4);
             dst.set_len(n);
         }
     }

--- a/rust_scorer/src/stream_io.rs
+++ b/rust_scorer/src/stream_io.rs
@@ -23,8 +23,11 @@ pub(crate) fn reserve_unpack_capacity(buf: &mut Vec<f32>, n: usize) {
     }
 }
 
-/// Decode little-endian `f32` bytes. On little-endian hosts, one unaligned `u32`
-/// load per float; otherwise `from_le_bytes`.
+/// Decode little-endian `f32` bytes into `dst`.
+///
+/// On little-endian hosts the bit pattern is already native `f32`, so the
+/// decode is a bulk `copy_nonoverlapping` (Issue #539) rather than a per-float
+/// load/`from_bits` loop. Big-endian hosts still convert via `from_le_bytes`.
 ///
 /// # Panics
 /// Panics if `src.len() != n * 4`. This check runs in both debug and release
@@ -45,14 +48,12 @@ pub(crate) fn unpack_f32s_le(src: &[u8], dst: &mut Vec<f32>, n: usize) {
     #[cfg(target_endian = "little")]
     {
         // SAFETY: `src.len() == n * 4`, capacity ≥ `n` after `reserve_unpack_capacity`;
-        // we initialise all `n` elements before `set_len(n)`.
+        // on little-endian hosts each 4-byte group is already a native `f32` bit
+        // pattern, so a bulk copy is bit-identical to per-element `from_bits`
+        // (Issue #539). Source and destination do not overlap.
         unsafe {
-            let out_ptr = dst.as_mut_ptr();
-            let p = src.as_ptr();
-            for i in 0..n {
-                let bits = p.add(i * 4).cast::<u32>().read_unaligned();
-                out_ptr.add(i).write(f32::from_bits(bits));
-            }
+            let out_ptr = dst.as_mut_ptr().cast::<u8>();
+            std::ptr::copy_nonoverlapping(src.as_ptr(), out_ptr, n * 4);
             dst.set_len(n);
         }
     }


### PR DESCRIPTION
## Summary

- Replace the per-float LE unpack loop in `stream_io::unpack_f32s_le` with `ptr::copy_nonoverlapping` (bit-identical on little-endian hosts).
- Keep the Issue #103 `src.len() == n * 4` assertion and the big-endian `from_le_bytes` arm unchanged.
- Mirror the same change in the Criterion bench duplicate so microbenches stay aligned.
- Did **not** pursue the zero-copy `bytemuck` variant — plain memcpy cleared the bar (per issue guidance).

## Production A/B (acceptance gate ≥ 1–2%)

| Axis | Value |
|---|---|
| Creature | Deep production JSON (~2511 in / ~1606 hidden) |
| Pool | N=50 randomly perturbed weight/bias variants |
| Corpus | Full ≈22 GiB `.trainData-binary_116` |
| GPU | off |
| Method | Interleaved before/after release binaries, 5 pairs, warm cache |

| Pair | Before (s) | After (s) |
|---:|---:|---:|
| 1 | 255.39 | 257.69 |
| 2 | 263.03 | 259.45 |
| 3 | 266.76 | 248.69 |
| 4 | 250.80 | 239.05 |
| 5 | 252.06 | 244.03 |
| **median** | **255.39** | **248.69** |

**+2.62%** median wall-clock. Error vectors bit-identical (`max_abs_diff=0`).

Closes #539.

## Test plan

- [x] `cargo test -p rust_scorer --lib unpack_f32s_le`
- [x] Production N=50 interleaved CLI A/B
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)