### PR TITLE
Host knob report and fleet knob-sweep harness (Issue #545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ section to the released version with its date.
 
 ### Added
 
+- **Host knob report and knob sweep harness (Issue #545).** `rust_scorer
+  --host-report` prints the detected host (logical CPUs, physical RAM) and every
+  resolved knob — `default_worker_count`, `max_worker_count`, `max_read_bytes`,
+  `default_training_read_bytes`, `gpu_scratch_bytes` — as one JSON object, each
+  tagged `default` or `env` so a fleet operator can see which values an override
+  actually moved. It scores nothing, creates no `wgpu` adapter, and so returns
+  the same JSON on a GPU-less host and under `--gpu off`.
+  `--record-bytes <BYTES>` picks the record width the record-size-adaptive read
+  knob is resolved for (default: the 9848 B production width).
+  [`scripts/bench-knob-sweep.sh`](./scripts/bench-knob-sweep.sh) sweeps one
+  `NEAT_SCORER_*` knob across a caller-supplied value list on the production
+  scoring path and reports the median wall-clock per value, prefixed by that
+  host's report; it skips cleanly without local inputs (Issue #448) and is
+  fail-loud once they are supplied. Measurement only — **no shipped default
+  changed**. Fleet baseline for the Apple mid tier recorded in
+  [`docs/performance-baseline.md`](./docs/performance-baseline.md).
+
 - **Parallel training-data file reads (Issue #529).** The forward-only fused
   path now streams a multi-file corpus through several concurrent `.bin`
   readers instead of one, removing the serial `f32` unpack and the per-chunk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.57"
+version = "1.1.58"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -439,6 +439,54 @@ score stays stable:
 > to a released scorer through the normal dependency-bump flow once a human cuts
 > the release.
 
+### Host knob report — `--host-report` (Issue #545)
+
+Every host-tuned default is chosen from a probed snapshot of the machine
+([`host_resources`](rust_scorer/src/host_resources.rs)), so retuning one across
+the fleet first needs a way to see what a given host **detected** and **chose**.
+`--host-report` prints exactly that as one JSON object and exits without scoring
+anything:
+
+```bash
+rust_scorer --host-report                      # production record width (9848 B)
+rust_scorer --host-report --record-bytes 40    # small-record corpora
+```
+
+```json
+{
+  "schema": "neat-scorer-host-report/1",
+  "logical_cpus": 10,
+  "physical_ram_bytes": 25769803776,
+  "record_bytes": 9848,
+  "knobs": {
+    "default_worker_count": { "value": 10, "source": "default", "env_var": "NEAT_SCORER_ACTIVATION_THREADS" },
+    "max_worker_count": { "value": 256, "source": "default", "env_var": null },
+    "max_read_bytes": { "value": 67108864, "source": "default", "env_var": null },
+    "default_training_read_bytes": { "value": 33552136, "source": "default", "env_var": "NEAT_SCORER_READ_BYTES" },
+    "gpu_scratch_bytes": { "value": 536870912, "source": "default", "env_var": "NEAT_SCORER_GPU_SCRATCH_BYTES" }
+  }
+}
+```
+
+- `value` is what the scorer will actually use, **after** every clamp and the
+  round-down to a whole record multiple — not the raw env string.
+- `source` is `env` only when an override was parsed and **honoured**. A
+  malformed value (`NEAT_SCORER_READ_BYTES=2MB`) is rejected by the shipped
+  resolver, so it keeps reporting `default` and still warns on stderr.
+- `env_var` is `null` for a host-derived ceiling, which takes no override.
+- `NEAT_SCORER_FILE_THREADS` shares the `default_worker_count` default,
+  additionally capped at the corpus file count.
+- Keys are snake_case and named after the functions that produced them, so a
+  pasted report maps 1:1 onto the code a retune has to change. This is a
+  diagnostic, **not** the camelCase scoring payload.
+
+The report is measurement only: it changes no default, never creates a `wgpu`
+adapter, and therefore returns the same JSON on a GPU-less host, under
+`--gpu off`, and under `--gpu on`. `--record-bytes` selects the record width the
+read-chunk knob is resolved for (the default is record-size adaptive); zero is
+rejected rather than clamped. Pair it with the knob sweep harness in
+[How to bench](#how-to-bench) when retuning a knob.
+
 ### Stdin input mode
 
 For restricted worker/sandbox environments where writing a temp file may fail
@@ -1337,6 +1385,45 @@ Per the
 `CONTRIBUTING.md`, performance PRs without before/after Criterion evidence are
 rejected, and a change that misses its acceptance bar is recorded as a
 `negative-result` on the issue instead of raised as a PR.
+
+### Knob sweep harness (Issue #545)
+
+CLI-level wall-clock sweeps live outside Criterion.
+[`scripts/bench-knob-sweep.sh`](scripts/bench-knob-sweep.sh) runs the production
+scoring path at a caller-supplied list of values for **one** knob and reports
+the median per value, in the same table shape as
+[`scripts/bench-shallow-gpu.sh`](scripts/bench-shallow-gpu.sh):
+
+```bash
+BENCH_SWEEP_CREATURE=/path/to/creatures_dir BENCH_SWEEP_DATA=/path/to/corpus \
+  BENCH_SWEEP_KNOB=NEAT_SCORER_READ_BYTES \
+  BENCH_SWEEP_VALUES=default,2097152,8388608,33554432 \
+  ./scripts/bench-knob-sweep.sh
+```
+
+The run opens with the host's `--host-report` JSON, so a pasted sweep carries
+the machine it was measured on. The first value in the list is the baseline
+every later value is compared against; the literal `default` runs with the knob
+**unset**, which is also the single-knob-neutral baseline used for the fleet
+captures in
+[`docs/performance-baseline.md`](docs/performance-baseline.md#544-fleet-knob-baseline--10-august-2026-issue-545).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BENCH_SWEEP_CREATURE` | — | local creature JSON or creatures directory (**required**) |
+| `BENCH_SWEEP_DATA` | — | local training-data directory of `.bin` files (**required**) |
+| `BENCH_SWEEP_KNOB` | `NEAT_SCORER_READ_BYTES` | `NEAT_SCORER_*` variable to sweep |
+| `BENCH_SWEEP_VALUES` | `default` | comma-separated values; `default` means "knob unset" |
+| `BENCH_SWEEP_REPS` | `5` | timed repetitions per value (median reported) |
+| `BENCH_SWEEP_GPU` | `auto` | `--gpu` mode for every run (production omits the flag) |
+| `BENCH_SWEEP_SCORER` | `target/release/rust_scorer` | scorer binary (built when absent) |
+
+This repo ships no production creature or corpus and fetches neither
+(Issue #448), so with either input unset the harness **skips cleanly** (exit 0)
+exactly as the other production benches do. Once inputs are supplied it is
+**fail-loud**: an unreadable input, a rejected knob name or value, a failed
+host report, or a non-zero scoring run all exit non-zero rather than reporting
+an empty sweep as success (`tests/scripts/bench_knob_sweep.bats`).
 
 ## How to flamegraph (Issue #37)
 

--- a/docs/archive/pr-summaries/pr-summary-545.md
+++ b/docs/archive/pr-summaries/pr-summary-545.md
@@ -1,0 +1,138 @@
+# Host knob report and fleet knob-sweep harness (Issue #545)
+
+## Summary
+
+Adds the measurement rig the rest of the #544 self-tune chain cites, so each
+retune sub-issue can produce before/after numbers instead of inventing its own
+harness. **Measurement only — no shipped default changed.** Closes #545.
+
+1. **Knob report.** `rust_scorer --host-report` prints the detected host
+   (logical CPUs, physical RAM) and every resolved knob —
+   `default_worker_count`, `max_worker_count`, `max_read_bytes`,
+   `default_training_read_bytes`, `gpu_scratch_bytes` — as one JSON object, each
+   tagged `default` or `env`. `source` is `env` only when an override was parsed
+   **and honoured**: a malformed value is rejected by the shipped resolver, so
+   it keeps reporting `default` (and still warns on stderr) rather than claiming
+   an override that never applied. The report is resolved before GPU mode
+   resolution, so it never creates a `wgpu` adapter and returns identical JSON
+   on a GPU-less host, under `--gpu off` and under `--gpu on`.
+   `--record-bytes <BYTES>` selects the record width the record-size-adaptive
+   read knob is resolved for (default: the 9848 B production width); zero is
+   rejected, not clamped.
+2. **Sweep harness.** `scripts/bench-knob-sweep.sh` runs the production scoring
+   path at a caller-supplied list of values for one `NEAT_SCORER_*` knob and
+   reports the median wall-clock per value, in the same table shape as
+   `scripts/bench-shallow-gpu.sh`. It opens with the host's `--host-report` JSON
+   so a pasted sweep carries the machine it was measured on. With
+   `BENCH_SWEEP_CREATURE` / `BENCH_SWEEP_DATA` unset it **skips cleanly**
+   (exit 0, Issue #448 convention); once supplied it is **fail-loud** — an
+   unreadable input, a knob name outside the `NEAT_SCORER_*` allowlist, a
+   non-numeric value, a failed host report or a non-zero scoring run all exit
+   non-zero.
+3. **Fleet baseline.** `docs/performance-baseline.md` gains a "#544 fleet knob
+   baseline" section with the report output, the single-knob-neutral baseline
+   and two example sweeps for the Apple mid tier (M4, 10 cores, 24 GB), plus the
+   harness's measured noise floor.
+
+```mermaid
+flowchart LR
+    H[host probe<br/>CPUs · RAM] --> R[--host-report JSON]
+    E[NEAT_SCORER_* env] --> R
+    R --> S[bench-knob-sweep.sh]
+    V[BENCH_SWEEP_VALUES] --> S
+    C[local creature + corpus] --> S
+    S --> T[median wall-clock per value<br/>+ delta vs baseline]
+    T --> D[#544 retune sub-issue<br/>before/after evidence]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Evidence is the report
+output, the harness run and the tests.
+
+`./target/release/rust_scorer --host-report` on an Apple M4 (10 cores, 24 GB):
+
+```json
+{
+  "schema": "neat-scorer-host-report/1",
+  "logical_cpus": 10,
+  "physical_ram_bytes": 25769803776,
+  "record_bytes": 9848,
+  "knobs": {
+    "default_worker_count": { "value": 10, "source": "default", "env_var": "NEAT_SCORER_ACTIVATION_THREADS" },
+    "max_worker_count": { "value": 256, "source": "default", "env_var": null },
+    "max_read_bytes": { "value": 67108864, "source": "default", "env_var": null },
+    "default_training_read_bytes": { "value": 33552136, "source": "default", "env_var": "NEAT_SCORER_READ_BYTES" },
+    "gpu_scratch_bytes": { "value": 536870912, "source": "default", "env_var": "NEAT_SCORER_GPU_SCRATCH_BYTES" }
+  }
+}
+```
+
+Every line matches the shipped policy for this tier: one worker per logical CPU
+under the 256 ceiling (≥ 8 GiB RAM), the 64 MiB mid-host read ceiling, the
+32 MiB large-record default rounded to a whole record multiple
+(`33552136 = 3407 × 9848`), and the 512 MiB scratch budget for the 16–64 GiB
+band. At `--record-bytes 40` the read default drops to `2097120`.
+
+Harness run (synthetic shallow pool at production record width — 50 creatures,
+20 000 records over 4 shards, 9848 B/record; this repo ships no production
+creature, Issue #448), median of 5 under `--gpu off`:
+
+| `NEAT_SCORER_READ_BYTES` | Wall (s) | vs baseline |
+|---|---|---|
+| `default` (→ 33 552 136) | 1.55 | baseline |
+| `2097152` | 1.52 | +1.9 % |
+| `8388608` | 1.54 | +0.6 % |
+| `33554432` (→ same 33 552 136) | 1.67 | −7.7 % |
+
+| `NEAT_SCORER_ACTIVATION_THREADS` | Wall (s) | vs baseline |
+|---|---|---|
+| `default` (→ 10) | 1.97 | baseline |
+| `4` | 1.79 | +9.1 % |
+| `10` | 1.68 | +14.7 % |
+| `20` | 1.63 | +17.3 % |
+
+`default` and `33554432` resolve to the *same* chunk size, so their 7.7 % gap is
+the harness's noise floor on this fixture, not a knob effect — recorded
+explicitly in the baseline doc so a retune does not cite a sub-noise win.
+
+**x86 Linux tier not captured.** No x86 Linux fleet host is reachable from the
+unattended worker, so that tier's row is marked outstanding and tracked in
+stSoftwareAU/NEAT-AI-scorer#551 (measurement only; needs a human with fleet
+access). The report *code path* is still exercised on the GPU-less Linux CI
+runner by `rust_scorer/tests/host_report.rs` on every PR.
+
+## Test Plan
+
+New — `rust_scorer/tests/host_report.rs` (integration, runs the built binary):
+
+- `host_report_runs_without_positional_args_and_emits_one_json_object` — exit 0,
+  stdout parses as exactly one JSON object, every knob key present with a
+  `default`/`env` source.
+- `host_report_runs_with_gpu_off_without_initialising_an_adapter` and
+  `host_report_never_aborts_even_under_gpu_on` — the GPU-less-runner cases from
+  the issue's failure-detection plan.
+- `env_override_flips_the_matching_knob_source_to_env` — read-bytes, GPU scratch
+  and activation-threads overrides each flip only their own entry, and the
+  reported value is the resolved (clamped, record-aligned) one.
+- `malformed_env_override_still_reports_the_default_source` — an ignored value
+  is not reported as an override, and still warns on stderr.
+- `record_bytes_flag_drives_the_read_default`, `zero_record_bytes_is_rejected`,
+  `report_output_is_stable_across_runs`.
+
+New — `rust_scorer/src/host_report.rs` unit tests: source classification for
+unset/blank/honoured/malformed/zero values, and the serialised shape.
+
+New — `rust_scorer/src/cli.rs` unit tests: `--host-report` parses with no
+positional args and resolves a report; the report is identical under
+`--gpu auto|on|off`; `--record-bytes` validation.
+
+New — `tests/scripts/bench_knob_sweep.bats` (15 cases): clean skip with either
+input unset, fail-loud on unreadable inputs / rejected knob name / non-numeric
+value / invalid GPU mode / failed host report / non-zero scorer exit, the knob
+reaching the scorer environment at each value (and unset for `default`), the
+requested repetition count, and the median + delta table.
+
+`./quality.sh` passes clean (shellcheck, cargo-deny, fmt, clippy `-D warnings`,
+check, build, 226 unit + all integration tests, rustdoc, release build);
+`markdownlint-cli2` reports 0 errors.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -19,11 +19,17 @@ the runs with [`scripts/run-benches.sh`](../scripts/run-benches.sh) or
 | `production_multi_creature/creatures/N` | Directory mode over copies of the production creature (`N=1`, `N=BENCH_PROD_CREATURES`). | The candidate optimisations #297–#299 A/B against this on the real creature, not the synthetic fixture. |
 | `fused_multi_file/file_workers/W` | Forward-only fused accumulate over the **same** corpus split across `BENCH_FUSED_FILES` files, at `W` concurrent `.bin` readers (Issue #529). | `W=1` reproduces the pre-#529 single sequential reader; `auto` is the shipped default (one reader per CPU, capped at the file count). Calls [`accumulate_cost_sum_forward_only_fused_with_workers`](../rust_scorer/src/stream_score.rs). |
 
-CLI-level GPU-vs-CPU wall-clock A/Bs live outside Criterion:
-[`scripts/bench-shallow-gpu.sh`](../scripts/bench-shallow-gpu.sh) (Issue #467)
-times `--gpu off` / `on` / `auto` on a **shallow** creature pool against a
-locally generated corpus at the caller's record width. It skips cleanly when
-`BENCH_SHALLOW_CREATURE` is unset — see the Issue #467 section below.
+CLI-level wall-clock A/Bs live outside Criterion:
+
+* [`scripts/bench-shallow-gpu.sh`](../scripts/bench-shallow-gpu.sh) (Issue #467)
+  times `--gpu off` / `on` / `auto` on a **shallow** creature pool against a
+  locally generated corpus at the caller's record width. It skips cleanly when
+  `BENCH_SHALLOW_CREATURE` is unset — see the Issue #467 section below.
+* [`scripts/bench-knob-sweep.sh`](../scripts/bench-knob-sweep.sh) (Issue #545)
+  sweeps **one** `NEAT_SCORER_*` knob across a caller-supplied value list on the
+  production scoring path and reports the median per value. It skips cleanly
+  when `BENCH_SWEEP_CREATURE` / `BENCH_SWEEP_DATA` are unset — see the Issue
+  #545 section below.
 
 ## Fixture parameters
 
@@ -41,6 +47,130 @@ Defaults are kept conservative so `cargo bench` finishes in a few minutes on
 typical dev hardware; sweep upwards via `BENCH_SCORING_BYTES` for the full
 target. **Always re-run the baseline at the same `BENCH_SCORING_BYTES`** — the
 absolute numbers below are fixture-size-specific.
+
+## #544 fleet knob baseline — 10 August 2026 (Issue #545)
+
+Enabler for the [#544](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/544)
+self-tune chain: the retune sub-issues cite their before/after numbers from the
+harness recorded here. **Measurement only — no shipped default changed.**
+
+Two pieces:
+
+* `rust_scorer --host-report` prints what a host detected and which knob values
+  it resolved, as one JSON object (see the README
+  [Host knob report](../README.md#host-knob-report----host-report-issue-545)
+  section). It never creates a `wgpu` adapter, so it returns the same JSON on a
+  GPU-less host and under `--gpu off`.
+* [`scripts/bench-knob-sweep.sh`](../scripts/bench-knob-sweep.sh) sweeps one
+  knob across a value list on the production scoring path and prints the median
+  wall-clock per value, prefixed by that host's report.
+
+```mermaid
+flowchart LR
+    H[host probe<br/>CPUs · RAM] --> R[--host-report JSON]
+    E[NEAT_SCORER_* env] --> R
+    R --> S[bench-knob-sweep.sh]
+    V[BENCH_SWEEP_VALUES] --> S
+    C[local creature + corpus] --> S
+    S --> T[median wall-clock per value<br/>+ delta vs baseline]
+    T --> D[#544 retune sub-issue<br/>before/after evidence]
+```
+
+### Tier: Apple mid (M4, 10 cores, 24 GB)
+
+| Field | Value |
+|---|---|
+| Machine | Apple M4, 10 logical cores, 24 GB, macOS 26.6.1 (Darwin 25.6.0, arm64) |
+| Toolchain | rustc 1.95.0, release profile |
+| Fixture | synthetic shallow pool at production record width — 50 creatures (2461 in / 19 hidden / 1 out, 22 221 synapses), 20 000 records over 4 `.bin` shards (196 960 000 bytes, 9848 B/record) |
+| Inputs | generated locally: this repo ships no production creature or corpus and fetches neither (Issue #448) |
+
+`rust_scorer --host-report` (no `NEAT_SCORER_*` set):
+
+```json
+{
+  "schema": "neat-scorer-host-report/1",
+  "logical_cpus": 10,
+  "physical_ram_bytes": 25769803776,
+  "record_bytes": 9848,
+  "knobs": {
+    "default_worker_count": { "value": 10, "source": "default", "env_var": "NEAT_SCORER_ACTIVATION_THREADS" },
+    "max_worker_count": { "value": 256, "source": "default", "env_var": null },
+    "max_read_bytes": { "value": 67108864, "source": "default", "env_var": null },
+    "default_training_read_bytes": { "value": 33552136, "source": "default", "env_var": "NEAT_SCORER_READ_BYTES" },
+    "gpu_scratch_bytes": { "value": 536870912, "source": "default", "env_var": "NEAT_SCORER_GPU_SCRATCH_BYTES" }
+  }
+}
+```
+
+Every value matches the shipped policy for this tier: 10 workers (one per
+logical CPU, below the 256 ceiling for ≥ 8 GiB RAM), the 64 MiB mid-host read
+ceiling, the 32 MiB large-record read default rounded down to a whole record
+multiple (`33552136 = 3407 × 9848`), and the historical 512 MiB scratch budget
+for the 16–64 GiB RAM band. At `--record-bytes 40` the read default drops to
+`2097120` (2 MiB rounded to 52 428 records) — the record-size adaptive branch.
+
+**Single-knob-neutral baseline** (`BENCH_SWEEP_VALUES=default`, median of 5):
+
+| `--gpu` | Wall (s) | `gpuBackend` |
+|---|---|---|
+| `auto` (production omits the flag) | 7.63 | `metal` |
+| `off` | 1.55 | `cpu-fallback` |
+
+**Example sweeps** (median of 5, `--gpu off` so the sweep measures the CPU
+pipeline rather than kernel routing):
+
+| `NEAT_SCORER_READ_BYTES` | Wall (s) | vs baseline |
+|---|---|---|
+| `default` (→ 33 552 136) | 1.55 | baseline |
+| `2097152` | 1.52 | +1.9 % |
+| `8388608` | 1.54 | +0.6 % |
+| `33554432` (→ same 33 552 136) | 1.67 | −7.7 % |
+
+| `NEAT_SCORER_ACTIVATION_THREADS` | Wall (s) | vs baseline |
+|---|---|---|
+| `default` (→ 10) | 1.97 | baseline |
+| `4` | 1.79 | +9.1 % |
+| `10` | 1.68 | +14.7 % |
+| `20` | 1.63 | +17.3 % |
+
+**Noise floor — read this before citing a sweep.** `default` and `33554432`
+resolve to the *same* 33 552 136-byte chunk, yet their medians differ by 7.7 %:
+that gap is the harness's noise floor on this fixture, not a knob effect. A
+retune must therefore either clear ~10 % here or use a corpus large enough that
+one repetition takes ≥ 5 s (the two `--gpu off` sweeps above run in ~1.6 s).
+Raise `BENCH_SWEEP_REPS` and the corpus size together; the medians tighten with
+both. The activation-threads column is above that floor and monotonic, so it is
+a real (if small) effect on this synthetic pool.
+
+The `auto` row scores on Metal because the pool is shallow `ScratchOnly`
+(#467 routing) — it is recorded as the *shipped-default* baseline for this host,
+not as a GPU-vs-CPU verdict. It is **not** comparable with the #467 A/B below:
+different corpus size, pool size and synthetic (untrained) weights.
+
+Reproduce:
+
+```bash
+BENCH_SWEEP_CREATURE=/path/to/creatures_dir BENCH_SWEEP_DATA=/path/to/corpus \
+  BENCH_SWEEP_VALUES=default ./scripts/bench-knob-sweep.sh
+BENCH_SWEEP_CREATURE=/path/to/creatures_dir BENCH_SWEEP_DATA=/path/to/corpus \
+  BENCH_SWEEP_GPU=off BENCH_SWEEP_KNOB=NEAT_SCORER_READ_BYTES \
+  BENCH_SWEEP_VALUES=default,2097152,8388608,33554432 ./scripts/bench-knob-sweep.sh
+```
+
+### Tier: x86 Linux — outstanding
+
+No x86 Linux fleet host (4–12 cores, 7.6–15.5 GB RAM, no GPU adapter) is
+reachable from the unattended worker that produced this section, so the x86 row
+is **not** captured here. The report
+path itself is exercised on the GPU-less Linux CI runner by
+[`rust_scorer/tests/host_report.rs`](../rust_scorer/tests/host_report.rs), which
+asserts exit 0, valid JSON and a complete knob set on every PR — what is missing
+is the *fleet* capture (that tier's detected RAM/CPU and its neutral baseline
+timings). Tracked in
+[Issue #551](https://github.com/stSoftwareAU/NEAT-AI-scorer/issues/551); run the
+two commands above on one x86 Linux host and append a "Tier: x86 Linux" block
+in the same shape.
 
 ## Parallel file reads — 5 August 2026 (Issue #529)
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.57"
+version = "1.1.58"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/cli.rs
+++ b/rust_scorer/src/cli.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 use crate::corpus_guard::assert_records_aligned;
 use crate::cost::CostKind;
 use crate::gpu::{GpuBackendLabel, GpuMode, ScoringPath};
+use crate::host_report::{DEFAULT_REPORT_RECORD_BYTES, HostReport};
 use crate::multi_score::{score_from_creature_dir_gpu_sampled, score_from_creature_dir_sampled};
 use crate::read_tuning::{training_read_backend_label, training_read_target_bytes_from_env};
 use crate::sampling::{SampleSpec, parse_sample_rate};
@@ -137,12 +138,48 @@ struct Cli {
     #[arg(long, value_name = "PHASE", default_value_t = 0)]
     sample_phase: u64,
 
+    /// Print the detected host resources and every resolved knob as one JSON
+    /// object, then exit — score nothing (Issue #545).
+    ///
+    /// The report names the logical CPU count, physical RAM, and the resolved
+    /// `default_worker_count`, `max_worker_count`, `max_read_bytes`,
+    /// `default_training_read_bytes` and GPU scratch budget, each tagged
+    /// `default` or `env` so a fleet operator can see which knobs an
+    /// environment override moved. Measurement only: no default changes and no
+    /// `wgpu` adapter is created, so it runs on a GPU-less host and under
+    /// `--gpu off` alike. Takes no positional arguments.
+    ///
+    /// See the README "Host knob report" section.
+    #[arg(long)]
+    host_report: bool,
+
+    /// Record width (bytes) `--host-report` resolves the read-chunk knob for.
+    ///
+    /// The read default is record-size adaptive, so the report needs a width;
+    /// it defaults to the production corpus shape (2461 inputs + 1 output as
+    /// `f32` = 9848 B). Ignored unless `--host-report` is set. Zero is
+    /// rejected — a corpus has no zero-width record.
+    #[arg(long, value_name = "BYTES", default_value_t = DEFAULT_REPORT_RECORD_BYTES, value_parser = parse_record_bytes)]
+    record_bytes: usize,
+
     /// Positional arguments.
     ///
     /// * default mode: `<creature.json> <data_dir>` (two values).
     /// * `--creature-stdin` mode: `<data_dir>` (one value).
     #[arg(num_args = 1..=2, value_name = "ARGS")]
     args: Vec<PathBuf>,
+}
+
+/// Validate `--record-bytes`: a positive record width (Issue #545).
+///
+/// Rejected rather than clamped so a typo'd `0` fails loud instead of silently
+/// reporting a knob value nobody asked for.
+fn parse_record_bytes(raw: &str) -> Result<usize, String> {
+    match raw.trim().parse::<usize>() {
+        Ok(0) => Err("--record-bytes must be greater than zero".to_string()),
+        Ok(bytes) => Ok(bytes),
+        Err(e) => Err(format!("invalid --record-bytes '{raw}': {e}")),
+    }
 }
 
 /// Resolve the `(creature_json, data_dir)` pair from parsed CLI args.
@@ -191,9 +228,18 @@ enum RunOutput {
     // (one heap pointer) and stays small.
     Single(Box<ScoreResult>),
     Multi(BTreeMap<String, ScoreResult>),
+    // Issue #545: `--host-report` scores nothing and prints the knob diagnostic.
+    Host(HostReport),
 }
 
 fn run(cli: &Cli) -> Result<RunOutput, String> {
+    // Issue #545: the knob report is measurement only and must never abort —
+    // resolved *before* GPU mode resolution or adapter selection so it works
+    // identically on a GPU-less host, under `--gpu off`, and under `--gpu on`.
+    if cli.host_report {
+        return Ok(RunOutput::Host(HostReport::resolve(cli.record_bytes)));
+    }
+
     // Resolve the GPU backend label up-front. For `--gpu off` this is a
     // constant `cpu-fallback` and never touches `wgpu`; for `auto` (the
     // default since Issue #83) and `on` it triggers adapter selection now
@@ -606,6 +652,7 @@ pub fn main() {
             .map_err(|e| format!("Failed to serialise result to JSON: {e}")),
         RunOutput::Multi(result_map) => serde_json::to_string_pretty(&result_map)
             .map_err(|e| format!("Failed to serialise multi-creature result to JSON: {e}")),
+        RunOutput::Host(report) => report.to_json(),
     });
 
     match output {
@@ -624,6 +671,7 @@ mod tests {
         match run(cli)? {
             RunOutput::Single(result) => Ok(*result),
             RunOutput::Multi(_) => Err("Expected single-creature output".to_string()),
+            RunOutput::Host(_) => Err("Expected single-creature output".to_string()),
         }
     }
 
@@ -719,6 +767,8 @@ mod tests {
             cost: CostKind::default(),
             sample_rate: None,
             sample_phase: 0,
+            host_report: false,
+            record_bytes: DEFAULT_REPORT_RECORD_BYTES,
             args: vec![creature.to_path_buf(), data.to_path_buf()],
         }
     }
@@ -1119,6 +1169,8 @@ mod tests {
             cost: CostKind::default(),
             sample_rate: None,
             sample_phase: 0,
+            host_report: false,
+            record_bytes: DEFAULT_REPORT_RECORD_BYTES,
             args: vec![PathBuf::from("/tmp/creature.json"), PathBuf::from("/tmp")],
         };
         let err = resolve_inputs(&cli).expect_err("extra positional args should fail");
@@ -1137,6 +1189,8 @@ mod tests {
             cost: CostKind::default(),
             sample_rate: None,
             sample_phase: 0,
+            host_report: false,
+            record_bytes: DEFAULT_REPORT_RECORD_BYTES,
             args: vec![PathBuf::from("/tmp")],
         };
         let err = resolve_inputs(&cli).expect_err("single positional arg should fail");
@@ -1406,6 +1460,70 @@ mod tests {
         assert!(
             help.contains("README"),
             "rendered --help must reference the README, got:\n{help}"
+        );
+    }
+
+    /// Issue #545: `--host-report` must parse with **no** positional arguments
+    /// (it scores nothing) and must resolve a report without touching `wgpu`.
+    #[test]
+    fn test_host_report_parses_without_positional_args() {
+        use clap::Parser;
+        let parsed = Cli::try_parse_from(["rust_scorer", "--host-report"])
+            .expect("--host-report must parse on its own");
+        assert!(parsed.host_report);
+        assert!(parsed.args.is_empty());
+        assert_eq!(parsed.record_bytes, DEFAULT_REPORT_RECORD_BYTES);
+
+        match run(&parsed).expect("--host-report must not fail") {
+            RunOutput::Host(report) => {
+                assert!(report.logical_cpus >= 1);
+                assert_eq!(report.record_bytes, DEFAULT_REPORT_RECORD_BYTES);
+                assert!(report.knobs.max_worker_count.value >= 1);
+                assert!(report.to_json().expect("serialises").contains("\"knobs\""));
+            }
+            _ => panic!("--host-report must yield the host report output"),
+        }
+    }
+
+    /// Issue #545: the report must resolve identically under every `--gpu`
+    /// mode, including `on` (which would otherwise demand an adapter).
+    #[test]
+    fn test_host_report_ignores_gpu_mode() {
+        use clap::Parser;
+        let mut reports = Vec::new();
+        for mode in ["auto", "on", "off"] {
+            let parsed = Cli::try_parse_from(["rust_scorer", "--host-report", "--gpu", mode])
+                .expect("flag combination must parse");
+            match run(&parsed).expect("--host-report must never abort") {
+                RunOutput::Host(report) => reports.push(report),
+                _ => panic!("--host-report must yield the host report output"),
+            }
+        }
+        assert!(
+            reports.windows(2).all(|w| w[0] == w[1]),
+            "the report must not vary with --gpu mode: {reports:?}"
+        );
+    }
+
+    /// Issue #545: `--record-bytes` selects the width the read knob is resolved
+    /// for; zero is rejected rather than silently clamped.
+    #[test]
+    fn test_record_bytes_flag_validation() {
+        use clap::Parser;
+        let parsed =
+            Cli::try_parse_from(["rust_scorer", "--host-report", "--record-bytes", "40"]).unwrap();
+        assert_eq!(parsed.record_bytes, 40);
+
+        let err = Cli::try_parse_from(["rust_scorer", "--host-report", "--record-bytes", "0"])
+            .expect_err("zero must be rejected");
+        assert!(
+            err.to_string().contains("greater than zero"),
+            "error must explain the constraint, got: {err}"
+        );
+        assert!(
+            Cli::try_parse_from(["rust_scorer", "--host-report", "--record-bytes", "wide"])
+                .is_err(),
+            "a non-numeric width must be rejected"
         );
     }
 

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -1162,7 +1162,11 @@ pub(crate) fn scratch_workgroups_x_for(
 
 /// Resolve the scratch-kernel memory budget from `NEAT_SCORER_GPU_SCRATCH_BYTES`,
 /// falling back to the host-aware default (Issue #182).
-fn scratch_budget_bytes_from_env() -> u64 {
+///
+/// Pure env + [`crate::host_resources`] arithmetic — no adapter is created — so
+/// the Issue #545 `--host-report` diagnostic can read the resolved budget on a
+/// GPU-less host.
+pub(crate) fn scratch_budget_bytes_from_env() -> u64 {
     let env = std::env::var("NEAT_SCORER_GPU_SCRATCH_BYTES").ok();
     let (parsed, warning) = crate::env_tuning::parse_tuning_var(
         "NEAT_SCORER_GPU_SCRATCH_BYTES",

--- a/rust_scorer/src/host_report.rs
+++ b/rust_scorer/src/host_report.rs
@@ -1,0 +1,322 @@
+//! `--host-report`: what this host detected and which knob values it resolved.
+//!
+//! Issue #545 (sub-issue of #544). Every host-tuned knob is chosen from a
+//! probed [`HostResources`](crate::host_resources::HostResources) snapshot, so
+//! retuning one across a 20+ machine fleet first needs a way to *see* what a
+//! given host actually detected and chose. This module renders that as one
+//! JSON object, each knob tagged with whether the value came from the built-in
+//! default or from an environment override.
+//!
+//! It is **measurement only** — resolving the report changes no default and
+//! never creates a `wgpu` adapter, so it runs unchanged on a GPU-less host and
+//! under `--gpu off`.
+//!
+//! Keys are snake_case and mirror the Rust functions that produced them
+//! (`default_worker_count`, `max_read_bytes`, …) so a pasted report line maps
+//! 1:1 onto the code a retune sub-issue has to change. This is deliberately
+//! *not* the camelCase [`ScoreResult`](crate::scoring::ScoreResult) contract —
+//! the report is a diagnostic, not part of the TypeScript bridge's scoring
+//! payload.
+
+use serde::Serialize;
+
+use crate::env_tuning::parse_tuning_var;
+use crate::gpu::forward_mse_batched::scratch_budget_bytes_from_env;
+use crate::host_resources;
+use crate::read_tuning::training_read_target_bytes_from_env;
+use crate::stream_score::activation_worker_count_for_scorer;
+
+/// Record width the read-chunk knob is resolved for when `--record-bytes` is
+/// omitted: the production corpus shape (2461 inputs + 1 output, `f32`).
+///
+/// The read default is record-size adaptive
+/// (`read_tuning::default_training_read_bytes_for`), so a report with
+/// no width would describe a knob nobody runs.
+pub const DEFAULT_REPORT_RECORD_BYTES: usize = 9848;
+
+/// Report schema tag, so a consumer can tell an old paste from a new one.
+const SCHEMA: &str = "neat-scorer-host-report/1";
+
+/// Where a resolved knob value came from.
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum KnobSource {
+    /// The built-in, host-derived default (no override, or one that was
+    /// rejected as malformed and therefore never applied).
+    Default,
+    /// An environment override that was parsed and honoured.
+    Env,
+}
+
+/// One resolved knob: the value the scorer will actually use, plus its origin.
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Knob {
+    /// Resolved value, after every clamp the shipped resolver applies.
+    pub value: u64,
+    /// Built-in default or honoured environment override.
+    pub source: KnobSource,
+    /// Environment variable that can override this knob, or `None` for a
+    /// host-derived ceiling that takes no override.
+    pub env_var: Option<&'static str>,
+}
+
+/// Every knob a #544 retune sub-issue may move.
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Knobs {
+    /// Activation / file-reader workers the scorer defaults to
+    /// ([`host_resources::default_worker_count`]), after
+    /// `NEAT_SCORER_ACTIVATION_THREADS`. `NEAT_SCORER_FILE_THREADS` shares this
+    /// default, additionally capped at the corpus file count.
+    pub default_worker_count: Knob,
+    /// Host ceiling both worker knobs clamp to.
+    pub max_worker_count: Knob,
+    /// Host ceiling `NEAT_SCORER_READ_BYTES` clamps to.
+    pub max_read_bytes: Knob,
+    /// Read-chunk target for `record_bytes`-wide records, after
+    /// `NEAT_SCORER_READ_BYTES` and the round-down to a whole record multiple.
+    pub default_training_read_bytes: Knob,
+    /// `forward_mse_scratch` SSBO budget, after `NEAT_SCORER_GPU_SCRATCH_BYTES`.
+    /// Resolved from host RAM alone — no adapter is created.
+    pub gpu_scratch_bytes: Knob,
+}
+
+/// One host's detected resources and resolved knobs.
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HostReport {
+    /// Schema tag (`neat-scorer-host-report/1`).
+    pub schema: &'static str,
+    /// Logical CPUs the host probe found.
+    pub logical_cpus: usize,
+    /// Physical RAM in bytes, or `null` where the platform probe is
+    /// unavailable (the knobs then take their unknown-RAM defaults).
+    pub physical_ram_bytes: Option<u64>,
+    /// Record width `default_training_read_bytes` was resolved for.
+    pub record_bytes: usize,
+    /// The resolved knobs.
+    pub knobs: Knobs,
+}
+
+impl HostReport {
+    /// Resolve the report for this process: probe the host, read the
+    /// environment, and run the same resolvers the scoring paths use.
+    #[must_use]
+    pub fn resolve(record_bytes: usize) -> Self {
+        let host = host_resources::host();
+        Self {
+            schema: SCHEMA,
+            logical_cpus: host.cpus,
+            physical_ram_bytes: host.physical_ram_bytes,
+            record_bytes,
+            knobs: Knobs {
+                default_worker_count: Knob {
+                    value: activation_worker_count_for_scorer() as u64,
+                    source: env_source_usize("NEAT_SCORER_ACTIVATION_THREADS"),
+                    env_var: Some("NEAT_SCORER_ACTIVATION_THREADS"),
+                },
+                max_worker_count: host_ceiling(host_resources::max_worker_count(&host) as u64),
+                max_read_bytes: host_ceiling(host_resources::max_read_bytes(&host) as u64),
+                default_training_read_bytes: Knob {
+                    value: training_read_target_bytes_from_env(record_bytes) as u64,
+                    source: env_source_usize("NEAT_SCORER_READ_BYTES"),
+                    env_var: Some("NEAT_SCORER_READ_BYTES"),
+                },
+                gpu_scratch_bytes: Knob {
+                    value: scratch_budget_bytes_from_env(),
+                    source: env_source_positive_u64("NEAT_SCORER_GPU_SCRATCH_BYTES"),
+                    env_var: Some("NEAT_SCORER_GPU_SCRATCH_BYTES"),
+                },
+            },
+        }
+    }
+
+    /// Render the report as one pretty JSON object.
+    ///
+    /// # Errors
+    ///
+    /// Returns the `serde_json` failure text if the report cannot be
+    /// serialised, so the caller can fail loud rather than print nothing.
+    pub fn to_json(&self) -> Result<String, String> {
+        serde_json::to_string_pretty(self)
+            .map_err(|e| format!("Failed to serialise host report to JSON: {e}"))
+    }
+}
+
+/// A knob with no override: a host-derived ceiling.
+const fn host_ceiling(value: u64) -> Knob {
+    Knob {
+        value,
+        source: KnobSource::Default,
+        env_var: None,
+    }
+}
+
+/// Would `name`'s current value be honoured by a `usize` knob resolver?
+fn env_source_usize(name: &str) -> KnobSource {
+    source_from_raw(name, std::env::var(name).ok().as_deref(), 0usize, |s| {
+        s.parse::<usize>().ok()
+    })
+}
+
+/// Would `name`'s current value be honoured by the GPU scratch resolver?
+///
+/// That resolver additionally rejects `0` as semantically invalid, so the same
+/// predicate is applied here.
+fn env_source_positive_u64(name: &str) -> KnobSource {
+    source_from_raw(name, std::env::var(name).ok().as_deref(), 0u64, |s| {
+        s.parse::<u64>().ok().filter(|&b| b > 0)
+    })
+}
+
+/// Classify a raw override value using the **shipped** acceptance predicate.
+///
+/// Unset, blank, and malformed values all fall back to the built-in default in
+/// [`parse_tuning_var`], so only a value that parser accepts is reported as
+/// `env`. Routing through the same helper keeps the reported source from
+/// drifting away from what the resolver actually did.
+fn source_from_raw<T, F>(name: &str, raw: Option<&str>, probe_default: T, parse: F) -> KnobSource
+where
+    T: std::fmt::Display,
+    F: FnOnce(&str) -> Option<T>,
+{
+    let Some(raw) = raw else {
+        return KnobSource::Default;
+    };
+    if raw.trim().is_empty() {
+        return KnobSource::Default;
+    }
+    let (_value, warning) = parse_tuning_var(name, Some(raw), probe_default, parse);
+    if warning.is_some() {
+        KnobSource::Default
+    } else {
+        KnobSource::Env
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_usize(s: &str) -> Option<usize> {
+        s.parse::<usize>().ok()
+    }
+
+    #[test]
+    fn unset_and_blank_overrides_report_the_default_source() {
+        assert_eq!(
+            source_from_raw("NEAT_SCORER_READ_BYTES", None, 0usize, parse_usize),
+            KnobSource::Default
+        );
+        for raw in ["", "   ", "\t"] {
+            assert_eq!(
+                source_from_raw("NEAT_SCORER_READ_BYTES", Some(raw), 0usize, parse_usize),
+                KnobSource::Default,
+                "blank {raw:?} is not an override"
+            );
+        }
+    }
+
+    #[test]
+    fn honoured_override_reports_the_env_source() {
+        assert_eq!(
+            source_from_raw(
+                "NEAT_SCORER_READ_BYTES",
+                Some("4194304"),
+                0usize,
+                parse_usize
+            ),
+            KnobSource::Env
+        );
+        // Surrounding whitespace is trimmed by the shared parser, so the value
+        // is still honoured — and must still read as an override.
+        assert_eq!(
+            source_from_raw(
+                "NEAT_SCORER_READ_BYTES",
+                Some(" 4194304 "),
+                0usize,
+                parse_usize
+            ),
+            KnobSource::Env
+        );
+    }
+
+    #[test]
+    fn malformed_override_reports_the_default_source() {
+        // The shipped resolver warns and falls back on these, so the report
+        // must not claim an override that never applied.
+        for raw in ["2MB", "-1", "lots"] {
+            assert_eq!(
+                source_from_raw("NEAT_SCORER_READ_BYTES", Some(raw), 0usize, parse_usize),
+                KnobSource::Default,
+                "malformed {raw:?} must not read as an override"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_gpu_scratch_is_not_an_override() {
+        // `scratch_budget_bytes_from_env` rejects zero as semantically invalid;
+        // the report applies the same predicate.
+        let parse = |s: &str| s.parse::<u64>().ok().filter(|&b| b > 0);
+        assert_eq!(
+            source_from_raw("NEAT_SCORER_GPU_SCRATCH_BYTES", Some("0"), 0u64, parse),
+            KnobSource::Default
+        );
+        assert_eq!(
+            source_from_raw(
+                "NEAT_SCORER_GPU_SCRATCH_BYTES",
+                Some("134217728"),
+                0u64,
+                parse
+            ),
+            KnobSource::Env
+        );
+    }
+
+    #[test]
+    fn report_serialises_every_knob_with_a_source() {
+        let report = HostReport::resolve(DEFAULT_REPORT_RECORD_BYTES);
+        let json = report.to_json().expect("report must serialise");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(value["schema"], SCHEMA);
+        assert_eq!(value["record_bytes"], DEFAULT_REPORT_RECORD_BYTES as u64);
+        assert!(value["logical_cpus"].as_u64().is_some_and(|n| n >= 1));
+        for key in [
+            "default_worker_count",
+            "max_worker_count",
+            "max_read_bytes",
+            "default_training_read_bytes",
+            "gpu_scratch_bytes",
+        ] {
+            let knob = &value["knobs"][key];
+            assert!(
+                knob["value"].as_u64().is_some_and(|v| v > 0),
+                "{key} must carry a positive value, got {knob}"
+            );
+            let source = knob["source"].as_str().unwrap_or_default();
+            assert!(
+                source == "default" || source == "env",
+                "{key} source must be default|env, got {knob}"
+            );
+        }
+        // Ceilings take no override, so they serialise a null `env_var`.
+        assert!(value["knobs"]["max_worker_count"]["env_var"].is_null());
+        assert_eq!(
+            value["knobs"]["max_read_bytes"]["source"], "default",
+            "a host ceiling is never an env override"
+        );
+    }
+
+    #[test]
+    fn read_default_tracks_the_requested_record_width() {
+        // Record-size adaptive: a production-width record takes a bigger chunk
+        // than a 40-byte one on every host whose RAM probe succeeds.
+        let small = HostReport::resolve(40);
+        let large = HostReport::resolve(DEFAULT_REPORT_RECORD_BYTES);
+        assert_eq!(small.record_bytes, 40);
+        assert_eq!(large.record_bytes, DEFAULT_REPORT_RECORD_BYTES);
+        assert!(
+            large.knobs.default_training_read_bytes.value
+                >= small.knobs.default_training_read_bytes.value
+        );
+    }
+}

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -22,6 +22,7 @@ pub mod cost;
 pub mod env_tuning;
 pub mod fixture_json;
 pub mod gpu;
+pub mod host_report;
 pub mod host_resources;
 pub mod multi_score;
 pub mod prod_fixture;

--- a/rust_scorer/tests/host_report.rs
+++ b/rust_scorer/tests/host_report.rs
@@ -1,0 +1,243 @@
+//! Integration tests for the `--host-report` knob diagnostic (Issue #545).
+//!
+//! The report is the measurement rig the rest of the #544 retune chain cites,
+//! so it must run **everywhere** — including the GPU-less CI runner and under
+//! `--gpu off` — without initialising a `wgpu` adapter, and must emit one
+//! stable JSON object a fleet operator can paste into an issue comment.
+
+use std::process::Command;
+
+use serde_json::Value;
+
+/// Tuning knobs cleared on every invocation so an inherited value from the
+/// developer's shell cannot flip a `source` assertion.
+const TUNING_VARS: [&str; 5] = [
+    "NEAT_SCORER_READ_BYTES",
+    "NEAT_SCORER_ACTIVATION_THREADS",
+    "NEAT_SCORER_FILE_THREADS",
+    "NEAT_SCORER_GPU_SCRATCH_BYTES",
+    "NEAT_SCORER_GPU",
+];
+
+/// Run the built binary with a hermetic environment and return
+/// `(status_code, stdout, stderr)`.
+fn run_scorer(args: &[&str], env: &[(&str, &str)]) -> (i32, String, String) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_rust_scorer"));
+    for var in TUNING_VARS {
+        cmd.env_remove(var);
+    }
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd.args(args).output().expect("run rust_scorer");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// Parse stdout as exactly one JSON object (fails on trailing junk).
+fn parse_report(stdout: &str) -> Value {
+    let value: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("--host-report stdout must be one JSON object: {e}\n{stdout}"));
+    assert!(
+        value.is_object(),
+        "--host-report must emit a JSON object, got: {value}"
+    );
+    value
+}
+
+/// Every knob entry the #544 retune sub-issues read.
+const KNOB_KEYS: [&str; 5] = [
+    "default_worker_count",
+    "max_worker_count",
+    "max_read_bytes",
+    "default_training_read_bytes",
+    "gpu_scratch_bytes",
+];
+
+fn assert_report_shape(report: &Value) {
+    assert!(
+        report["logical_cpus"].as_u64().is_some_and(|n| n >= 1),
+        "logical_cpus must be a positive integer, got: {report}"
+    );
+    // `physical_ram_bytes` is `null` only where the platform probe is
+    // unavailable; on every supported CI/fleet OS it is a positive integer.
+    let ram = &report["physical_ram_bytes"];
+    assert!(
+        ram.is_null() || ram.as_u64().is_some_and(|n| n > 0),
+        "physical_ram_bytes must be null or positive, got: {ram}"
+    );
+    assert!(
+        report["record_bytes"].as_u64().is_some_and(|n| n > 0),
+        "record_bytes must be a positive integer, got: {report}"
+    );
+    let knobs = report["knobs"]
+        .as_object()
+        .unwrap_or_else(|| panic!("report must carry a knobs object, got: {report}"));
+    for key in KNOB_KEYS {
+        let knob = knobs
+            .get(key)
+            .unwrap_or_else(|| panic!("knob '{key}' missing from report: {report}"));
+        assert!(
+            knob["value"].as_u64().is_some_and(|v| v > 0),
+            "knob '{key}' must carry a positive value, got: {knob}"
+        );
+        let source = knob["source"].as_str().unwrap_or_default();
+        assert!(
+            source == "default" || source == "env",
+            "knob '{key}' source must be 'default' or 'env', got: {knob}"
+        );
+    }
+}
+
+#[test]
+fn host_report_runs_without_positional_args_and_emits_one_json_object() {
+    let (code, stdout, stderr) = run_scorer(&["--host-report"], &[]);
+    assert_eq!(code, 0, "--host-report must exit 0; stderr: {stderr}");
+    let report = parse_report(&stdout);
+    assert_report_shape(&report);
+    for key in KNOB_KEYS {
+        assert_eq!(
+            report["knobs"][key]["source"], "default",
+            "with no env override, knob '{key}' must report source=default"
+        );
+    }
+}
+
+#[test]
+fn host_report_runs_with_gpu_off_without_initialising_an_adapter() {
+    let (code, stdout, stderr) = run_scorer(&["--host-report", "--gpu", "off"], &[]);
+    assert_eq!(
+        code, 0,
+        "--host-report --gpu off must exit 0; stderr: {stderr}"
+    );
+    assert_report_shape(&parse_report(&stdout));
+}
+
+/// `--gpu on` on a GPU-less host normally hard-errors; the report must still
+/// run, because it never reaches adapter selection.
+#[test]
+fn host_report_never_aborts_even_under_gpu_on() {
+    let (code, stdout, stderr) = run_scorer(&["--host-report", "--gpu", "on"], &[]);
+    assert_eq!(
+        code, 0,
+        "--host-report --gpu on must still report; stderr: {stderr}"
+    );
+    assert_report_shape(&parse_report(&stdout));
+}
+
+#[test]
+fn env_override_flips_the_matching_knob_source_to_env() {
+    // 4 MiB is inside every host's `max_read_bytes` clamp, and a whole number
+    // of the default 9848-byte record width is *not* required — the resolver
+    // rounds down to the record multiple, so assert the rounded value.
+    let (code, stdout, stderr) =
+        run_scorer(&["--host-report"], &[("NEAT_SCORER_READ_BYTES", "4194304")]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let report = parse_report(&stdout);
+    let knob = &report["knobs"]["default_training_read_bytes"];
+    assert_eq!(
+        knob["source"], "env",
+        "an honoured NEAT_SCORER_READ_BYTES must report source=env, got: {knob}"
+    );
+    let record_bytes = report["record_bytes"].as_u64().expect("record_bytes");
+    let value = knob["value"].as_u64().expect("value");
+    assert_eq!(
+        value,
+        (4_194_304 / record_bytes) * record_bytes,
+        "value must be the resolved (record-aligned) read target, got: {knob}"
+    );
+    // Untouched knobs keep reporting their built-in default.
+    assert_eq!(report["knobs"]["gpu_scratch_bytes"]["source"], "default");
+
+    let (code, stdout, _) = run_scorer(
+        &["--host-report"],
+        &[("NEAT_SCORER_GPU_SCRATCH_BYTES", "134217728")],
+    );
+    assert_eq!(code, 0);
+    let report = parse_report(&stdout);
+    assert_eq!(report["knobs"]["gpu_scratch_bytes"]["source"], "env");
+    assert_eq!(
+        report["knobs"]["gpu_scratch_bytes"]["value"],
+        134_217_728u64
+    );
+
+    let (code, stdout, _) = run_scorer(
+        &["--host-report"],
+        &[("NEAT_SCORER_ACTIVATION_THREADS", "3")],
+    );
+    assert_eq!(code, 0);
+    let report = parse_report(&stdout);
+    assert_eq!(report["knobs"]["default_worker_count"]["source"], "env");
+    assert_eq!(report["knobs"]["default_worker_count"]["value"], 3);
+}
+
+/// A malformed override is *not* honoured (the shipped resolver warns and falls
+/// back), so the report must keep saying `default` rather than claiming an
+/// override that never took effect.
+#[test]
+fn malformed_env_override_still_reports_the_default_source() {
+    let (code, stdout, stderr) =
+        run_scorer(&["--host-report"], &[("NEAT_SCORER_READ_BYTES", "2MB")]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let report = parse_report(&stdout);
+    assert_eq!(
+        report["knobs"]["default_training_read_bytes"]["source"], "default",
+        "an ignored malformed value must not be reported as an env override"
+    );
+    assert!(
+        stderr.contains("ignoring invalid NEAT_SCORER_READ_BYTES"),
+        "the malformed value must still be reported on stderr, got: {stderr}"
+    );
+}
+
+/// The read default is record-size adaptive, so the report takes the width it
+/// was resolved for and echoes it back.
+#[test]
+fn record_bytes_flag_drives_the_read_default() {
+    let (code, stdout, stderr) = run_scorer(&["--host-report", "--record-bytes", "40"], &[]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let small = parse_report(&stdout);
+    assert_eq!(small["record_bytes"], 40);
+
+    let (code, stdout, _) = run_scorer(&["--host-report", "--record-bytes", "9848"], &[]);
+    assert_eq!(code, 0);
+    let large = parse_report(&stdout);
+    assert_eq!(large["record_bytes"], 9848);
+
+    let small_read = small["knobs"]["default_training_read_bytes"]["value"]
+        .as_u64()
+        .expect("value");
+    let large_read = large["knobs"]["default_training_read_bytes"]["value"]
+        .as_u64()
+        .expect("value");
+    assert!(
+        large_read > small_read,
+        "production-width records must take a larger read chunk than 40-byte records \
+         ({large_read} vs {small_read})"
+    );
+}
+
+/// Input validation: a zero record width is rejected loudly rather than
+/// silently clamped.
+#[test]
+fn zero_record_bytes_is_rejected() {
+    let (code, _stdout, stderr) = run_scorer(&["--host-report", "--record-bytes", "0"], &[]);
+    assert_ne!(code, 0, "--record-bytes 0 must fail loud");
+    assert!(
+        stderr.to_lowercase().contains("record"),
+        "the error must name the offending flag, got: {stderr}"
+    );
+}
+
+/// Two consecutive runs on the same host with the same environment must emit
+/// byte-identical JSON — the report is pasted into issue comments and diffed
+/// between fleet hosts.
+#[test]
+fn report_output_is_stable_across_runs() {
+    let (_, first, _) = run_scorer(&["--host-report"], &[]);
+    let (_, second, _) = run_scorer(&["--host-report"], &[]);
+    assert_eq!(first, second, "--host-report output must be deterministic");
+}

--- a/scripts/bench-knob-sweep.sh
+++ b/scripts/bench-knob-sweep.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+# scripts/bench-knob-sweep.sh — Issue #545 (enabler for the #544 retune chain)
+#
+# Sweeps ONE host-tuned knob across a caller-supplied list of values on the
+# production scoring path and reports the median wall-clock per value, in the
+# same table shape as `scripts/bench-shallow-gpu.sh`. Every #544 sub-issue cites
+# its before/after numbers from here instead of hand-rolling a measurement rig.
+#
+# The run opens with the scorer's own `--host-report` JSON, so a pasted sweep
+# carries the host it was measured on (logical CPUs, RAM, resolved knobs).
+#
+# This public repo ships no production creature and no corpus, and fetches
+# neither (Issue #448): point BENCH_SWEEP_CREATURE and BENCH_SWEEP_DATA at local
+# inputs. With either unset the harness skips cleanly (exit 0); once they are
+# supplied it is fail-loud — an unreadable input or a failed scoring run exits
+# non-zero rather than reporting an empty sweep as success.
+#
+# Usage:
+#   BENCH_SWEEP_CREATURE=/path/to/creatures_dir BENCH_SWEEP_DATA=/path/to/corpus \
+#     BENCH_SWEEP_KNOB=NEAT_SCORER_READ_BYTES \
+#     BENCH_SWEEP_VALUES=default,2097152,8388608,33554432 \
+#     ./scripts/bench-knob-sweep.sh
+#
+# Environment:
+#   BENCH_SWEEP_CREATURE  local creature JSON *or* creatures directory (required)
+#   BENCH_SWEEP_DATA      local training-data directory of .bin files (required)
+#   BENCH_SWEEP_KNOB      NEAT_SCORER_* env var to sweep
+#                         (default NEAT_SCORER_READ_BYTES)
+#   BENCH_SWEEP_VALUES    comma-separated values; the literal `default` runs
+#                         with the knob unset (default "default" — a
+#                         single-knob-neutral baseline run)
+#   BENCH_SWEEP_REPS      timed repetitions per value (default 5, median reported)
+#   BENCH_SWEEP_GPU       --gpu mode for every run (default auto, as production
+#                         omits the flag)
+#   BENCH_SWEEP_SCORER    scorer binary (default target/release/rust_scorer,
+#                         built with `cargo build --release` when absent)
+#
+# Requires `python3` (median arithmetic).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+CREATURE="${BENCH_SWEEP_CREATURE:-}"
+DATA_DIR="${BENCH_SWEEP_DATA:-}"
+KNOB="${BENCH_SWEEP_KNOB:-NEAT_SCORER_READ_BYTES}"
+VALUE_SPEC="${BENCH_SWEEP_VALUES:-default}"
+REPS="${BENCH_SWEEP_REPS:-5}"
+GPU_MODE="${BENCH_SWEEP_GPU:-auto}"
+
+if [ -z "$CREATURE" ] || [ -z "$DATA_DIR" ]; then
+  echo "⏭️  BENCH_SWEEP_CREATURE / BENCH_SWEEP_DATA are unset — nothing to sweep, skipping."
+  echo "   This repo ships no creature or corpus and fetches none (Issue #448)."
+  echo "   Supply local inputs, e.g.:"
+  echo "     BENCH_SWEEP_CREATURE=/path/to/creatures BENCH_SWEEP_DATA=/path/to/corpus $0"
+  exit 0
+fi
+
+if ! command -v python3 > /dev/null 2>&1; then
+  echo "❌ python3 is required for the median arithmetic" >&2
+  exit 1
+fi
+
+if [ ! -e "$CREATURE" ] || [ ! -r "$CREATURE" ]; then
+  echo "❌ BENCH_SWEEP_CREATURE is not a readable file or directory: ${CREATURE}" >&2
+  exit 1
+fi
+if [ ! -d "$DATA_DIR" ] || [ ! -r "$DATA_DIR" ]; then
+  echo "❌ BENCH_SWEEP_DATA is not a readable directory: ${DATA_DIR}" >&2
+  exit 1
+fi
+
+# Allowlist the knob name: it is injected into the scorer's environment, so only
+# the scorer's own tuning namespace is accepted.
+case "$KNOB" in
+  NEAT_SCORER_*)
+    if ! printf '%s' "$KNOB" | grep -Eq '^NEAT_SCORER_[A-Z0-9_]+$'; then
+      echo "❌ BENCH_SWEEP_KNOB must match NEAT_SCORER_[A-Z0-9_]+: ${KNOB}" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "❌ BENCH_SWEEP_KNOB must be a NEAT_SCORER_* tuning variable: ${KNOB}" >&2
+    exit 1
+    ;;
+esac
+
+if ! printf '%s' "$REPS" | grep -Eq '^[1-9][0-9]*$'; then
+  echo "❌ BENCH_SWEEP_REPS must be a positive integer: ${REPS}" >&2
+  exit 1
+fi
+
+case "$GPU_MODE" in
+  auto | on | off) ;;
+  *)
+    echo "❌ BENCH_SWEEP_GPU must be auto, on or off: ${GPU_MODE}" >&2
+    exit 1
+    ;;
+esac
+
+# Split the comma-separated value list (bash 3.2 compatible; parameter expansion
+# only — never assign IFS globally).
+VALUES=()
+REMAINING="$VALUE_SPEC"
+while [ -n "$REMAINING" ]; do
+  case "$REMAINING" in
+    *,*)
+      v="${REMAINING%%,*}"
+      REMAINING="${REMAINING#*,}"
+      ;;
+    *)
+      v="$REMAINING"
+      REMAINING=''
+      ;;
+  esac
+  [ -n "$v" ] && VALUES+=("$v")
+done
+
+if [ "${#VALUES[@]}" -eq 0 ]; then
+  echo "❌ BENCH_SWEEP_VALUES contained no usable value: ${VALUE_SPEC}" >&2
+  exit 1
+fi
+
+for v in "${VALUES[@]}"; do
+  if [ "$v" != "default" ] && ! printf '%s' "$v" | grep -Eq '^[0-9]+$'; then
+    echo "❌ BENCH_SWEEP_VALUES entries must be 'default' or a non-negative integer: ${v}" >&2
+    exit 1
+  fi
+done
+
+SCORER="${BENCH_SWEEP_SCORER:-${REPO_ROOT}/target/release/rust_scorer}"
+if [ ! -x "$SCORER" ]; then
+  echo "🛠  Building release scorer (missing: $SCORER)"
+  if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck disable=SC1091
+    source "$HOME/.cargo/env"
+  fi
+  (cd "$REPO_ROOT" && cargo build -p rust_scorer --release)
+fi
+if [ ! -x "$SCORER" ]; then
+  echo "❌ scorer binary is not executable: $SCORER" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/neat-knob-sweep.XXXXXX")"
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+echo "🖥  Host knob report"
+if ! "$SCORER" --host-report > "${WORK_DIR}/host-report.json" 2> "${WORK_DIR}/host-report.err"; then
+  echo "❌ ${SCORER} --host-report failed — the harness cannot record the host it measured" >&2
+  sed -n '1,20p' "${WORK_DIR}/host-report.err" >&2
+  exit 1
+fi
+cat "${WORK_DIR}/host-report.json"
+
+echo
+echo "🔁 Sweeping ${KNOB} over: ${VALUES[*]}"
+echo "   creature=${CREATURE}  data=${DATA_DIR}  reps=${REPS}  --gpu ${GPU_MODE}"
+
+RESULT_LINES=""
+BASELINE_MEDIAN=""
+
+# `time` writes to the enclosing stderr; the command's own streams are captured
+# separately so only the elapsed seconds reach `elapsed`.
+TIMEFORMAT='%R'
+
+for value in "${VALUES[@]}"; do
+  echo
+  echo "⏱  ${KNOB}=${value}"
+  samples=()
+  backend=""
+  for rep in $(seq 1 "$REPS"); do
+    out="${WORK_DIR}/out-${value}.json"
+    err="${WORK_DIR}/err-${value}.txt"
+    rc_file="${WORK_DIR}/rc-${value}.txt"
+    if [ "$value" = "default" ]; then
+      elapsed="$( { time env -u "$KNOB" "$SCORER" --gpu "$GPU_MODE" "$CREATURE" "$DATA_DIR" \
+        > "$out" 2> "$err"; echo "$?" > "$rc_file"; } 2>&1 )"
+    else
+      elapsed="$( { time env "${KNOB}=${value}" "$SCORER" --gpu "$GPU_MODE" "$CREATURE" "$DATA_DIR" \
+        > "$out" 2> "$err"; echo "$?" > "$rc_file"; } 2>&1 )"
+    fi
+    rc="$(cat "$rc_file")"
+    if [ "$rc" -ne 0 ]; then
+      echo "❌ scorer failed at ${KNOB}=${value} (exit ${rc})" >&2
+      sed -n '1,20p' "$err" >&2
+      exit 1
+    fi
+    backend="$(sed -n 's/.*"gpuBackend": *"\([^"]*\)".*/\1/p' "$out" | head -n1)"
+    samples+=("$elapsed")
+    echo "   rep ${rep}: ${elapsed}s (${backend})"
+  done
+
+  median="$(python3 -c '
+import statistics, sys
+print(f"{statistics.median(float(x) for x in sys.argv[1:]):.2f}")' \
+    ${samples[@]+"${samples[@]}"})"
+  echo "   median: ${median}s"
+
+  if [ -z "$BASELINE_MEDIAN" ]; then
+    BASELINE_MEDIAN="$median"
+    RESULT_LINES="${RESULT_LINES}| \`${value}\` | ${median} | ${backend} | baseline |"$'\n'
+  else
+    # A baseline median of 0.00s means the run finished below the timer's
+    # resolution, so a percentage is undefined — say so rather than dividing by
+    # zero (which would abort the sweep under `set -e`).
+    delta="$(python3 -c '
+import sys
+base, other = float(sys.argv[1]), float(sys.argv[2])
+if base <= 0.0:
+    print("n/a (baseline median 0.00s — below timer resolution)")
+else:
+    print(f"{(base - other) / base * 100.0:+.1f}% vs baseline")' "$BASELINE_MEDIAN" "$median")"
+    echo "   vs baseline: ${delta}"
+    RESULT_LINES="${RESULT_LINES}| \`${value}\` | ${median} | ${backend} | ${delta} |"$'\n'
+  fi
+done
+
+echo
+echo "📊 Median wall-clock (${KNOB}, ${REPS} reps, --gpu ${GPU_MODE})"
+echo
+echo "| Value | Wall (s) | gpuBackend | Delta |"
+echo "|---|---|---|---|"
+printf '%s' "$RESULT_LINES"

--- a/tests/scripts/bench_knob_sweep.bats
+++ b/tests/scripts/bench_knob_sweep.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Tests for scripts/bench-knob-sweep.sh — Issue #545.
+#
+# The real harness scores a production corpus, so the scorer binary is shimmed
+# on disk and the inputs kept tiny. We assert the observable contract:
+#   * missing corpus/creature inputs skip cleanly (exit 0) — the Issue #448
+#     convention shared with scripts/bench-shallow-gpu.sh,
+#   * supplied-but-unreadable inputs fail loud (non-zero) — never a silent pass,
+#   * the swept knob reaches the scorer's environment at each value, and is
+#     unset for the literal `default`,
+#   * every value runs the requested number of repetitions,
+#   * a non-zero scorer exit propagates,
+#   * the host report and the median/delta table are emitted.
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/bench-knob-sweep.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP="$(mktemp -d)"
+  export TMP
+  SCORER_LOG="${TMP}/scorer-log"
+  export SCORER_LOG
+
+  # Shim scorer: answers --host-report, otherwise logs the swept knob value and
+  # emits a plausible directory-mode JSON body.
+  cat > "${TMP}/scorer" << EOF
+#!/bin/bash
+if [ "\$1" = "--host-report" ]; then
+  echo '{"schema":"neat-scorer-host-report/1","logical_cpus":4,"knobs":{}}'
+  exit "\${SHIM_REPORT_EXIT:-0}"
+fi
+echo "ARGS: \$* KNOB=\${NEAT_SCORER_READ_BYTES-unset} THREADS=\${NEAT_SCORER_ACTIVATION_THREADS-unset}" >> "${SCORER_LOG}"
+echo '{"c-000":{"score":-0.1,"error":1.0,"recordCount":8,"gpuBackend":"cpu-fallback"}}'
+exit "\${SHIM_SCORER_EXIT:-0}"
+EOF
+  chmod +x "${TMP}/scorer"
+
+  mkdir -p "${TMP}/creatures" "${TMP}/data"
+  printf 'x' > "${TMP}/data/0.bin"
+  printf '{}' > "${TMP}/creatures/c-000.json"
+
+  export BENCH_SWEEP_SCORER="${TMP}/scorer"
+  export BENCH_SWEEP_REPS=2
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+@test "skips cleanly when the creature input is unset" {
+  run env -u BENCH_SWEEP_CREATURE BENCH_SWEEP_DATA="${TMP}/data" "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BENCH_SWEEP_CREATURE"* ]]
+  [[ "$output" == *"skip"* ]]
+  [ ! -f "$SCORER_LOG" ]
+}
+
+@test "skips cleanly when the corpus input is unset" {
+  run env -u BENCH_SWEEP_DATA BENCH_SWEEP_CREATURE="${TMP}/creatures" "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skip"* ]]
+  [ ! -f "$SCORER_LOG" ]
+}
+
+@test "fails loud when the creature input does not exist" {
+  BENCH_SWEEP_CREATURE="${TMP}/missing" BENCH_SWEEP_DATA="${TMP}/data" \
+    run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "fails loud when the corpus directory does not exist" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/no-such-corpus" \
+    run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no-such-corpus"* ]]
+}
+
+@test "prints the host report before sweeping" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"neat-scorer-host-report/1"* ]]
+}
+
+@test "fails loud when the scorer cannot produce a host report" {
+  SHIM_REPORT_EXIT=4 BENCH_SWEEP_CREATURE="${TMP}/creatures" \
+    BENCH_SWEEP_DATA="${TMP}/data" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"host-report"* ]]
+}
+
+@test "runs every value for the requested repetitions" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_VALUES="2097152,8388608" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c 'KNOB=2097152' "$SCORER_LOG")" -eq 2 ]
+  [ "$(grep -c 'KNOB=8388608' "$SCORER_LOG")" -eq 2 ]
+}
+
+@test "the literal default value runs with the knob unset" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_VALUES="default" NEAT_SCORER_READ_BYTES=999 run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c 'KNOB=unset' "$SCORER_LOG")" -eq 2 ]
+}
+
+@test "sweeps a knob other than the read-bytes default" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_KNOB=NEAT_SCORER_ACTIVATION_THREADS BENCH_SWEEP_VALUES="4" \
+    run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c 'THREADS=4' "$SCORER_LOG")" -eq 2 ]
+}
+
+@test "invokes the scorer with the creature and data paths and the gpu mode" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_GPU=off BENCH_SWEEP_VALUES="default" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  grep -q -- "--gpu off ${TMP}/creatures ${TMP}/data" "$SCORER_LOG"
+}
+
+@test "rejects a knob outside the NEAT_SCORER_ namespace" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_KNOB="PATH" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"NEAT_SCORER"* ]]
+  [ ! -f "$SCORER_LOG" ]
+}
+
+@test "rejects a non-numeric sweep value" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_VALUES="2097152,lots" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"lots"* ]]
+  [ ! -f "$SCORER_LOG" ]
+}
+
+@test "rejects an invalid gpu mode" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_GPU="yolo" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"yolo"* ]]
+}
+
+@test "propagates a non-zero scorer exit instead of reporting success" {
+  SHIM_SCORER_EXIT=3 BENCH_SWEEP_CREATURE="${TMP}/creatures" \
+    BENCH_SWEEP_DATA="${TMP}/data" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"exit 3"* ]]
+}
+
+@test "prints a median per value and the delta against the first value" {
+  BENCH_SWEEP_CREATURE="${TMP}/creatures" BENCH_SWEEP_DATA="${TMP}/data" \
+    BENCH_SWEEP_VALUES="default,2097152" run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"median"* ]]
+  [[ "$output" == *"vs baseline"* ]]
+  [[ "$output" == *"| Value | Wall (s) | gpuBackend | Delta |"* ]]
+}


### PR DESCRIPTION
# Host knob report and fleet knob-sweep harness (Issue #545)

## Summary

Adds the measurement rig the rest of the #544 self-tune chain cites, so each
retune sub-issue can produce before/after numbers instead of inventing its own
harness. **Measurement only — no shipped default changed.** Closes #545.

1. **Knob report.** `rust_scorer --host-report` prints the detected host
   (logical CPUs, physical RAM) and every resolved knob —
   `default_worker_count`, `max_worker_count`, `max_read_bytes`,
   `default_training_read_bytes`, `gpu_scratch_bytes` — as one JSON object, each
   tagged `default` or `env`. `source` is `env` only when an override was parsed
   **and honoured**: a malformed value is rejected by the shipped resolver, so
   it keeps reporting `default` (and still warns on stderr) rather than claiming
   an override that never applied. The report is resolved before GPU mode
   resolution, so it never creates a `wgpu` adapter and returns identical JSON
   on a GPU-less host, under `--gpu off` and under `--gpu on`.
   `--record-bytes <BYTES>` selects the record width the record-size-adaptive
   read knob is resolved for (default: the 9848 B production width); zero is
   rejected, not clamped.
2. **Sweep harness.** `scripts/bench-knob-sweep.sh` runs the production scoring
   path at a caller-supplied list of values for one `NEAT_SCORER_*` knob and
   reports the median wall-clock per value, in the same table shape as
   `scripts/bench-shallow-gpu.sh`. It opens with the host's `--host-report` JSON
   so a pasted sweep carries the machine it was measured on. With
   `BENCH_SWEEP_CREATURE` / `BENCH_SWEEP_DATA` unset it **skips cleanly**
   (exit 0, Issue #448 convention); once supplied it is **fail-loud** — an
   unreadable input, a knob name outside the `NEAT_SCORER_*` allowlist, a
   non-numeric value, a failed host report or a non-zero scoring run all exit
   non-zero.
3. **Fleet baseline.** `docs/performance-baseline.md` gains a "#544 fleet knob
   baseline" section with the report output, the single-knob-neutral baseline
   and two example sweeps for the Apple mid tier (M4, 10 cores, 24 GB), plus the
   harness's measured noise floor.

```mermaid
flowchart LR
    H[host probe<br/>CPUs · RAM] --> R[--host-report JSON]
    E[NEAT_SCORER_* env] --> R
    R --> S[bench-knob-sweep.sh]
    V[BENCH_SWEEP_VALUES] --> S
    C[local creature + corpus] --> S
    S --> T[median wall-clock per value<br/>+ delta vs baseline]
    T --> D[#544 retune sub-issue<br/>before/after evidence]
```

## Evidence

Backend/CLI change — no web interface to screenshot. Evidence is the report
output, the harness run and the tests.

`./target/release/rust_scorer --host-report` on an Apple M4 (10 cores, 24 GB):

```json
{
  "schema": "neat-scorer-host-report/1",
  "logical_cpus": 10,
  "physical_ram_bytes": 25769803776,
  "record_bytes": 9848,
  "knobs": {
    "default_worker_count": { "value": 10, "source": "default", "env_var": "NEAT_SCORER_ACTIVATION_THREADS" },
    "max_worker_count": { "value": 256, "source": "default", "env_var": null },
    "max_read_bytes": { "value": 67108864, "source": "default", "env_var": null },
    "default_training_read_bytes": { "value": 33552136, "source": "default", "env_var": "NEAT_SCORER_READ_BYTES" },
    "gpu_scratch_bytes": { "value": 536870912, "source": "default", "env_var": "NEAT_SCORER_GPU_SCRATCH_BYTES" }
  }
}
```

Every line matches the shipped policy for this tier: one worker per logical CPU
under the 256 ceiling (≥ 8 GiB RAM), the 64 MiB mid-host read ceiling, the
32 MiB large-record default rounded to a whole record multiple
(`33552136 = 3407 × 9848`), and the 512 MiB scratch budget for the 16–64 GiB
band. At `--record-bytes 40` the read default drops to `2097120`.

Harness run (synthetic shallow pool at production record width — 50 creatures,
20 000 records over 4 shards, 9848 B/record; this repo ships no production
creature, Issue #448), median of 5 under `--gpu off`:

| `NEAT_SCORER_READ_BYTES` | Wall (s) | vs baseline |
|---|---|---|
| `default` (→ 33 552 136) | 1.55 | baseline |
| `2097152` | 1.52 | +1.9 % |
| `8388608` | 1.54 | +0.6 % |
| `33554432` (→ same 33 552 136) | 1.67 | −7.7 % |

| `NEAT_SCORER_ACTIVATION_THREADS` | Wall (s) | vs baseline |
|---|---|---|
| `default` (→ 10) | 1.97 | baseline |
| `4` | 1.79 | +9.1 % |
| `10` | 1.68 | +14.7 % |
| `20` | 1.63 | +17.3 % |

`default` and `33554432` resolve to the *same* chunk size, so their 7.7 % gap is
the harness's noise floor on this fixture, not a knob effect — recorded
explicitly in the baseline doc so a retune does not cite a sub-noise win.

**x86 Linux tier not captured.** No x86 Linux fleet host is reachable from the
unattended worker, so that tier's row is marked outstanding and tracked in
stSoftwareAU/NEAT-AI-scorer#551 (measurement only; needs a human with fleet
access). The report *code path* is still exercised on the GPU-less Linux CI
runner by `rust_scorer/tests/host_report.rs` on every PR.

## Test Plan

New — `rust_scorer/tests/host_report.rs` (integration, runs the built binary):

- `host_report_runs_without_positional_args_and_emits_one_json_object` — exit 0,
  stdout parses as exactly one JSON object, every knob key present with a
  `default`/`env` source.
- `host_report_runs_with_gpu_off_without_initialising_an_adapter` and
  `host_report_never_aborts_even_under_gpu_on` — the GPU-less-runner cases from
  the issue's failure-detection plan.
- `env_override_flips_the_matching_knob_source_to_env` — read-bytes, GPU scratch
  and activation-threads overrides each flip only their own entry, and the
  reported value is the resolved (clamped, record-aligned) one.
- `malformed_env_override_still_reports_the_default_source` — an ignored value
  is not reported as an override, and still warns on stderr.
- `record_bytes_flag_drives_the_read_default`, `zero_record_bytes_is_rejected`,
  `report_output_is_stable_across_runs`.

New — `rust_scorer/src/host_report.rs` unit tests: source classification for
unset/blank/honoured/malformed/zero values, and the serialised shape.

New — `rust_scorer/src/cli.rs` unit tests: `--host-report` parses with no
positional args and resolves a report; the report is identical under
`--gpu auto|on|off`; `--record-bytes` validation.

New — `tests/scripts/bench_knob_sweep.bats` (15 cases): clean skip with either
input unset, fail-loud on unreadable inputs / rejected knob name / non-numeric
value / invalid GPU mode / failed host report / non-zero scorer exit, the knob
reaching the scorer environment at each value (and unset for `default`), the
requested repetition count, and the median + delta table.

`./quality.sh` passes clean (shellcheck, cargo-deny, fmt, clippy `-D warnings`,
check, build, 226 unit + all integration tests, rustdoc, release build);
`markdownlint-cli2` reports 0 errors.



## Milestone
This PR is part of the **#544 rust_scorer: self-tune read, worker and GPU knobs to detected host hardware** milestone and targets the `milestone/544-rust-scorer-self-tune-read-worker-and-gpu-knob` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msmnus04-173d33`<!-- vibe-worker-issue-545 -->