### PR TITLE
Branding: hot-link neat-ai-scorer.png from the hub as the README banner (Issue #565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ section to the released version with its date.
 
 ### Added
 
+- **README branding banner, hot-linked from the hub (Issue #565).** One image
+  line under the H1 points at the hub's canonical per-repo preview
+  (`stSoftwareAU/NEAT-AI` `docs/brand/social-previews/neat-ai-scorer.png`,
+  1280×640), so a hub re-render propagates automatically and no image file is
+  committed here. `scripts/check-readme-banner.sh` (in `quality.sh`, and in CI
+  via `tests/scripts/readme_banner.bats`) fails the gate when the banner goes
+  missing, drifts away from the H1, points at a repo-local or wrong-repo
+  image, or loses alt text naming the project.
 - **`docs/self-tuning.md` — the self-tuning policy, tier tables and #544
   roll-up (Issue #550).** One document now carries the full detection → tier →
   knob mapping (worker ceiling, record-size tier, read-chunk RAM ceiling,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.60"
+version = "1.1.61"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NEAT-AI-scorer
 
+![NEAT-AI-scorer banner](https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png)
+
 Native **MSE scorer** CLI for NEAT-AI creatures. Shared logic lives in **`neat-core`**, resolved from a **path dependency** on **[NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core)** (see `rust_scorer/Cargo.toml`). GitHub Actions checks out `NEAT-AI-core` next to this repo so CI can resolve that path
 
 ## Source

--- a/docs/archive/pr-summaries/pr-summary-565.md
+++ b/docs/archive/pr-summaries/pr-summary-565.md
@@ -1,0 +1,58 @@
+# PR Summary — Issue #565
+
+## Summary
+
+Added the branding banner to the root `README.md`: one image line directly
+under the H1 that **hot-links** the hub's canonical per-repo preview
+(`https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png`,
+1280×640). Nothing is committed to this repo, so a future hub re-render
+propagates here automatically.
+
+A guard keeps the banner honest: `scripts/check-readme-banner.sh` (wired into
+`quality.sh`, and run in CI through the existing `bats tests/scripts` job) fails
+when the banner is missing, drifts away from the H1, points at a repo-local or
+another repo's image, or loses alt text naming the project. No other README
+change; `docs/archive/pr-summaries/README.md` stays text-only.
+
+Closes #565.
+
+## Evidence
+
+No web UI to drive here — Playwright MCP is not available in this container, so
+the banner was verified at the source instead:
+
+- Hot-link reachable and correctly sized:
+  `curl -sSI` → `200 image/png`; PNG IHDR decodes to **1280×640**
+  (`0x0500` × `0x0280`).
+- Guard script against the real README:
+
+  ```text
+  OK   README.md: carries a banner image line directly under the H1
+  OK   README.md: banner hot-links the hub preview (https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png)
+  OK   README.md: banner alt text names the project
+  ```
+
+- The banner as it renders (same hot-link the README uses):
+
+  ![NEAT-AI-scorer banner](https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png)
+
+Gate status: `./quality.sh` passed every step up to the codespell preflight,
+which cannot run in this container (`codespell` is not installed and there is no
+`pip`); CI runs that job for real. The full `bats tests/scripts` suite was run
+separately — 615 pass, and the single failure
+(`diagrams_mermaid.bats::living docs contain no box-drawing ASCII diagrams`) is
+pre-existing and environmental: the container has no `en_US.UTF-8` locale, so
+`grep` matches em-dash bytes against the box-drawing class. It fails identically
+on a stashed (unmodified) tree.
+
+## Test Plan
+
+- Added `tests/scripts/readme_banner.bats` (10 cases) exercising
+  `scripts/check-readme-banner.sh` against synthetic fixtures:
+  - passes when the banner hot-links the hub preview under the H1;
+  - fails when there is no banner, or it sits below other prose;
+  - fails when it points at a repo-local image, or another repo's preview;
+  - fails when alt text is empty or does not name the project;
+  - shared harness contract: missing README and unknown flag rejected;
+  - final case runs the validator against the **real** `README.md`, so the
+    banner cannot be dropped without CI going red.

--- a/quality.sh
+++ b/quality.sh
@@ -158,6 +158,9 @@ echo "📦 Validating the binary list is single-homed in the README (Issue #509)
 echo "🔗 Validating cross-document citations resolve (Issue #505)..."
 ./scripts/check-docs-cross-references.sh
 
+echo "🖼️  Validating the README branding banner hot-links the hub preview (Issue #565)..."
+./scripts/check-readme-banner.sh
+
 echo "🕵️  Validating README names no private repository (Issue #450)..."
 ./scripts/check-readme-private-repo-refs.sh
 

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.60"
+version = "1.1.61"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-readme-banner.sh
+++ b/scripts/check-readme-banner.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# check-readme-banner.sh — Issue #565.
+#
+# Guards the README branding banner. The banner is a single image line directly
+# under the H1 that **hot-links** the hub's canonical per-repo preview
+# (`stSoftwareAU/NEAT-AI` `docs/brand/social-previews/neat-ai-scorer.png`), so a
+# hub re-render propagates here automatically and this repo commits no image.
+#
+# The gate enforces:
+#   1. The first non-blank line after the H1 is a markdown image — the banner.
+#   2. Its target is the hub raw hot-link for *this* repo's preview, not a
+#      repo-local path and not another repo's art.
+#   3. Its alt text is non-empty and names the project.
+#
+# Usage:
+#   check-readme-banner.sh [--readme PATH]
+#
+# Exit codes:
+#   0  the banner is present, hot-linked and described
+#   1  the banner is missing, local, mis-targeted or undescribed
+#   2  usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
+
+# The hub's canonical preview for this repo. Any ref on the hub is accepted so a
+# branch rename does not break the gate; the file name is pinned.
+BANNER_HOST="https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/"
+BANNER_FILE="docs/brand/social-previews/neat-ai-scorer.png"
+PROJECT_NAME="NEAT-AI-scorer"
+
+usage() {
+  cat <<'EOF'
+Usage: check-readme-banner.sh [--readme PATH]
+
+Options:
+  --readme PATH  README to validate (default: README.md at the repo root).
+  -h, --help     Show this message.
+
+Exits 0 when the README carries the hot-linked branding banner under its H1.
+EOF
+}
+
+parse_check_args --readme "README.md" "$@"
+README="$CHECK_TARGET"
+check_require_file "$README" "README"
+check_subject "${README##*/}"
+
+# The first non-blank line after the H1 — the banner's only allowed home.
+banner_line="$(awk '
+  /^# / { seen = 1; next }
+  seen && NF { print; exit }
+' "$README")"
+
+if [[ "$banner_line" != !\[* ]]; then
+  fail "no branding banner directly under the H1 — add one image line hot-linking ${BANNER_HOST}<ref>/${BANNER_FILE} (Issue #565)"
+  exit "$EXIT_CODE"
+fi
+ok "carries a banner image line directly under the H1"
+
+alt="${banner_line#!\[}"
+alt="${alt%%]*}"
+url="${banner_line#*](}"
+url="${url%%)*}"
+
+# 2. Hot-linked to the hub's preview for this repo.
+if [[ "$url" == "$BANNER_HOST"*"/$BANNER_FILE" ]]; then
+  ok "banner hot-links the hub preview ($url)"
+else
+  fail "banner target '$url' is not the hub hot-link — expected ${BANNER_HOST}<ref>/${BANNER_FILE} so a hub re-render propagates and no image is committed here (Issue #565)"
+fi
+
+# 3. Alt text present and naming the project.
+if [[ -z "${alt//[[:space:]]/}" ]]; then
+  fail "banner alt text is empty — describe the image and name $PROJECT_NAME (Issue #565)"
+elif grep -qiF "$PROJECT_NAME" <<<"$alt"; then
+  ok "banner alt text names the project"
+else
+  fail "banner alt text '$alt' does not name $PROJECT_NAME (Issue #565)"
+fi
+
+exit "$EXIT_CODE"

--- a/tests/scripts/readme_banner.bats
+++ b/tests/scripts/readme_banner.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-readme-banner.sh — Issue #565.
+#
+# The validator keeps the README branding banner in place: one image line
+# directly under the H1, alt text naming the project, and a hot-link to the
+# hub's canonical per-repo preview so a hub re-render propagates without this
+# repo committing any image. Synthetic fixtures in a temp directory exercise
+# the behaviour, so the real README is never mutated.
+
+load 'test_helper'
+
+BANNER_URL="https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png"
+
+setup() {
+  SCRIPT_UNDER_TEST="${BATS_TEST_DIRNAME}/../../scripts/check-readme-banner.sh"
+  [ -x "$SCRIPT_UNDER_TEST" ] || chmod +x "$SCRIPT_UNDER_TEST"
+
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+
+  write_readme "![NEAT-AI-scorer banner]($BANNER_URL)"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# Stand-in for the real README: H1, banner line, then ordinary prose.
+write_readme() {
+  cat >"$TMP_DIR/README.md" <<EOF
+# NEAT-AI-scorer
+
+$1
+
+Native **MSE scorer** CLI for NEAT-AI creatures.
+
+## Build
+EOF
+}
+
+run_check() {
+  run "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/README.md"
+}
+
+@test "passes when the banner hot-links the hub preview under the H1" {
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "fails when the README has no banner under the H1" {
+  cat >"$TMP_DIR/README.md" <<'EOF'
+# NEAT-AI-scorer
+
+Native **MSE scorer** CLI for NEAT-AI creatures.
+EOF
+  run_check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"banner"* ]]
+}
+
+@test "fails when the banner sits below other prose instead of under the H1" {
+  cat >"$TMP_DIR/README.md" <<EOF
+# NEAT-AI-scorer
+
+Native **MSE scorer** CLI for NEAT-AI creatures.
+
+![NEAT-AI-scorer banner]($BANNER_URL)
+EOF
+  run_check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"banner"* ]]
+}
+
+@test "fails when the banner points at a repo-local image instead of the hub" {
+  write_readme "![NEAT-AI-scorer banner](docs/brand/neat-ai-scorer.png)"
+  run_check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"raw.githubusercontent.com"* ]]
+}
+
+@test "fails when the banner hot-links another repo's preview" {
+  write_readme "![NEAT-AI-scorer banner](https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-core.png)"
+  run_check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"neat-ai-scorer.png"* ]]
+}
+
+@test "fails when the banner alt text is empty" {
+  write_readme "![]($BANNER_URL)"
+  run_check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"alt text"* ]]
+}
+
+@test "fails when the banner alt text does not name the project" {
+  write_readme "![banner]($BANNER_URL)"
+  run_check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"alt text"* ]]
+}
+
+@test "fails loud when the README is missing" {
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --readme "$TMP_DIR/absent.md"
+}
+
+@test "rejects unknown arguments with a usage error" {
+  assert_unknown_flag_rejected "$SCRIPT_UNDER_TEST"
+}
+
+@test "the real repository README satisfies the banner check" {
+  run "$SCRIPT_UNDER_TEST"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# PR Summary — Issue #565

## Summary

Added the branding banner to the root `README.md`: one image line directly
under the H1 that **hot-links** the hub's canonical per-repo preview
(`https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png`,
1280×640). Nothing is committed to this repo, so a future hub re-render
propagates here automatically.

A guard keeps the banner honest: `scripts/check-readme-banner.sh` (wired into
`quality.sh`, and run in CI through the existing `bats tests/scripts` job) fails
when the banner is missing, drifts away from the H1, points at a repo-local or
another repo's image, or loses alt text naming the project. No other README
change; `docs/archive/pr-summaries/README.md` stays text-only.

Closes #565.

## Evidence

No web UI to drive here — Playwright MCP is not available in this container, so
the banner was verified at the source instead:

- Hot-link reachable and correctly sized:
  `curl -sSI` → `200 image/png`; PNG IHDR decodes to **1280×640**
  (`0x0500` × `0x0280`).
- Guard script against the real README:

  ```text
  OK   README.md: carries a banner image line directly under the H1
  OK   README.md: banner hot-links the hub preview (https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png)
  OK   README.md: banner alt text names the project
  ```

- The banner as it renders (same hot-link the README uses):

  ![NEAT-AI-scorer banner](https://raw.githubusercontent.com/stSoftwareAU/NEAT-AI/Develop/docs/brand/social-previews/neat-ai-scorer.png)

Gate status: `./quality.sh` passed every step up to the codespell preflight,
which cannot run in this container (`codespell` is not installed and there is no
`pip`); CI runs that job for real. The full `bats tests/scripts` suite was run
separately — 615 pass, and the single failure
(`diagrams_mermaid.bats::living docs contain no box-drawing ASCII diagrams`) is
pre-existing and environmental: the container has no `en_US.UTF-8` locale, so
`grep` matches em-dash bytes against the box-drawing class. It fails identically
on a stashed (unmodified) tree.

## Test Plan

- Added `tests/scripts/readme_banner.bats` (10 cases) exercising
  `scripts/check-readme-banner.sh` against synthetic fixtures:
  - passes when the banner hot-links the hub preview under the H1;
  - fails when there is no banner, or it sits below other prose;
  - fails when it points at a repo-local image, or another repo's preview;
  - fails when alt text is empty or does not name the project;
  - shared harness contract: missing README and unknown flag rejected;
  - final case runs the validator against the **real** `README.md`, so the
    banner cannot be dropped without CI going red.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msxvjcym-49c640`<!-- vibe-worker-issue-565 -->