### PR TITLE
Refuse rust_scorer version downgrades vs Develop (Issue #567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ section to the released version with its date.
 
 ### Added
 
+- **`rust_scorer` version downgrades are refused (Issue #567).**
+  `scripts/version-increment.sh` now compares the branch version with the base
+  ref numerically instead of treating any `current != base` as "already
+  bumped": a version strictly below the base exits **3** with a
+  `version downgrade refused` message from both `--already-bumped` and
+  `--run`, so a merge conflict that restores Develop's older version fails CI
+  instead of shipping a downgrade to a downstream `rust_scorer` pin. Equal
+  versions still auto-patch-bump; ahead versions are accepted without a bump;
+  `0.10.0` is correctly ahead of `0.9.9` and a pre-release suffix sorts below
+  the bare release of the same triple. Covered by
+  `tests/scripts/version_increment.bats` (behind → fail, equal/ahead → pass)
+  and documented in the CONTRIBUTING PR-workflow section.
+
 - **Single `input`/`output` ≥ 1 guard on every scoring path, with regression
   tests (Issue #571).** `rust_scorer/src/creature_width.rs` is now the one
   place the observation-width rule is worded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,20 @@ automatically bumps the patch component of `rust_scorer`'s version in
 branch. Because the version is bumped automatically, the `CHANGELOG.md` is
 the human-readable record of *what* changed — please keep it current.
 
+**Version downgrades are refused (Issue #567).** Downstream consumers pin and
+rebuild `rust_scorer` by version, so a branch version *below* the base ref must
+never ship. [`scripts/version-increment.sh`](./scripts/version-increment.sh)
+compares the branch version with the base numerically (`0.10.0` is ahead of
+`0.9.9`; a pre-release suffix sorts below the bare release of the same
+triple) and both `--already-bumped` and `--run` exit **3** with a
+`version downgrade refused` message when the branch is behind — a downgrade
+is never mistaken for "already bumped", and CI goes red rather than pushing
+it. Equal versions still auto-patch-bump, and an ahead version is accepted
+without forcing a second bump. If a merge conflict restores Develop's older
+version, set `[package].version` in
+[`rust_scorer/Cargo.toml`](./rust_scorer/Cargo.toml) to at least the base
+version and push again.
+
 ## Performance Task Workflow
 
 This section is the **single home** for the project's performance-change rules.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.62"
+version = "1.1.63"
 dependencies = [
  "bytemuck",
  "clap",

--- a/docs/archive/pr-summaries/pr-summary-567.md
+++ b/docs/archive/pr-summaries/pr-summary-567.md
@@ -1,0 +1,99 @@
+# Refuse `rust_scorer` version downgrades vs the base ref (Issue #567)
+
+## Summary
+
+`scripts/version-increment.sh` treated **any** `current != base` as "already
+bumped", so a branch whose `rust_scorer` version was *below* `origin/Develop` —
+the shape a badly resolved merge conflict produces — was silently skipped and
+shipped a **downgrade** to the downstream consumers that pin and rebuild
+`rust_scorer` by version.
+
+The script now compares the two versions instead of merely testing them for
+inequality:
+
+- **Behind → fail loud.** Both `--already-bumped` and `--run` exit **3** with
+  `Error: version downgrade refused — branch version X is behind base Y …`.
+  `--run` writes nothing, so the manifest is left as the author committed it.
+- **Equal → auto-patch-bump**, exactly as before.
+- **Ahead → accepted**, with no second bump forced.
+- Comparison is **numeric per component** (`0.10.0` is ahead of `0.9.9`, which a
+  string compare gets wrong), and a pre-release suffix sorts below the bare
+  release of the same triple (`0.5.4-rc1` < `0.5.4`), matching semver.
+- A version that is not semver `X.Y.Z` exits **2** with a clear message rather
+  than being mistaken for a bump.
+
+No workflow YAML change is required, and none is included (the worker holds no
+`workflow` OAuth scope — see the CONTRIBUTING [Human
+escalation](../../../CONTRIBUTING.md#human-escalation) contract). The existing
+wiring already fails CI on a downgrade: the guard job's `--already-bumped` exits
+non-zero, so `should_bump=true` and the `bump` job runs `--run`, which exits 3
+and fails the job before anything is committed or pushed. That guard → bump
+sequence is pinned by a test.
+
+Closes #567.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Evidence is the BATS suite
+(`bats tests/scripts/version_increment.bats`), 20/20 passing, with the six new
+downgrade cases failing before the change and passing after:
+
+```text
+ok  9 already-bumped? refuses a patch downgrade against the base ref
+ok 10 already-bumped? refuses a minor downgrade against the base ref
+ok 11 already-bumped? accepts an ahead version (no re-bump forced)
+ok 12 already-bumped? compares components numerically, not as strings
+ok 13 already-bumped? treats a pre-release of the base version as behind it
+ok 14 run refuses a downgrade and leaves the manifest untouched
+ok 15 run accepts an ahead version without forcing another bump
+ok 16 run still bumps when the branch version equals the base
+ok 17 a non-semver branch version fails loud rather than being called a bump
+ok 18 the workflow guard/bump sequence fails CI on a downgrade
+```
+
+Decision flow now applied by both `--already-bumped` and `--run`:
+
+```mermaid
+flowchart TD
+    A[Read branch version + base ref version] --> B{Base ref reachable?}
+    B -- no --> C[Conservative: not bumped]
+    B -- yes --> D{Compare branch vs base}
+    D -- "branch &lt; base" --> E[Exit 3<br/>downgrade refused — CI red]
+    D -- "branch == base" --> F[Patch-bump once]
+    D -- "branch &gt; base" --> G[Skip — already bumped]
+```
+
+## Test Plan
+
+Added to `tests/scripts/version_increment.bats` (all exercise the real script
+against temporary git repositories, asserting exit codes, messages and manifest
+side-effects):
+
+- `already-bumped? refuses a patch downgrade against the base ref` — 0.5.3 vs
+  0.5.4 → exit 3, message names both versions.
+- `already-bumped? refuses a minor downgrade against the base ref` — 0.4.9 vs
+  0.5.4 → exit 3.
+- `already-bumped? accepts an ahead version (no re-bump forced)` — 0.6.0 → exit 0.
+- `already-bumped? compares components numerically, not as strings` — 0.10.0 vs
+  0.5.4 → exit 0 (a lexical compare would call this a downgrade).
+- `already-bumped? treats a pre-release of the base version as behind it` —
+  0.5.4-rc1 vs 0.5.4 → exit 3.
+- `run refuses a downgrade and leaves the manifest untouched` — exit 3 and the
+  manifest still reads 0.5.3.
+- `run accepts an ahead version without forcing another bump` — skip, 0.10.0
+  preserved.
+- `run still bumps when the branch version equals the base` — 0.5.4 → 0.5.5.
+- `a non-semver branch version fails loud rather than being called a bump` —
+  exit 2, "semver" in the message.
+- `the workflow guard/bump sequence fails CI on a downgrade` — replays the
+  workflow's guard (`--already-bumped`) → bump (`--run`) ordering and asserts
+  both steps end non-zero.
+
+Existing tests are unchanged and still pass; the only behavioural change to a
+previously documented path is that a *behind* version, which used to be reported
+as "already bumped", is now refused.
+
+Docs updated: the no-downgrade rule is documented in the CONTRIBUTING
+[Pull request workflow](../../../CONTRIBUTING.md#pull-request-workflow) section,
+the script's own `--help` now lists the exit codes, and `CHANGELOG.md` carries
+an `[Unreleased]` entry.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.62"
+version = "1.1.63"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/version-increment.sh
+++ b/scripts/version-increment.sh
@@ -6,6 +6,10 @@
 #   * Detect whether the current git branch has already diverged from its
 #     base ref on that version (so re-running CI does not produce duplicate
 #     bump commits and a human-authored bump is respected).
+#   * Refuse a *downgrade* — a branch version strictly below the base ref —
+#     rather than mistaking it for "already bumped" (Issue #567). Downstream
+#     consumers pin and rebuild `rust_scorer` by version, so a merge conflict
+#     that silently restores Develop's older version must fail loud, not ship.
 #   * Perform a single idempotent patch-level bump on request.
 #
 # Designed to be callable both from local shells and from a GitHub Actions
@@ -20,7 +24,7 @@ Usage: version-increment.sh <mode> [--manifest PATH] [--base-ref REF] [--repo DI
 Modes (exactly one):
   --get-version       Print the current [package].version from the manifest.
   --bump-patch        Increment the patch component of [package].version.
-  --already-bumped    Exit 0 if branch version differs from base, else exit 1.
+  --already-bumped    Exit 0 if branch version is ahead of base, else exit 1.
   --run               End-to-end: skip if already bumped (or manually bumped),
                       otherwise bump-patch. Prints a one-line status.
 
@@ -30,6 +34,12 @@ Options:
   --repo DIR          Repository directory for git operations (default: cwd).
   --dry-run           For --bump-patch, print the new version without writing.
   -h, --help          Show this message.
+
+Exit codes for --already-bumped / --run:
+  0  ahead of base (already bumped), or a bump was applied.
+  1  --already-bumped only: branch version equals base, or base unreachable.
+  2  usage error, or a version that is not semver X.Y.Z.
+  3  downgrade refused — branch version is strictly below base (Issue #567).
 EOF
 }
 
@@ -156,6 +166,69 @@ manifest_rel_path() {
   fi
 }
 
+# Exit code used when a downgrade is refused (Issue #567).
+EXIT_DOWNGRADE=3
+# Exit code for a usage error or a version that is not semver.
+EXIT_USAGE=2
+
+# Split "X.Y.Z[suffix]" into "X Y Z suffix" (suffix may be empty).
+parse_version() {
+  local version="$1"
+  if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+    echo "Error: version '$version' is not semver X.Y.Z" >&2
+    return 1
+  fi
+  printf '%s %s %s %s\n' \
+    "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"
+}
+
+# Print -1, 0 or 1 for a < b, a == b, a > b. Components compare numerically
+# (so 0.10.0 is ahead of 0.9.9); a pre-release suffix sorts below the bare
+# release of the same triple, matching semver.
+version_compare() {
+  local a_parts b_parts
+  a_parts="$(parse_version "$1")" || return 1
+  b_parts="$(parse_version "$2")" || return 1
+
+  local a_major a_minor a_patch a_suffix
+  local b_major b_minor b_patch b_suffix
+  read -r a_major a_minor a_patch a_suffix <<<"$a_parts"
+  read -r b_major b_minor b_patch b_suffix <<<"$b_parts"
+
+  local -a a_nums=("$a_major" "$a_minor" "$a_patch")
+  local -a b_nums=("$b_major" "$b_minor" "$b_patch")
+  local i
+  for i in 0 1 2; do
+    if ((10#${a_nums[$i]} < 10#${b_nums[$i]})); then echo -1; return 0; fi
+    if ((10#${a_nums[$i]} > 10#${b_nums[$i]})); then echo 1; return 0; fi
+  done
+
+  if [[ "$a_suffix" == "$b_suffix" ]]; then
+    echo 0
+  elif [[ -z "$a_suffix" ]]; then
+    echo 1   # release beats pre-release
+  elif [[ -z "$b_suffix" ]]; then
+    echo -1
+  elif [[ "$a_suffix" < "$b_suffix" ]]; then
+    echo -1
+  else
+    echo 1
+  fi
+}
+
+# Fail loud when the branch version is behind the base ref (Issue #567).
+# A downgrade is never "already bumped" — it exits non-zero so CI goes red
+# instead of silently shipping Develop's older version.
+refuse_downgrade() {
+  local current="$1" base="$2"
+  local cmp
+  cmp="$(version_compare "$current" "$base")" || exit "$EXIT_USAGE"
+  if [[ "$cmp" == "-1" ]]; then
+    echo "Error: version downgrade refused — branch version ${current} is behind base ${base} (${BASE_REF}); set [package].version in ${MANIFEST} to at least ${base}" >&2
+    exit "$EXIT_DOWNGRADE"
+  fi
+}
+
 bump_patch() {
   local version="$1"
   if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
@@ -195,6 +268,7 @@ case "$MODE" in
       # Base ref unreachable — treat as "not bumped" so CI stays conservative.
       exit 1
     fi
+    refuse_downgrade "$current" "$base_version"
     if [[ "$current" != "$base_version" ]]; then
       exit 0
     else
@@ -206,6 +280,10 @@ case "$MODE" in
     current="$(extract_version "$MANIFEST")"
     rel="$(manifest_rel_path "$REPO_DIR" "$MANIFEST")"
     base_version="$(extract_version_at_ref "$REPO_DIR" "$BASE_REF" "$rel")"
+
+    if [[ -n "$base_version" ]]; then
+      refuse_downgrade "$current" "$base_version"
+    fi
 
     if [[ -n "$base_version" && "$current" != "$base_version" ]]; then
       echo "skip: version already bumped on branch (base=${base_version}, branch=${current})"

--- a/tests/scripts/version_increment.bats
+++ b/tests/scripts/version_increment.bats
@@ -109,6 +109,103 @@ teardown() {
   [ "$output" = "0.6.0" ]
 }
 
+# --- downgrade refusal (Issue #567) ----------------------------------------
+#
+# A branch version strictly BELOW the base ref is a downgrade — the failure
+# mode a bad merge conflict resolution produces. It must fail loud, never be
+# mistaken for "already bumped".
+
+# Set the branch manifest to a specific version and commit it.
+set_branch_version() {
+  (
+    cd "$TMP_REPO"
+    sed -i.bak "s/^version = .*/version = \"$1\"/" rust_scorer/Cargo.toml
+    rm -f rust_scorer/Cargo.toml.bak
+    git add rust_scorer/Cargo.toml
+    git commit -q -m "set version $1"
+  )
+}
+
+@test "already-bumped? refuses a patch downgrade against the base ref" {
+  set_branch_version "0.5.3"
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"downgrade"* ]]
+  [[ "$output" == *"0.5.3"* ]]
+  [[ "$output" == *"0.5.4"* ]]
+}
+
+@test "already-bumped? refuses a minor downgrade against the base ref" {
+  set_branch_version "0.4.9"
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"downgrade"* ]]
+}
+
+@test "already-bumped? accepts an ahead version (no re-bump forced)" {
+  set_branch_version "0.6.0"
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "already-bumped? compares components numerically, not as strings" {
+  # 0.10.0 is AHEAD of 0.5.4 even though it sorts before it lexically.
+  set_branch_version "0.10.0"
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "already-bumped? treats a pre-release of the base version as behind it" {
+  set_branch_version "0.5.4-rc1"
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"downgrade"* ]]
+}
+
+@test "run refuses a downgrade and leaves the manifest untouched" {
+  set_branch_version "0.5.3"
+  run "$SCRIPT_UNDER_TEST" --run --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"downgrade"* ]]
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$output" = "0.5.3" ]
+}
+
+@test "run accepts an ahead version without forcing another bump" {
+  set_branch_version "0.10.0"
+  run "$SCRIPT_UNDER_TEST" --run --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skip"* ]]
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$output" = "0.10.0" ]
+}
+
+@test "run still bumps when the branch version equals the base" {
+  run "$SCRIPT_UNDER_TEST" --run --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bumped"* ]]
+  run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/rust_scorer/Cargo.toml"
+  [ "$output" = "0.5.5" ]
+}
+
+@test "a non-semver branch version fails loud rather than being called a bump" {
+  set_branch_version "not-a-version"
+  run "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"semver"* ]]
+}
+
+@test "the workflow guard/bump sequence fails CI on a downgrade" {
+  # Mirrors .github/workflows/version-increment.yml: the guard runs
+  # --already-bumped, and when that is non-zero the bump job runs --run.
+  set_branch_version "0.5.3"
+  guard_status=0
+  "$SCRIPT_UNDER_TEST" --already-bumped --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO" >/dev/null 2>&1 || guard_status=$?
+  [ "$guard_status" -ne 0 ]
+  run "$SCRIPT_UNDER_TEST" --run --manifest "$TMP_REPO/rust_scorer/Cargo.toml" --base-ref main --repo "$TMP_REPO"
+  [ "$status" -ne 0 ]
+}
+
 @test "missing manifest yields a clear error" {
   run "$SCRIPT_UNDER_TEST" --get-version --manifest "$TMP_REPO/does-not-exist.toml"
   [ "$status" -ne 0 ]


### PR DESCRIPTION
# Refuse `rust_scorer` version downgrades vs the base ref (Issue #567)

## Summary

`scripts/version-increment.sh` treated **any** `current != base` as "already
bumped", so a branch whose `rust_scorer` version was *below* `origin/Develop` —
the shape a badly resolved merge conflict produces — was silently skipped and
shipped a **downgrade** to the downstream consumers that pin and rebuild
`rust_scorer` by version.

The script now compares the two versions instead of merely testing them for
inequality:

- **Behind → fail loud.** Both `--already-bumped` and `--run` exit **3** with
  `Error: version downgrade refused — branch version X is behind base Y …`.
  `--run` writes nothing, so the manifest is left as the author committed it.
- **Equal → auto-patch-bump**, exactly as before.
- **Ahead → accepted**, with no second bump forced.
- Comparison is **numeric per component** (`0.10.0` is ahead of `0.9.9`, which a
  string compare gets wrong), and a pre-release suffix sorts below the bare
  release of the same triple (`0.5.4-rc1` < `0.5.4`), matching semver.
- A version that is not semver `X.Y.Z` exits **2** with a clear message rather
  than being mistaken for a bump.

No workflow YAML change is required, and none is included (the worker holds no
`workflow` OAuth scope — see the CONTRIBUTING [Human
escalation](../../../CONTRIBUTING.md#human-escalation) contract). The existing
wiring already fails CI on a downgrade: the guard job's `--already-bumped` exits
non-zero, so `should_bump=true` and the `bump` job runs `--run`, which exits 3
and fails the job before anything is committed or pushed. That guard → bump
sequence is pinned by a test.

Closes #567.

## Evidence

Backend/CLI change — no web interface to screenshot. Evidence is the BATS suite
(`bats tests/scripts/version_increment.bats`), 20/20 passing, with the six new
downgrade cases failing before the change and passing after:

```text
ok  9 already-bumped? refuses a patch downgrade against the base ref
ok 10 already-bumped? refuses a minor downgrade against the base ref
ok 11 already-bumped? accepts an ahead version (no re-bump forced)
ok 12 already-bumped? compares components numerically, not as strings
ok 13 already-bumped? treats a pre-release of the base version as behind it
ok 14 run refuses a downgrade and leaves the manifest untouched
ok 15 run accepts an ahead version without forcing another bump
ok 16 run still bumps when the branch version equals the base
ok 17 a non-semver branch version fails loud rather than being called a bump
ok 18 the workflow guard/bump sequence fails CI on a downgrade
```

Decision flow now applied by both `--already-bumped` and `--run`:

```mermaid
flowchart TD
    A[Read branch version + base ref version] --> B{Base ref reachable?}
    B -- no --> C[Conservative: not bumped]
    B -- yes --> D{Compare branch vs base}
    D -- "branch &lt; base" --> E[Exit 3<br/>downgrade refused — CI red]
    D -- "branch == base" --> F[Patch-bump once]
    D -- "branch &gt; base" --> G[Skip — already bumped]
```

## Test Plan

Added to `tests/scripts/version_increment.bats` (all exercise the real script
against temporary git repositories, asserting exit codes, messages and manifest
side-effects):

- `already-bumped? refuses a patch downgrade against the base ref` — 0.5.3 vs
  0.5.4 → exit 3, message names both versions.
- `already-bumped? refuses a minor downgrade against the base ref` — 0.4.9 vs
  0.5.4 → exit 3.
- `already-bumped? accepts an ahead version (no re-bump forced)` — 0.6.0 → exit 0.
- `already-bumped? compares components numerically, not as strings` — 0.10.0 vs
  0.5.4 → exit 0 (a lexical compare would call this a downgrade).
- `already-bumped? treats a pre-release of the base version as behind it` —
  0.5.4-rc1 vs 0.5.4 → exit 3.
- `run refuses a downgrade and leaves the manifest untouched` — exit 3 and the
  manifest still reads 0.5.3.
- `run accepts an ahead version without forcing another bump` — skip, 0.10.0
  preserved.
- `run still bumps when the branch version equals the base` — 0.5.4 → 0.5.5.
- `a non-semver branch version fails loud rather than being called a bump` —
  exit 2, "semver" in the message.
- `the workflow guard/bump sequence fails CI on a downgrade` — replays the
  workflow's guard (`--already-bumped`) → bump (`--run`) ordering and asserts
  both steps end non-zero.

Existing tests are unchanged and still pass; the only behavioural change to a
previously documented path is that a *behind* version, which used to be reported
as "already bumped", is now refused.

Docs updated: the no-downgrade rule is documented in the CONTRIBUTING
[Pull request workflow](../../../CONTRIBUTING.md#pull-request-workflow) section,
the script's own `--help` now lists the exit codes, and `CHANGELOG.md` carries
an `[Unreleased]` entry.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msyib942-619600`<!-- vibe-worker-issue-567 -->