### PR TITLE
Single input/output ≥ 1 guard on every scoring path, with regression tests (#571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ section to the released version with its date.
 
 ### Added
 
+- **Single `input`/`output` ≥ 1 guard on every scoring path, with regression
+  tests (Issue #571).** `rust_scorer/src/creature_width.rs` is now the one
+  place the observation-width rule is worded
+  (`Must have at least one input neurons was: N` /
+  `Must have at least one output neurons was: N`, mirroring the TypeScript
+  reference and the `neat-core` errors NEAT-AI-core#550 adds). The single-
+  creature, `--creature-stdin`, directory (CPU and GPU pre-flight), fused
+  streaming (`stream_score`), cost-dispatch (`accumulate_cost_sum`),
+  complexity-scoring (`compute_score_components`), production-fixture and
+  `cost_scan_bench` paths all reject `input < 1` / `output < 1` through it,
+  before any training file is opened — no fallback, no re-derivation from
+  `neurons`. `tests/input_output_width_guard.rs` pins both zeroed counts on
+  every entry path and confirms a valid creature still scores with a
+  `input + output` record width. The local guard stays after core#550 ships
+  (it is the scorer's boundary regardless of the core version).
+
 - **README branding banner, hot-linked from the hub (Issue #565).** One image
   line under the H1 points at the hub's canonical per-repo preview
   (`stSoftwareAU/NEAT-AI` `docs/brand/social-previews/neat-ai-scorer.png`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.61"
+version = "1.1.62"
 dependencies = [
  "bytemuck",
  "clap",

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.61"
+version = "1.1.62"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/bin/cost_scan_bench.rs
+++ b/rust_scorer/src/bin/cost_scan_bench.rs
@@ -43,6 +43,7 @@ use neat_core::creature::{compile_creature, parse_creature_json};
 use neat_core::training_data::{TrainingDataConfig, find_bin_files};
 
 use rust_scorer::cost::CostKind;
+use rust_scorer::creature_width::validate_creature_width;
 use rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused;
 
 #[derive(Parser, Debug)]
@@ -110,6 +111,7 @@ fn run_one_cost(
     runs: usize,
 ) -> Result<CostRow, String> {
     let creature = parse_creature_json(creature_json).map_err(|e| e.to_string())?;
+    validate_creature_width(&creature).map_err(|e| e.to_string())?;
     // Warm-up run: validates the cost is dispatchable and primes caches.
     let mut net = compile_creature(&creature).map_err(|e| e.to_string())?;
     let (warm_sum, warm_records, _, _, _) =
@@ -168,6 +170,11 @@ fn main() {
             std::process::exit(2);
         }
     };
+    // Issue #571: reject a widthless creature before any `.bin` is listed.
+    if let Err(e) = validate_creature_width(&creature) {
+        eprintln!("Invalid creature {}: {e}", cli.creature.display());
+        std::process::exit(2);
+    }
 
     if !cli.data_dir.is_dir() {
         eprintln!("data_dir does not exist: {}", cli.data_dir.display());

--- a/rust_scorer/src/cli.rs
+++ b/rust_scorer/src/cli.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 
 use crate::corpus_guard::assert_records_aligned;
 use crate::cost::CostKind;
+use crate::creature_width::validate_creature_width;
 use crate::gpu::{GpuBackendLabel, GpuMode, ScoringPath};
 use crate::host_report::{DEFAULT_REPORT_RECORD_BYTES, HostReport};
 use crate::multi_score::{score_from_creature_dir_gpu_sampled, score_from_creature_dir_sampled};
@@ -478,9 +479,10 @@ fn score_from_json(
     let started = Instant::now();
     let creature = parse_creature_json(creature_json).map_err(|e| e.to_string())?;
 
-    if creature.input == 0 || creature.output == 0 {
-        return Err("Creature JSON must set positive input and output counts".to_string());
-    }
+    // Issue #571: `input` / `output` are the authoritative observation width
+    // (never derivable from `neurons`); reject `< 1` before compiling and
+    // before any training file is opened.
+    validate_creature_width(&creature).map_err(|e| e.to_string())?;
 
     let compile_started = Instant::now();
     let mut network = compile_creature(&creature).map_err(|e| e.to_string())?;
@@ -1232,6 +1234,47 @@ mod tests {
         )
         .expect_err("invalid JSON should fail");
         assert!(!err.is_empty());
+    }
+
+    /// Issue #571: `input: 0` / `output: 0` are rejected on the single-creature
+    /// path with the shared wording, before the data directory is touched —
+    /// the data path here does not exist, so any read attempt would surface a
+    /// different error.
+    #[test]
+    fn test_score_from_json_rejects_zero_input_and_output_before_reading_data() {
+        let tmp = TempDir::new().unwrap();
+        let missing_data = tmp.path().join("no-such-data-dir");
+        for (inputs, outputs, expected) in [
+            (0, 1, "Must have at least one input neurons was: 0"),
+            (1, 0, "Must have at least one output neurons was: 0"),
+        ] {
+            for forward_only in [true, false] {
+                let json = make_creature_json_with_forward_only(
+                    inputs,
+                    outputs,
+                    &[],
+                    &[("input-0", "output-0", 1.0)],
+                    Some("4.0.0"),
+                    forward_only,
+                );
+                let err = score_from_json(
+                    &json,
+                    &missing_data,
+                    GpuBackendLabel::CpuFallback,
+                    CostKind::default(),
+                    &SampleSpec::full(),
+                )
+                .expect_err("widthless creature must be rejected");
+                assert!(
+                    err.contains(expected),
+                    "forward_only={forward_only}: expected `{expected}`, got `{err}`"
+                );
+                assert!(
+                    !err.contains("is not a directory"),
+                    "guard must fire before the data path is read, got `{err}`"
+                );
+            }
+        }
     }
 
     /// Clap must accept `--creature-stdin` with a single positional arg and

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -230,6 +230,11 @@ pub fn accumulate_cost_sum(
     forward_only: bool,
 ) -> Result<f64, String> {
     use neat_core::loss;
+    // Issue #571: an observation width below one is never accepted — the
+    // stride would be meaningless and the loss helpers would silently score
+    // nothing (or everything as targets).
+    crate::creature_width::validate_observation_width(input_size, num_outputs)
+        .map_err(|e| e.to_string())?;
     // Issue #200: reject malformed chunks whose float length is not a whole
     // number of packed records. The upstream `*_sum_batch_packed` helpers
     // silently truncate a trailing partial record, so a content-dependent

--- a/rust_scorer/src/creature_width.rs
+++ b/rust_scorer/src/creature_width.rs
@@ -1,0 +1,186 @@
+//! The observation-width guard — Issue #571.
+//!
+//! The `CreatureExport` top-level `input` / `output` integers are the fleet's
+//! **observation width contract**: `input` is the observation count and
+//! `output` the target count. `neurons` deliberately lists only *non-input*
+//! neurons, so `input` **cannot be re-derived** from the neuron list. A creature
+//! with `input < 1` or `output < 1` is therefore never accepted anywhere — not
+//! on read, not on compile, not before a single training byte is opened. There
+//! is no fallback and no default.
+//!
+//! This module is the one place that error is worded, so every scoring path
+//! (single-creature, directory / GPU, fused streaming, the cost dispatcher and
+//! the fixture loaders) reports the same string. The wording mirrors the
+//! TypeScript reference (`CreatureValidate.ts`) and the `neat-core`
+//! `InvalidInputCount` / `InvalidOutputCount` errors that
+//! [NEAT-AI-core#550](https://github.com/stSoftwareAU/NEAT-AI-core/issues/550)
+//! adds, so logs never show two divergent messages. The local guard stays even
+//! after that release: it is the scorer's boundary and must fail loudly
+//! regardless of the core version it is built against.
+
+use neat_core::creature::CreatureExport;
+
+/// A creature declared an observation width the scorer must never accept.
+///
+/// `Display` mirrors the TypeScript reference wording byte-for-byte:
+/// `Must have at least one input neurons was: N` /
+/// `Must have at least one output neurons was: N`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreatureWidthError {
+    /// The top-level `input` count was below one.
+    InvalidInputCount {
+        /// The declared `input` value.
+        found: usize,
+    },
+    /// The top-level `output` count was below one.
+    InvalidOutputCount {
+        /// The declared `output` value.
+        found: usize,
+    },
+}
+
+impl std::fmt::Display for CreatureWidthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidInputCount { found } => {
+                write!(f, "Must have at least one input neurons was: {found}")
+            }
+            Self::InvalidOutputCount { found } => {
+                write!(f, "Must have at least one output neurons was: {found}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CreatureWidthError {}
+
+/// Reject an observation width with `input < 1` or `output < 1`.
+///
+/// `input` is checked first (matching the TypeScript reference order), so a
+/// creature that fails both reports the input count.
+///
+/// # Examples
+///
+/// ```
+/// use rust_scorer::creature_width::{CreatureWidthError, validate_observation_width};
+///
+/// assert_eq!(validate_observation_width(3, 1), Ok(()));
+/// assert_eq!(
+///     validate_observation_width(0, 1),
+///     Err(CreatureWidthError::InvalidInputCount { found: 0 })
+/// );
+/// assert_eq!(
+///     validate_observation_width(3, 0).unwrap_err().to_string(),
+///     "Must have at least one output neurons was: 0"
+/// );
+/// ```
+pub fn validate_observation_width(input: usize, output: usize) -> Result<(), CreatureWidthError> {
+    if input < 1 {
+        return Err(CreatureWidthError::InvalidInputCount { found: input });
+    }
+    if output < 1 {
+        return Err(CreatureWidthError::InvalidOutputCount { found: output });
+    }
+    Ok(())
+}
+
+/// Reject a parsed creature whose top-level `input` / `output` count is below
+/// one. Call this immediately after `parse_creature_json` and before compiling
+/// or opening any training data.
+///
+/// # Examples
+///
+/// ```
+/// use neat_core::creature::parse_creature_json;
+/// use rust_scorer::creature_width::validate_creature_width;
+///
+/// let creature = parse_creature_json(
+///     r#"{"input":1,"output":1,"forwardOnly":true,"neurons":[
+///         {"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}],
+///         "synapses":[{"fromUUID":"input-0","toUUID":"output-0","weight":1.0}]}"#,
+/// )
+/// .unwrap();
+/// assert!(validate_creature_width(&creature).is_ok());
+/// ```
+pub fn validate_creature_width(creature: &CreatureExport) -> Result<(), CreatureWidthError> {
+    validate_observation_width(creature.input, creature.output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neat_core::creature::NeuronExport;
+
+    #[test]
+    fn zero_input_is_rejected_with_the_reference_wording() {
+        let err = validate_observation_width(0, 1).unwrap_err();
+        assert_eq!(err, CreatureWidthError::InvalidInputCount { found: 0 });
+        assert_eq!(
+            err.to_string(),
+            "Must have at least one input neurons was: 0"
+        );
+    }
+
+    #[test]
+    fn zero_output_is_rejected_with_the_reference_wording() {
+        let err = validate_observation_width(1, 0).unwrap_err();
+        assert_eq!(err, CreatureWidthError::InvalidOutputCount { found: 0 });
+        assert_eq!(
+            err.to_string(),
+            "Must have at least one output neurons was: 0"
+        );
+    }
+
+    #[test]
+    fn input_is_checked_before_output() {
+        assert_eq!(
+            validate_observation_width(0, 0),
+            Err(CreatureWidthError::InvalidInputCount { found: 0 })
+        );
+    }
+
+    #[test]
+    fn positive_widths_pass() {
+        assert_eq!(validate_observation_width(1, 1), Ok(()));
+        assert_eq!(validate_observation_width(2511, 1), Ok(()));
+    }
+
+    #[test]
+    fn creature_guard_reads_the_top_level_counts_not_the_neuron_list() {
+        // `neurons` lists only non-input neurons: an export with a full output
+        // neuron list but `input: 0` must still be rejected, because the
+        // observation count cannot be re-derived from the neuron list. Built
+        // as a struct literal (not parsed) so the test keeps exercising this
+        // guard once `neat-core` itself rejects the JSON (NEAT-AI-core#550).
+        let creature = CreatureExport {
+            input: 0,
+            output: 1,
+            neurons: vec![NeuronExport {
+                neuron_type: "output".to_string(),
+                uuid: "output-0".to_string(),
+                bias: 0.0,
+                squash: Some("IDENTITY".to_string()),
+            }],
+            synapses: vec![],
+            semantic_version: None,
+            forward_only: true,
+        };
+        assert_eq!(
+            validate_creature_width(&creature),
+            Err(CreatureWidthError::InvalidInputCount { found: 0 })
+        );
+
+        let creature = CreatureExport {
+            input: 1,
+            output: 0,
+            neurons: vec![],
+            synapses: vec![],
+            semantic_version: None,
+            forward_only: true,
+        };
+        assert_eq!(
+            validate_creature_width(&creature),
+            Err(CreatureWidthError::InvalidOutputCount { found: 0 })
+        );
+    }
+}

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -19,6 +19,7 @@
 pub mod cli;
 pub mod corpus_guard;
 pub mod cost;
+pub mod creature_width;
 pub mod env_tuning;
 pub mod fixture_json;
 pub mod gpu;

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -58,6 +58,7 @@ use crate::gpu::{GpuBackendLabel, GpuContext};
 // Directory scoring drives one continuous `for_each_read_chunk` sweep (a single
 // read buffer), so it takes the single-reader read default — Issue #549's
 // aggregate `readers × chunk` bound applies to the multi-reader fused path.
+use crate::creature_width::validate_creature_width;
 use crate::read_tuning::{training_read_backend_label, training_read_target_bytes_from_env};
 use crate::sampling::SampleSpec;
 use crate::scoring::{ScoreResult, calculate_score, complexity_penalty, compute_score_components};
@@ -225,12 +226,11 @@ fn load_creatures_from_dir(creatures_dir: &Path) -> Result<Vec<LoadedCreature>, 
 
         let creature = parse_creature_json(&creature_json)
             .map_err(|e| format!("Failed parsing creature '{}': {e}", path.display()))?;
-        if creature.input == 0 || creature.output == 0 {
-            return Err(format!(
-                "Creature '{}' must set positive input and output counts",
-                path.display()
-            ));
-        }
+        // Issue #571: the top-level counts are the observation width; a
+        // `< 1` count fails the whole directory load before any training
+        // file is opened (no fallback, no re-derivation from `neurons`).
+        validate_creature_width(&creature)
+            .map_err(|e| format!("Creature '{}': {e}", path.display()))?;
         if !creature.forward_only {
             return Err(format!(
                 "Creature '{}' has forwardOnly=false; multi-creature directory mode requires forwardOnly=true for every creature",
@@ -1443,6 +1443,53 @@ fn score_from_creature_dir_gpu_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #571: a directory holding a creature with `input: 0` or
+    /// `output: 0` fails the load with the shared wording, naming the file,
+    /// before the training-data path is touched (it does not exist here).
+    #[test]
+    fn directory_load_rejects_zero_input_and_output_before_reading_data() {
+        use crate::fixture_json::{creature_envelope, neuron_json, synapse_json};
+        let neurons = vec![neuron_json("output", "output-0", 0.0, "IDENTITY")];
+        let synapses = vec![synapse_json("input-0", "output-0", 1.0)];
+        for (inputs, outputs, expected) in [
+            (0, 1, "Must have at least one input neurons was: 0"),
+            (1, 0, "Must have at least one output neurons was: 0"),
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let creatures = tmp.path().join("creatures");
+            fs::create_dir(&creatures).unwrap();
+            fs::write(
+                creatures.join("ok.json"),
+                creature_envelope(1, 1, &neurons, &synapses),
+            )
+            .unwrap();
+            fs::write(
+                creatures.join("widthless.json"),
+                creature_envelope(inputs, outputs, &neurons, &synapses),
+            )
+            .unwrap();
+            let missing_data = tmp.path().join("no-such-data-dir");
+
+            let err = score_from_creature_dir_sampled(
+                &creatures,
+                &missing_data,
+                GpuBackendLabel::CpuFallback,
+                CostKind::Mse,
+                &SampleSpec::full(),
+            )
+            .expect_err("widthless creature must fail the directory load");
+            assert!(err.contains(expected), "expected `{expected}`, got `{err}`");
+            assert!(
+                err.contains("widthless.json"),
+                "error must name the offending file, got `{err}`"
+            );
+            assert!(
+                !err.contains("is not a directory"),
+                "guard must fire before the data path is read, got `{err}`"
+            );
+        }
+    }
 
     #[test]
     fn workers_per_creature_one_per_when_population_meets_threads() {

--- a/rust_scorer/src/prod_fixture.rs
+++ b/rust_scorer/src/prod_fixture.rs
@@ -29,6 +29,8 @@ use std::path::PathBuf;
 
 use neat_core::creature::{CreatureExport, parse_creature_json};
 
+use crate::creature_width::validate_creature_width;
+
 /// Environment variable pointing at a **local** production `network.json`.
 ///
 /// The public repo ships no production creature and fetches nothing at bench
@@ -100,7 +102,12 @@ pub(crate) fn parse_production_creature(json: &str) -> Result<CreatureExport, Pr
     if json.trim().is_empty() {
         return Err(ProdFixtureError::Empty);
     }
-    parse_creature_json(json).map_err(|e| ProdFixtureError::Parse(e.to_string()))
+    let creature = parse_creature_json(json).map_err(|e| ProdFixtureError::Parse(e.to_string()))?;
+    // Issue #571: a fixture with `input < 1` / `output < 1` is a parse-level
+    // failure — the observation width is part of the wire contract, and the
+    // topology ranges below assume it is present.
+    validate_creature_width(&creature).map_err(|e| ProdFixtureError::Parse(e.to_string()))?;
+    Ok(creature)
 }
 
 /// Assert the creature's topology sits within the expected production ranges.
@@ -214,6 +221,25 @@ mod tests {
             Err(ProdFixtureError::Empty)
         );
         assert_eq!(parse_production_creature(""), Err(ProdFixtureError::Empty));
+    }
+
+    /// Issue #571: the fixture loader rejects a widthless creature at parse
+    /// time with the shared wording, before the topology ranges are consulted.
+    #[test]
+    fn parse_rejects_zero_input_and_output() {
+        for (input, output, expected) in [
+            (0, 1, "Must have at least one input neurons was: 0"),
+            (2461, 0, "Must have at least one output neurons was: 0"),
+        ] {
+            let json = creature_json(input, output, 1665, 21_510);
+            match parse_production_creature(&json) {
+                Err(ProdFixtureError::Parse(msg)) => {
+                    assert!(msg.contains(expected), "expected `{expected}`, got `{msg}`");
+                }
+                other => panic!("expected Parse error for widthless creature, got {other:?}"),
+            }
+            assert!(load_production_creature(&json).is_err());
+        }
     }
 
     #[test]

--- a/rust_scorer/src/scoring.rs
+++ b/rust_scorer/src/scoring.rs
@@ -6,6 +6,7 @@
 use neat_core::creature::CreatureExport;
 use neat_core::squash::SquashType;
 
+use crate::creature_width::{CreatureWidthError, validate_creature_width};
 use crate::gpu::GpuBackendLabel;
 
 /// The current semantic major version matching the TypeScript constant.
@@ -63,6 +64,10 @@ pub enum ScoringError {
         /// The offending average error.
         error: f64,
     },
+    /// The creature declared an `input` / `output` count below one (Issue
+    /// #571). Wraps the shared [`CreatureWidthError`] so the message is the
+    /// same one every scoring path reports.
+    InvalidObservationWidth(CreatureWidthError),
 }
 
 impl std::fmt::Display for ScoringError {
@@ -90,6 +95,7 @@ impl std::fmt::Display for ScoringError {
             Self::NegativeAverageError { error } => {
                 write!(f, "Average error {error} is negative")
             }
+            Self::InvalidObservationWidth(err) => write!(f, "{err}"),
         }
     }
 }
@@ -231,6 +237,10 @@ pub struct ScoreComponents {
 pub fn compute_score_components(
     creature: &CreatureExport,
 ) -> Result<ScoreComponents, ScoringError> {
+    // Issue #571: a widthless creature is rejected on every path, including
+    // this data-free complexity pass.
+    validate_creature_width(creature).map_err(ScoringError::InvalidObservationWidth)?;
+
     let mut max_weight_bias: f64 = 0.0;
     let mut total_weight_bias: f64 = 0.0;
     let mut count_weight_bias: usize = 0;

--- a/rust_scorer/src/stream_score.rs
+++ b/rust_scorer/src/stream_score.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use crate::cost::{CostKind, accumulate_cost_sum};
+use crate::creature_width::validate_observation_width;
 use crate::host_resources::{self, HostResources};
 use crate::read_tuning::{self, max_read_bytes, training_read_target_bytes_from_env_for_readers};
 use crate::sampling::SampleSpec;
@@ -468,6 +469,11 @@ pub fn accumulate_cost_sum_forward_only_fused_sampled_with_workers(
     sample: SampleSpec,
     file_workers: usize,
 ) -> Result<(f64, usize, usize, usize, f64), String> {
+    // Issue #571: the record width is `num_inputs + num_outputs` from the
+    // creature export; either count below one is rejected here, before any
+    // `.bin` file is opened, so a library caller that skipped the CLI guard
+    // still fails loudly with the same message.
+    validate_observation_width(config.num_inputs, config.num_outputs).map_err(|e| e.to_string())?;
     let record_bytes = config.bytes_per_record();
     if record_bytes == 0 {
         return Err("Invalid record byte length (zero)".to_string());

--- a/rust_scorer/tests/input_output_width_guard.rs
+++ b/rust_scorer/tests/input_output_width_guard.rs
@@ -1,0 +1,340 @@
+//! Issue #571 — `input < 1` / `output < 1` is never accepted on any scoring
+//! path, and the rejection happens **before any training data is opened**.
+//!
+//! Every test below points the scorer at a training-data path that does not
+//! exist. A path that read data first would fail with a `not a directory` /
+//! `No .bin files` error; the width guard must fire ahead of that, with the
+//! single shared wording from `rust_scorer::creature_width`.
+//!
+//! The wording asserted here is the TypeScript reference string
+//! (`CreatureValidate.ts`) that `neat-core` will also emit once
+//! NEAT-AI-core#550 lands, so these tests hold whether the JSON is rejected by
+//! this crate's boundary guard or by the core parser.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use neat_core::creature::{
+    CreatureExport, NeuronExport, SynapseExport, compile_creature, parse_creature_json,
+};
+use neat_core::training_data::TrainingDataConfig;
+use rust_scorer::cost::{CostKind, accumulate_cost_sum};
+use rust_scorer::creature_width::{
+    CreatureWidthError, validate_creature_width, validate_observation_width,
+};
+use rust_scorer::fixture_json::{creature_envelope, neuron_json, synapse_json};
+use rust_scorer::scoring::{ScoringError, compute_score_components};
+use rust_scorer::stream_score::accumulate_cost_sum_forward_only_fused;
+
+const INPUT_ZERO_MSG: &str = "Must have at least one input neurons was: 0";
+const OUTPUT_ZERO_MSG: &str = "Must have at least one output neurons was: 0";
+
+/// A one-output creature whose top-level counts are set explicitly, so a
+/// zeroed `input` still carries the full (non-input) neuron list — the case
+/// where a consumer that re-derived width from `neurons` would go wrong.
+fn creature_json(input: usize, output: usize) -> String {
+    let neurons = vec![neuron_json("output", "output-0", 0.0, "IDENTITY")];
+    let synapses = vec![synapse_json("input-0", "output-0", 1.0)];
+    creature_envelope(input, output, &neurons, &synapses)
+}
+
+fn scorer_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rust_scorer"))
+}
+
+fn missing_data_dir(tmp: &Path) -> PathBuf {
+    let missing = tmp.join("no-such-data-dir");
+    assert!(!missing.exists());
+    missing
+}
+
+fn assert_rejected_before_data(output: &std::process::Output, expected: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "scorer must exit non-zero, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        stderr.contains(expected),
+        "stderr must carry the shared width error `{expected}`, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("is not a directory") && !stderr.contains("No .bin files"),
+        "the width guard must fire before the data directory is touched, got:\n{stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "no score JSON may be emitted for a widthless creature, got:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Single-creature path (`rust_scorer <creature.json> <data_dir>`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_creature_path_rejects_zero_input_before_reading_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let creature = tmp.path().join("creature.json");
+    std::fs::write(&creature, creature_json(0, 1)).unwrap();
+
+    let output = Command::new(scorer_bin())
+        .arg(&creature)
+        .arg(missing_data_dir(tmp.path()))
+        .output()
+        .expect("spawn scorer");
+    assert_rejected_before_data(&output, INPUT_ZERO_MSG);
+}
+
+#[test]
+fn single_creature_path_rejects_zero_output_before_reading_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let creature = tmp.path().join("creature.json");
+    std::fs::write(&creature, creature_json(1, 0)).unwrap();
+
+    let output = Command::new(scorer_bin())
+        .arg(&creature)
+        .arg(missing_data_dir(tmp.path()))
+        .output()
+        .expect("spawn scorer");
+    assert_rejected_before_data(&output, OUTPUT_ZERO_MSG);
+}
+
+#[test]
+fn creature_stdin_path_rejects_zero_input_before_reading_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut child = Command::new(scorer_bin())
+        .arg("--creature-stdin")
+        .arg(missing_data_dir(tmp.path()))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn scorer");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(creature_json(0, 1).as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_rejected_before_data(&output, INPUT_ZERO_MSG);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-creature directory path (`rust_scorer <creatures_dir> <data_dir>`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn directory_path_rejects_zero_input_before_reading_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let creatures = tmp.path().join("creatures");
+    std::fs::create_dir(&creatures).unwrap();
+    std::fs::write(creatures.join("ok.json"), creature_json(1, 1)).unwrap();
+    std::fs::write(creatures.join("widthless.json"), creature_json(0, 1)).unwrap();
+
+    for gpu in ["off", "auto"] {
+        let output = Command::new(scorer_bin())
+            .arg("--gpu")
+            .arg(gpu)
+            .arg(&creatures)
+            .arg(missing_data_dir(tmp.path()))
+            .output()
+            .expect("spawn scorer");
+        assert_rejected_before_data(&output, INPUT_ZERO_MSG);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("widthless.json"),
+            "directory mode must name the offending creature, got:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn directory_path_rejects_zero_output_before_reading_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let creatures = tmp.path().join("creatures");
+    std::fs::create_dir(&creatures).unwrap();
+    std::fs::write(creatures.join("widthless.json"), creature_json(1, 0)).unwrap();
+
+    let output = Command::new(scorer_bin())
+        .arg("--gpu")
+        .arg("off")
+        .arg(&creatures)
+        .arg(missing_data_dir(tmp.path()))
+        .output()
+        .expect("spawn scorer");
+    assert_rejected_before_data(&output, OUTPUT_ZERO_MSG);
+}
+
+// ---------------------------------------------------------------------------
+// Fused streaming path (library API, `stream_score`)
+// ---------------------------------------------------------------------------
+
+fn compiled_identity() -> neat_core::network::CompiledNetwork {
+    let creature = parse_creature_json(&creature_json(1, 1)).expect("valid creature parses");
+    compile_creature(&creature).expect("valid creature compiles")
+}
+
+#[test]
+fn streaming_path_rejects_zero_input_before_opening_any_bin() {
+    let mut net = compiled_identity();
+    let config = TrainingDataConfig {
+        num_inputs: 0,
+        num_outputs: 1,
+    };
+    // A `.bin` that does not exist: reaching the reader would fail with an
+    // I/O error, not the width message.
+    let bin_files = vec![PathBuf::from("/nonexistent/issue-571/0.bin")];
+    let err = accumulate_cost_sum_forward_only_fused(CostKind::Mse, &bin_files, &config, &mut net)
+        .expect_err("input:0 must be rejected");
+    assert_eq!(err, INPUT_ZERO_MSG);
+}
+
+#[test]
+fn streaming_path_rejects_zero_output_before_opening_any_bin() {
+    let mut net = compiled_identity();
+    let config = TrainingDataConfig {
+        num_inputs: 1,
+        num_outputs: 0,
+    };
+    let bin_files = vec![PathBuf::from("/nonexistent/issue-571/0.bin")];
+    let err = accumulate_cost_sum_forward_only_fused(CostKind::Mse, &bin_files, &config, &mut net)
+        .expect_err("output:0 must be rejected");
+    assert_eq!(err, OUTPUT_ZERO_MSG);
+}
+
+// ---------------------------------------------------------------------------
+// Cost dispatcher and complexity scoring (library API)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cost_dispatcher_rejects_zero_widths() {
+    let mut net = compiled_identity();
+    let err = accumulate_cost_sum(CostKind::Mse, &mut net, &[0.5, 0.5], 0, 2, true)
+        .expect_err("input_size 0 must be rejected");
+    assert_eq!(err, INPUT_ZERO_MSG);
+    let err = accumulate_cost_sum(CostKind::Mae, &mut net, &[0.5, 0.5], 2, 0, true)
+        .expect_err("num_outputs 0 must be rejected");
+    assert_eq!(err, OUTPUT_ZERO_MSG);
+}
+
+#[test]
+fn score_components_reject_widthless_export() {
+    // Struct literal, not parsed JSON, so this keeps testing the scorer's own
+    // guard after `neat-core` starts rejecting the JSON (NEAT-AI-core#550).
+    let creature = CreatureExport {
+        input: 0,
+        output: 1,
+        neurons: vec![NeuronExport {
+            neuron_type: "output".to_string(),
+            uuid: "output-0".to_string(),
+            bias: 0.0,
+            squash: Some("IDENTITY".to_string()),
+        }],
+        synapses: vec![SynapseExport {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }],
+        semantic_version: Some("4.0.0".to_string()),
+        forward_only: true,
+    };
+    let err = compute_score_components(&creature).expect_err("input:0 must be rejected");
+    assert_eq!(
+        err,
+        ScoringError::InvalidObservationWidth(CreatureWidthError::InvalidInputCount { found: 0 })
+    );
+    assert_eq!(err.to_string(), INPUT_ZERO_MSG);
+
+    let creature = CreatureExport {
+        output: 0,
+        input: 1,
+        ..creature
+    };
+    assert_eq!(
+        compute_score_components(&creature).unwrap_err().to_string(),
+        OUTPUT_ZERO_MSG
+    );
+}
+
+#[test]
+fn shared_helper_is_the_single_source_of_the_wording() {
+    assert_eq!(
+        validate_observation_width(0, 7).unwrap_err().to_string(),
+        INPUT_ZERO_MSG
+    );
+    assert_eq!(
+        validate_observation_width(7, 0).unwrap_err().to_string(),
+        OUTPUT_ZERO_MSG
+    );
+    let ok = parse_creature_json(&creature_json(3, 1)).unwrap();
+    assert_eq!(validate_creature_width(&ok), Ok(()));
+}
+
+// ---------------------------------------------------------------------------
+// A creature with valid counts still scores on both entry paths, and the
+// record width it reads is `input + output` from the export.
+// ---------------------------------------------------------------------------
+
+fn write_records(dir: &Path, records: &[(Vec<f32>, Vec<f32>)]) {
+    std::fs::create_dir_all(dir).unwrap();
+    let mut file = std::fs::File::create(dir.join("0.bin")).unwrap();
+    for (inputs, outputs) in records {
+        for &v in inputs.iter().chain(outputs.iter()) {
+            file.write_all(&v.to_le_bytes()).unwrap();
+        }
+    }
+}
+
+#[test]
+fn valid_counts_still_score_on_single_and_directory_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    // 2 inputs + 1 output; only input-0 is wired, input-1 is a pure width
+    // contribution (2 + 1 = 3 floats per record). Two records exactly.
+    let json = creature_json(2, 1);
+    let data = tmp.path().join("data");
+    write_records(
+        &data,
+        &[(vec![0.5, 9.0], vec![0.5]), (vec![1.0, 9.0], vec![1.0])],
+    );
+
+    let creature = tmp.path().join("creature.json");
+    std::fs::write(&creature, &json).unwrap();
+    let output = Command::new(scorer_bin())
+        .arg(&creature)
+        .arg(&data)
+        .output()
+        .expect("spawn scorer");
+    assert!(
+        output.status.success(),
+        "single-creature scoring must succeed, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let single: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(single["recordCount"].as_u64(), Some(2));
+    assert_eq!(single["error"].as_f64(), Some(0.0));
+
+    let creatures = tmp.path().join("creatures");
+    std::fs::create_dir(&creatures).unwrap();
+    std::fs::write(creatures.join("a.json"), &json).unwrap();
+    let output = Command::new(scorer_bin())
+        .arg("--gpu")
+        .arg("off")
+        .arg(&creatures)
+        .arg(&data)
+        .output()
+        .expect("spawn scorer");
+    assert!(
+        output.status.success(),
+        "directory scoring must succeed, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let multi: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(multi["a"]["recordCount"].as_u64(), Some(2));
+    assert_eq!(multi["a"]["error"].as_f64(), Some(0.0));
+}


### PR DESCRIPTION
Closes #571

## What

- **One helper, one wording.** New `rust_scorer/src/creature_width.rs` — `CreatureWidthError { InvalidInputCount, InvalidOutputCount }`, `validate_observation_width(input, output)` and `validate_creature_width(&CreatureExport)`. `Display` mirrors the TypeScript reference (`CreatureValidate.ts`) and the `neat-core` errors NEAT-AI-core#550 adds: `Must have at least one input neurons was: N` / `Must have at least one output neurons was: N`.
- **Every path routes through it, before any training file is opened:**
  - `cli.rs` `score_from_json` — single-creature file **and** `--creature-stdin` (replaces the old `"Creature JSON must set positive input and output counts"` string).
  - `multi_score.rs` `load_creatures_from_dir` — directory mode CPU, GPU and both pre-flight probes; error names the offending file.
  - `stream_score.rs` `accumulate_cost_sum_forward_only_fused_sampled_with_workers` — the fused streaming entry every `stream_score` wrapper funnels into; guards `config.num_inputs/num_outputs` ahead of the `.bin` reader.
  - `cost.rs` `accumulate_cost_sum` — width check ahead of the stride check.
  - `scoring.rs` `compute_score_components` — new `ScoringError::InvalidObservationWidth(CreatureWidthError)` (Display delegates to the shared string).
  - `prod_fixture.rs` `parse_production_creature` — surfaces as `ProdFixtureError::Parse`, matching what core#550 will produce.
  - `src/bin/cost_scan_bench.rs` — both parse sites.
- **Record width audit:** `cli.rs`, `multi_score.rs` (CPU + GPU), `stream_score.rs`, `cost.rs`, `prod_fixture.rs`, `cost_scan_bench`, benches — every `TrainingDataConfig` / `values_per_record` is `input + output` from the export; no neuron-count derivation exists. No change needed.
- CHANGELOG entry under `[Unreleased]`.

## Why

`input` is the authoritative observation count and cannot be re-derived from `neurons` (inputs are not listed there). `input < 1` / `output < 1` must fail loudly with no fallback on every path, and the scorer's message must match core so logs never show two divergent strings.

## Verification

- `./quality.sh` — all checks passed (shellcheck, cargo-deny, `fmt --check`, clippy `-D warnings`, check, build, test, rustdoc `-D warnings`, release build).
- `cargo test`: 431 passed, 0 failed across 30 test binaries/doc-tests.
- New `rust_scorer/tests/input_output_width_guard.rs` (11 tests): `input: 0` and `output: 0` rejected on the single-creature, `--creature-stdin`, directory (`--gpu off` and `auto`) and fused streaming paths — each against a **non-existent** data path, asserting the shared wording and the absence of any `not a directory` / `No .bin files` error; `accumulate_cost_sum` and `compute_score_components` reject zero widths; a valid 2-in/1-out creature still scores on both entry paths with a 3-float record width.
- Unit tests added in `creature_width` (5), `cli` (both counts × forward-only/recurrent), `multi_score` (directory load), `prod_fixture`.
- Guard tests build `CreatureExport` as struct literals where possible so they keep exercising this crate's boundary after `neat-core` starts rejecting the JSON itself; the JSON-path tests assert `contains(<reference wording>)` so they hold under either core version.

Rollout: independent of NEAT-AI-core#550 (local guard stays); merge before core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
