### PR TITLE
fix(ci): sync Cargo.lock to latest neat-core on every PR (#542)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,9 +1,14 @@
-# Auto-format PR job (Issue #19).
+# Auto-format / PR housekeeping job (Issues #19, #542).
 #
 # Runs on pull requests targeting Develop or a milestone/* branch. Applies
-# `cargo fmt --all` on the PR branch; if the working tree changes, the fix
-# is committed and pushed back. Re-running on a clean branch is a no-op,
-# so the job is safe/idempotent.
+# `cargo fmt --all` and refreshes `Cargo.lock` against the checked-out
+# NEAT-AI-core path dependency (`cargo update -p neat-core`) so workers stop
+# reprinting `Updating neat-core vX -> vY` after every fetch. If the working
+# tree changes, the fix is committed and pushed back. Re-running on a clean
+# branch is a no-op, so the job is safe/idempotent.
+#
+# Deliberately does NOT bump `neat-core.expected-version` — the Issue #252
+# breaking-bump gate stays a human acknowledgement.
 #
 # Permissions are scoped to the minimum: `contents: write` to push the
 # rustfmt commit. `pull-requests: read` is sufficient for the workflow's
@@ -72,10 +77,21 @@ jobs:
           set -euo pipefail
           cargo fmt --all
 
+      # Refresh Cargo.lock against the sibling neat-core path dependency
+      # (Issue #542). Without this, every worker `cargo build` rewrites the
+      # lock locally and `model_fetch` hard-resets it on the next run.
+      # Scoped to `-p neat-core` so crates.io quarantine / weekly bump policy
+      # is untouched — only the path-dep version (and the workspace member
+      # version Cargo rewrites alongside it) moves.
+      - name: Sync Cargo.lock to latest neat-core
+        run: |
+          set -euo pipefail
+          cargo update -p neat-core
+
       # Resolve the commit message here, not in the push step below: the
       # helper is PR-head code, so running it alongside $GH_PAT would hand
       # the org PAT straight to an attacker-editable script (Issue #497).
-      - name: Detect formatting changes
+      - name: Detect formatting / lockfile changes
         id: detect
         run: |
           set -euo pipefail
@@ -122,7 +138,7 @@ jobs:
       # repository hooks (a planted `.git/hooks/pre-commit` would otherwise run
       # with $GH_PAT in scope), and no repository script is executed here.
       # Enforced by `scripts/check-push-step-hardening.sh`.
-      - name: Commit and push rustfmt fixes
+      - name: Commit and push rustfmt / lock sync fixes
         if: steps.detect.outputs.changed == 'true'
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ section to the released version with its date.
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR auto-format syncs `Cargo.lock` to latest neat-core (Issue #542).** The
+  auto-format job now runs `cargo update -p neat-core` after `cargo fmt`, so
+  every PR refreshes the path-dependency lock entry against the checked-out
+  NEAT-AI-core `Develop`. That stops workers reprinting
+  `Updating neat-core vX -> vY` after every `model_fetch` hard-reset of a
+  stale lock. The Issue #252 `neat-core.expected-version` gate is unchanged
+  (still deliberate). This PR also acknowledges neat-core `0.9.0` in the
+  baseline and commits the matching lock sync.
+
 ### Added
 
 - **Parallel training-data file reads (Issue #529).** The forward-only fused

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.56"
+version = "1.1.57"
 dependencies = [
  "bytemuck",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.8.12"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.54"
+version = "1.1.56"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -979,15 +979,20 @@ lives in `scripts/version-increment.sh` and is covered by
 short-lived repo-scoped installation token (see below) so the follow-on PR
 checks run without an "Approve and run" gate (Issue #435).
 
-PRs also run an auto-format job (`.github/workflows/auto-format.yml`,
-Issue #19). The job runs `cargo fmt --all` on the PR branch; if the working
-tree changes, the formatting fix is committed with a deterministic message
-and pushed back. When there are no changes the commit step is skipped, so
-re-running on a clean branch is a no-op. Change detection and the commit
-message live in `scripts/auto-format.sh` and are covered by
-`tests/scripts/auto_format.bats`; the workflow itself is validated by
-`scripts/check-auto-format-workflow.sh` (invoked from `quality.sh`). The same
-bot-push token pattern applies here (Issue #435).
+PRs also run an auto-format / housekeeping job
+(`.github/workflows/auto-format.yml`, Issues #19 and #542). The job runs
+`cargo fmt --all` and then `cargo update -p neat-core` so `Cargo.lock`
+tracks the checked-out NEAT-AI-core path dependency (workers otherwise
+rewrite the lock on every `cargo build` and `model_fetch` resets it). If the
+working tree changes, the fix is committed with a deterministic message and
+pushed back. When there are no changes the commit step is skipped, so
+re-running on a clean branch is a no-op. The job deliberately does **not**
+bump `neat-core.expected-version` — the Issue #252 breaking-bump gate stays a
+human acknowledgement. Change detection and the commit message live in
+`scripts/auto-format.sh` and are covered by `tests/scripts/auto_format.bats`;
+the workflow itself is validated by `scripts/check-auto-format-workflow.sh`
+(invoked from `quality.sh`). The same bot-push token pattern applies here
+(Issue #435).
 
 #### Bot-push credential — repo-scoped installation token (Issue #498)
 

--- a/docs/archive/pr-summaries/pr-summary-542.md
+++ b/docs/archive/pr-summaries/pr-summary-542.md
@@ -1,0 +1,30 @@
+# PR summary — Issue #542
+
+## Problem
+
+GRQ workers repeatedly printed `Updating neat-core v0.8.12 -> v0.9.0` even when
+`model_fetch` skipped the NEAT-AI-core git update. Cause: `NEAT-AI-scorer`'s
+committed `Cargo.lock` lagged the sibling path dependency. Every
+`ensure_neat_ai_native_scorer` `cargo build` rewrote the lock locally; the next
+`model_fetch` hard-reset restored the stale lock.
+
+PR automation already ran rustfmt (#19) and the guarded version bump (#20), but
+never refreshed `Cargo.lock` against latest NEAT-AI-core `Develop`.
+
+## Fix
+
+1. Extend `.github/workflows/auto-format.yml` to run
+   `cargo update -p neat-core` after `cargo fmt --all`, then commit/push when
+   the tracked tree is dirty (same ACTIONS_PUSH / App-token pattern).
+2. Teach `scripts/check-auto-format-workflow.sh` + BATS to require that step.
+3. Acknowledge neat-core `0.9.0` in `neat-core.expected-version` (SOA hot-synapse
+   API break is unused by scorer) and commit the matching `Cargo.lock` sync.
+
+Deliberately does **not** auto-bump `neat-core.expected-version` on every PR —
+the Issue #252 breaking-bump gate stays a human acknowledgement.
+
+## Maintainer note (workflow YAML)
+
+This PR edits `.github/workflows/auto-format.yml`. If the automation worker
+cannot push workflow changes, a maintainer must merge (or apply) that YAML
+diff. See CONTRIBUTING.md "Human escalation".

--- a/docs/archive/pr-summaries/pr-summary-542.md
+++ b/docs/archive/pr-summaries/pr-summary-542.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-GRQ workers repeatedly printed `Updating neat-core v0.8.12 -> v0.9.0` even when
+Workers repeatedly printed `Updating neat-core v0.8.12 -> v0.9.0` even when
 `model_fetch` skipped the NEAT-AI-core git update. Cause: `NEAT-AI-scorer`'s
 committed `Cargo.lock` lagged the sibling path dependency. Every
 `ensure_neat_ai_native_scorer` `cargo build` rewrote the lock locally; the next

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -42,4 +42,13 @@
 # rust_scorer` and the full scorer test suite (303 tests) passing against the
 # sibling neat-core at 0.8.1, plus a repo-wide grep confirming no reference to
 # any removed symbol.
-0.8.1
+#
+# 0.8.1 -> 0.9.0: acknowledge the neat-core #533 / #537 struct-of-arrays hot
+# synapse view. BREAKING CHANGE is confined to
+# `weighted_sum_interleaved` / `weighted_sum_interleaved_8` signatures and
+# `CompiledNetwork` struct-literal construction (`hot_weights` / `hot_from`).
+# rust_scorer never calls those entry points and never constructs
+# `CompiledNetwork` via struct literal — every fixture goes through
+# `compile_creature` — so no scorer code change is required. Verified by a
+# clean `cargo check -p rust_scorer` against sibling neat-core 0.9.0.
+0.9.0

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.56"
+version = "1.1.57"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/auto-format.sh
+++ b/scripts/auto-format.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
-# Auto-format helper for the CI PR job (Issue #19).
+# Auto-format / PR housekeeping helper for the CI PR job (Issues #19, #542).
 #
 # Responsibilities:
 #   * Emit the deterministic commit message the workflow uses when pushing
-#     rustfmt-generated fixes back onto a PR branch.
+#     rustfmt and/or Cargo.lock sync fixes back onto a PR branch.
 #   * Detect whether the working tree has pending changes after `cargo fmt`
-#     ran, so the workflow can commit only when needed (idempotent guard).
+#     and `cargo update -p neat-core` ran, so the workflow can commit only
+#     when needed (idempotent guard).
 #
 # Running cargo is the workflow's job — this script does not invoke any
 # build tooling, which keeps the BATS suite hermetic (no Rust toolchain
 # required in the bash helper tests).
 set -euo pipefail
 
-COMMIT_MESSAGE="chore(fmt): apply rustfmt fixes
+COMMIT_MESSAGE="chore(fmt): apply rustfmt and sync neat-core lock
 
-Automated by the auto-format PR job (rustfmt via cargo fmt) — see issue #19."
+Automated by the auto-format PR job (rustfmt via cargo fmt; Cargo.lock
+synced to the checked-out NEAT-AI-core path dependency via
+\`cargo update -p neat-core\`) — see issues #19 and #542."
 
 usage() {
   cat <<'EOF'
@@ -70,15 +73,16 @@ case "$MODE" in
 
   check-changes)
     # Only inspect changes to tracked files. Untracked paths (lines starting
-    # with '??') are excluded because cargo fmt cannot modify files that are
-    # not part of the tracked working tree — e.g. path-dependency repos
-    # checked out alongside the workspace (such as NEAT-AI-core/).
+    # with '??') are excluded because cargo fmt / cargo update cannot modify
+    # files that are not part of the tracked working tree — e.g. path-
+    # dependency repos checked out alongside the workspace (such as
+    # NEAT-AI-core/).
     status_output="$(cd "$REPO_DIR" && git status --porcelain | grep -v '^??' || true)"
     if [[ -z "$status_output" ]]; then
-      echo "clean: no formatting changes detected"
+      echo "clean: no formatting or lockfile changes detected"
       exit 1
     else
-      echo "dirty: formatting changes detected"
+      echo "dirty: formatting or lockfile changes detected"
       exit 0
     fi
     ;;

--- a/scripts/check-auto-format-workflow.sh
+++ b/scripts/check-auto-format-workflow.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
-# Validate the auto-format PR workflow (Issue #19).
+# Validate the auto-format PR workflow (Issues #19, #542).
 #
 # The auto-format workflow must:
-#   1. Run on `pull_request` events only — formatting fixes push back to
-#      the PR branch, which is meaningless for `push` / scheduled events.
+#   1. Run on `pull_request` events only — formatting / lock fixes push back
+#      to the PR branch, which is meaningless for `push` / scheduled events.
 #   2. Declare minimal permissions: `contents: write` is required to push,
 #      nothing beyond what the job needs should be granted (in particular
 #      not `write-all` or scopes the workflow doesn't use).
 #   3. Invoke `cargo fmt --all` to produce the formatting fixes.
-#   4. Gate the commit/push step behind a change-detection output so the
+#   4. Invoke `cargo update -p neat-core` so Cargo.lock tracks the checked-
+#      out NEAT-AI-core path dependency (Issue #542).
+#   5. Gate the commit/push step behind a change-detection output so the
 #      job is idempotent — re-running on a clean branch is a no-op.
-#   5. Refuse to push onto a fork's PR branch (the GITHUB_TOKEN cannot
+#   6. Refuse to push onto a fork's PR branch (the GITHUB_TOKEN cannot
 #      write there anyway; skipping keeps failure messages tidy).
-#   6. Authenticate the push with the org-level ACTIONS_PUSH PAT (with
+#   7. Authenticate the push with the org-level ACTIONS_PUSH PAT (with
 #      GITHUB_TOKEN fallback) so bot `synchronize` events re-trigger PR
 #      checks without the "Approve and run" gate (Issue #435).
 set -euo pipefail
@@ -65,7 +67,16 @@ else
   fail "no 'cargo fmt --all' invocation"
 fi
 
-# 4. Change-detection guard on the commit/push step. We look for a step that
+# 4. neat-core lock sync present (Issue #542). Scoped `-p neat-core` keeps
+#    crates.io bumps on the quarantine / weekly path; only the path-dep
+#    version (and the workspace member version Cargo rewrites with it) moves.
+if grep -qE 'cargo[[:space:]]+update[[:space:]]+-p[[:space:]]+neat-core' "$WORKFLOW"; then
+  ok "cargo update -p neat-core lock sync present"
+else
+  fail "no 'cargo update -p neat-core' — PRs will leave Cargo.lock lagging NEAT-AI-core (Issue #542)"
+fi
+
+# 5. Change-detection guard on the commit/push step. We look for a step that
 #    declares `if:` and references the detection output — the specific id
 #    name is flexible but the presence of conditional commit/push is
 #    mandatory for idempotency.
@@ -78,7 +89,7 @@ else
   fail "no conditional 'if: steps.*.outputs.*' guard — commit/push must be conditional"
 fi
 
-# 5. Fork-PR safety — skip when the PR head is on a fork. Any of the common
+# 6. Fork-PR safety — skip when the PR head is on a fork. Any of the common
 #    forms satisfy this check: comparing `head.repo.full_name` to
 #    `github.repository`, or checking `head.repo.fork == false`.
 if grep -qE 'github\.event\.pull_request\.head\.repo\.full_name[[:space:]]*==' "$WORKFLOW" \
@@ -88,14 +99,14 @@ else
   fail "no head.repo check — pushes onto forks will fail silently"
 fi
 
-# 6. Strict bash in every run: block that does a commit/push sequence.
+# 7. Strict bash in every run: block that does a commit/push sequence.
 if grep -qE 'set[[:space:]]+-euo[[:space:]]+pipefail' "$WORKFLOW"; then
   ok "strict bash (set -euo pipefail) present"
 else
   fail "no 'set -euo pipefail' in run: blocks — failures may be swallowed"
 fi
 
-# 7. Bot push must use ACTIONS_PUSH (org PAT) with GITHUB_TOKEN fallback.
+# 8. Bot push must use ACTIONS_PUSH (org PAT) with GITHUB_TOKEN fallback.
 #    A bare GITHUB_TOKEN push attributes the synchronize event to
 #    github-actions[bot] and leaves required checks "awaiting approval"
 #    (Issue #435). Accept either the expression form or a GH_PAT env that

--- a/tests/scripts/auto_format.bats
+++ b/tests/scripts/auto_format.bats
@@ -38,7 +38,7 @@ teardown() {
 
 # --- auto-format.sh --------------------------------------------------------
 
-@test "commit-message prints a deterministic message mentioning rustfmt and issue 19" {
+@test "commit-message prints a deterministic message mentioning rustfmt, lock sync, and issues" {
   run "$AUTO_FORMAT" --commit-message
   [ "$status" -eq 0 ]
   first="$output"
@@ -48,7 +48,9 @@ teardown() {
   # Deterministic across invocations.
   [ "$output" = "$first" ]
   [[ "$output" == *"rustfmt"* ]]
+  [[ "$output" == *"neat-core"* ]]
   [[ "$output" == *"#19"* ]]
+  [[ "$output" == *"#542"* ]]
 }
 
 @test "check-changes exits 1 on a clean working tree" {
@@ -127,7 +129,11 @@ jobs:
         run: |
           set -euo pipefail
           cargo fmt --all
-      - name: Detect formatting changes
+      - name: Sync Cargo.lock to latest neat-core
+        run: |
+          set -euo pipefail
+          cargo update -p neat-core
+      - name: Detect formatting / lockfile changes
         id: detect
         run: |
           set -euo pipefail
@@ -136,7 +142,7 @@ jobs:
           else
             echo "changed=false" >>"$GITHUB_OUTPUT"
           fi
-      - name: Commit and push rustfmt fixes
+      - name: Commit and push rustfmt / lock sync fixes
         if: steps.detect.outputs.changed == 'true'
         env:
           GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
@@ -214,6 +220,46 @@ EOF
   run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"cargo fmt"* ]]
+}
+
+@test "workflow validator fails when neat-core lock sync is missing" {
+  cat >"$TMP_WF/auto-format.yml" <<'EOF'
+name: Auto Format
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - Develop
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  auto-format:
+    name: Auto-format Code
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Apply cargo fmt
+        run: |
+          set -euo pipefail
+          cargo fmt --all
+      - name: Detect formatting changes
+        id: detect
+        run: |
+          set -euo pipefail
+          echo "changed=true" >>"$GITHUB_OUTPUT"
+      - name: Commit and push
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_PAT: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git commit -am "fmt"
+          git push
+EOF
+  run "$WF_CHECK" --workflow "$TMP_WF/auto-format.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"neat-core"* || "$output" == *"cargo update"* ]]
 }
 
 @test "workflow validator fails when the commit step is unconditional" {


### PR DESCRIPTION
## Summary
- Extend the PR auto-format job to run `cargo update -p neat-core` after `cargo fmt`, committing any `Cargo.lock` drift against the checked-out NEAT-AI-core `Develop`.
- Keep the Issue #252 `neat-core.expected-version` gate deliberate (no auto-bump); acknowledge current `0.9.0` in this PR and sync the lock.
- Cover the new workflow step in `check-auto-format-workflow.sh` + BATS.

## Why
Workers were repeatedly printing `Updating neat-core v0.8.12 -> v0.9.0` because `Cargo.lock` lagged the path dependency; `model_fetch` hard-resets undid local cargo rewrites. PR automation formatted and version-bumped but never refreshed the lock.

## Test plan
- [x] `./scripts/check-auto-format-workflow.sh`
- [x] `./scripts/check-neat-core-version.sh`
- [x] `bats tests/scripts/auto_format.bats` (16/16)
- [x] `cargo check -p rust_scorer` against sibling neat-core 0.9.0
- [ ] CI green on this PR (auto-format should be a no-op once lock is synced)

Closes #542


Made with [Cursor](https://cursor.com)