### PR TITLE
Acknowledge neat-core 0.10.0 in the version baseline (GRQ#4259)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.1"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.64"
+version = "1.1.65"
 dependencies = [
  "bytemuck",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -51,4 +51,17 @@
 # `CompiledNetwork` via struct literal — every fixture goes through
 # `compile_creature` — so no scorer code change is required. Verified by a
 # clean `cargo check -p rust_scorer` against sibling neat-core 0.9.0.
-0.9.0
+#
+# 0.9.0 -> 0.10.0: acknowledge neat-core #569 (GRQ#4257), which retyped the
+# public `MemeticExport::weights` field from
+# `BTreeMap<String, Vec<MemeticWeightExport>>` to the new `MemeticWeights` enum
+# so both valid `memetic.weights` wire forms parse. rust_scorer never reads
+# memetic weights, but neat-core #559 also added `CreatureExport::memetic` and
+# `NeuronExport::id`, and scorer builds both structs by literal in its own
+# tests — those literals now name the new fields (`memetic: None`, `id: None`).
+# No production scorer code changed. Verified by the full quality gate against
+# sibling neat-core 0.10.0, plus
+# `rust_scorer/tests/memetic_wire_forms_scoring.rs`, which asserts a creature
+# carrying either wire form parses, compiles and scores identically to the same
+# creature without one.
+0.10.0

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.64"
+version = "1.1.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/cost.rs
+++ b/rust_scorer/src/cost.rs
@@ -198,6 +198,7 @@ impl CostKind {
 ///     input: 1,
 ///     output: 1,
 ///     neurons: vec![NeuronExport {
+///         id: None,
 ///         neuron_type: "output".to_string(),
 ///         uuid: "output-0".to_string(),
 ///         bias: 0.0,
@@ -211,6 +212,7 @@ impl CostKind {
 ///     }],
 ///     semantic_version: Some("4.0.0".to_string()),
 ///     forward_only: true,
+///     memetic: None,
 /// };
 /// let mut network = compile_creature(&creature).unwrap();
 ///

--- a/rust_scorer/src/creature_width.rs
+++ b/rust_scorer/src/creature_width.rs
@@ -156,6 +156,7 @@ mod tests {
             input: 0,
             output: 1,
             neurons: vec![NeuronExport {
+                id: None,
                 neuron_type: "output".to_string(),
                 uuid: "output-0".to_string(),
                 bias: 0.0,
@@ -164,6 +165,7 @@ mod tests {
             synapses: vec![],
             semantic_version: None,
             forward_only: true,
+            memetic: None,
         };
         assert_eq!(
             validate_creature_width(&creature),
@@ -177,6 +179,7 @@ mod tests {
             synapses: vec![],
             semantic_version: None,
             forward_only: true,
+            memetic: None,
         };
         assert_eq!(
             validate_creature_width(&creature),

--- a/rust_scorer/src/if_tree_fixture.rs
+++ b/rust_scorer/src/if_tree_fixture.rs
@@ -30,6 +30,15 @@
 //! neurons are hosted by both GPU kernels (Issue #312), so the fixture needs no
 //! reserved bias column in the corpus and works against any record layout.
 //!
+//! A creature may not carry two synapses between the same ordered pair of
+//! neurons — NEAT-AI's TypeScript loader keys synapses by `(from, to)` and
+//! collapses duplicates, and `neat_core::compile_creature` rejects them
+//! outright (NEAT-AI-core#556). One `IF` node reads up to **three** bias-1
+//! sources — condition, positive branch, negative branch — so it needs three
+//! distinct constants ([`BIAS_ONE_UUID`], [`BIAS_ONE_POSITIVE_UUID`],
+//! [`BIAS_ONE_NEGATIVE_UUID`]), not one reused three times. All three hold the
+//! same `1.0`, so the arithmetic is unchanged; only the wiring is legal.
+//!
 //! Once `NEAT-AI-core#555` lands its canonical fixture and graft helper, these
 //! builders become the scorer-side consumers of it; the parity assertions in
 //! `tests/if_tree_parity.rs` are written against the semantics, not the builder,
@@ -38,8 +47,30 @@
 use crate::fixture_json::{creature_envelope, neuron_json, synapse_json, typed_synapse_json};
 
 /// UUID of the constant neuron every tree fixture uses to inject `1.0` into the
-/// condition and branch buckets.
+/// **condition** bucket.
 pub const BIAS_ONE_UUID: &str = "const-one";
+
+/// UUID of the constant neuron feeding the **positive** branch of an `IF` node
+/// whose high child is a leaf. Distinct from [`BIAS_ONE_UUID`] so the node does
+/// not carry two synapses from the same source (NEAT-AI-core#556).
+pub const BIAS_ONE_POSITIVE_UUID: &str = "const-one-positive";
+
+/// UUID of the constant neuron feeding the **negative** branch of an `IF` node
+/// whose low child is a leaf. Distinct from [`BIAS_ONE_UUID`] for the same
+/// reason as [`BIAS_ONE_POSITIVE_UUID`].
+pub const BIAS_ONE_NEGATIVE_UUID: &str = "const-one-negative";
+
+/// The three bias-1 constants an `IF` node hangs off, in emission order.
+///
+/// Listed ahead of every hidden neuron that reads them, and all holding the
+/// same `1.0` — one per synapse role, so no `(from, to)` pair repeats.
+fn bias_one_neurons() -> Vec<String> {
+    vec![
+        neuron_json("constant", BIAS_ONE_UUID, 1.0, "IDENTITY"),
+        neuron_json("constant", BIAS_ONE_POSITIVE_UUID, 1.0, "IDENTITY"),
+        neuron_json("constant", BIAS_ONE_NEGATIVE_UUID, 1.0, "IDENTITY"),
+    ]
+}
 
 /// UUID of the single output neuron every fixture in this module emits.
 pub const OUTPUT_UUID: &str = "output-0";
@@ -156,12 +187,15 @@ fn push_node_synapses(spec: &TreeSpec, id: usize, synapses: &mut Vec<String>) {
         -spec.threshold(id),
         Some("condition"),
     ));
-    for (child, role) in [(2 * id + 2, "positive"), (2 * id + 1, "negative")] {
+    for (child, role, leaf_one) in [
+        (2 * id + 2, "positive", BIAS_ONE_POSITIVE_UUID),
+        (2 * id + 1, "negative", BIAS_ONE_NEGATIVE_UUID),
+    ] {
         if child < internal {
             synapses.push(typed_synapse_json(&node_uuid(child), &to, 1.0, Some(role)));
         } else {
             synapses.push(typed_synapse_json(
-                BIAS_ONE_UUID,
+                leaf_one,
                 &to,
                 spec.leaf_value(child - internal),
                 Some(role),
@@ -179,7 +213,7 @@ fn push_node_synapses(spec: &TreeSpec, id: usize, synapses: &mut Vec<String>) {
 #[must_use]
 pub fn tree_creature_json(spec: &TreeSpec) -> String {
     let internal = spec.num_internal_nodes();
-    let mut neurons = vec![neuron_json("constant", BIAS_ONE_UUID, 1.0, "IDENTITY")];
+    let mut neurons = bias_one_neurons();
     let mut synapses = Vec::with_capacity(internal * 4 + 1);
     // Heap numbering is level order, so descending ids visit the deepest level
     // first — every child is emitted before the parent that reads it.
@@ -239,11 +273,11 @@ pub fn tree_reference_output(spec: &TreeSpec, inputs: &[f32]) -> f32 {
 #[must_use]
 pub fn mixed_neural_if_creature_json(spec: &TreeSpec, hidden: usize) -> String {
     let num_inputs = spec.num_inputs;
-    let mut neurons = Vec::with_capacity(hidden + 3);
+    let mut neurons = Vec::with_capacity(hidden + 5);
     for h in 0..hidden {
         neurons.push(neuron_json("hidden", &format!("hidden-{h}"), 0.05, "TANH"));
     }
-    neurons.push(neuron_json("constant", BIAS_ONE_UUID, 1.0, "IDENTITY"));
+    neurons.extend(bias_one_neurons());
     neurons.push(neuron_json("hidden", &node_uuid(0), 0.0, "IF"));
     neurons.push(neuron_json("output", OUTPUT_UUID, 0.0, "IDENTITY"));
 
@@ -277,13 +311,13 @@ pub fn mixed_neural_if_creature_json(spec: &TreeSpec, hidden: usize) -> String {
         Some("condition"),
     ));
     synapses.push(typed_synapse_json(
-        BIAS_ONE_UUID,
+        BIAS_ONE_POSITIVE_UUID,
         &root,
         spec.leaf_value(1),
         Some("positive"),
     ));
     synapses.push(typed_synapse_json(
-        BIAS_ONE_UUID,
+        BIAS_ONE_NEGATIVE_UUID,
         &root,
         spec.leaf_value(0),
         Some("negative"),
@@ -309,11 +343,11 @@ pub fn mixed_neural_if_creature_json(spec: &TreeSpec, hidden: usize) -> String {
 pub fn grafted_creature_json(spec: &TreeSpec, hidden: usize) -> String {
     let spec = &TreeSpec::new(spec.num_inputs, 1, spec.seed);
     let num_inputs = spec.num_inputs;
-    let mut neurons = Vec::with_capacity(hidden + 3);
+    let mut neurons = Vec::with_capacity(hidden + 5);
     for h in 0..hidden {
         neurons.push(neuron_json("hidden", &format!("hidden-{h}"), 0.05, "TANH"));
     }
-    neurons.push(neuron_json("constant", BIAS_ONE_UUID, 1.0, "IDENTITY"));
+    neurons.extend(bias_one_neurons());
     neurons.push(neuron_json("hidden", &node_uuid(0), 0.0, "IF"));
     neurons.push(neuron_json("output", OUTPUT_UUID, 0.0, "IDENTITY"));
 

--- a/rust_scorer/src/scoring.rs
+++ b/rust_scorer/src/scoring.rs
@@ -213,6 +213,7 @@ pub struct ScoreComponents {
 ///     input: 1,
 ///     output: 1,
 ///     neurons: vec![NeuronExport {
+///         id: None,
 ///         neuron_type: "output".to_string(),
 ///         uuid: "output-0".to_string(),
 ///         bias: -0.3,
@@ -226,6 +227,7 @@ pub struct ScoreComponents {
 ///     }],
 ///     semantic_version: Some("4.0.0".to_string()),
 ///     forward_only: true,
+///     memetic: None,
 /// };
 ///
 /// let components = compute_score_components(&creature).unwrap();
@@ -722,12 +724,14 @@ mod tests {
             output: 1,
             neurons: vec![
                 neat_core::creature::NeuronExport {
+                    id: None,
                     neuron_type: "hidden".to_string(),
                     uuid: "hidden-0".to_string(),
                     bias: 0.5,
                     squash: Some("TANH".to_string()),
                 },
                 neat_core::creature::NeuronExport {
+                    id: None,
                     neuron_type: "output".to_string(),
                     uuid: "output-0".to_string(),
                     bias: -0.3,
@@ -756,6 +760,7 @@ mod tests {
             ],
             semantic_version: Some("4.1.0".to_string()),
             forward_only: false,
+            memetic: None,
         };
 
         let components = compute_score_components(&creature).unwrap();
@@ -774,6 +779,7 @@ mod tests {
             input: 1,
             output: 1,
             neurons: vec![neat_core::creature::NeuronExport {
+                id: None,
                 neuron_type: "output".to_string(),
                 uuid: "output-0".to_string(),
                 bias,
@@ -787,6 +793,7 @@ mod tests {
             }],
             semantic_version: Some("4.0.0".to_string()),
             forward_only: false,
+            memetic: None,
         }
     }
 

--- a/rust_scorer/tests/input_output_width_guard.rs
+++ b/rust_scorer/tests/input_output_width_guard.rs
@@ -230,6 +230,7 @@ fn score_components_reject_widthless_export() {
         input: 0,
         output: 1,
         neurons: vec![NeuronExport {
+            id: None,
             neuron_type: "output".to_string(),
             uuid: "output-0".to_string(),
             bias: 0.0,
@@ -243,6 +244,7 @@ fn score_components_reject_widthless_export() {
         }],
         semantic_version: Some("4.0.0".to_string()),
         forward_only: true,
+        memetic: None,
     };
     let err = compute_score_components(&creature).expect_err("input:0 must be rejected");
     assert_eq!(

--- a/rust_scorer/tests/memetic_wire_forms_scoring.rs
+++ b/rust_scorer/tests/memetic_wire_forms_scoring.rs
@@ -1,0 +1,140 @@
+//! GRQ#4259 / neat-core#569 — a creature carrying `memetic.weights` in either
+//! valid wire form flows through the scorer unchanged.
+//!
+//! neat-core 0.10.0 retyped the public `MemeticExport::weights` field from
+//! `BTreeMap<String, Vec<MemeticWeightExport>>` to the `MemeticWeights` enum so
+//! that both NEAT-AI wire forms parse — the UUID-keyed row array written by
+//! `MemeticWireExport.ts` (the form that cost the fleet a Backprop stage,
+//! GRQ#4257) and the id-keyed map. `rust_scorer` never reads memetic weights,
+//! but every creature it scores is parsed by neat-core, so this is the
+//! behaviour the acknowledged breaking bump has to preserve: both forms parse,
+//! neither changes any score component, and an invalid form still fails loud.
+//!
+//! These assertions cannot hold against neat-core < 0.10.0: the row form is
+//! rejected there with `invalid type: sequence, expected a map`.
+
+use neat_core::creature::{compile_creature, parse_creature_json};
+use rust_scorer::fixture_json::{creature_envelope, neuron_json, synapse_json};
+use rust_scorer::scoring::compute_score_components;
+
+/// The two-input, one-hidden, one-output creature every case below scores,
+/// optionally carrying a `memetic` block spliced in before the closing brace.
+fn creature_json(memetic: Option<&str>) -> String {
+    let neurons = vec![
+        neuron_json("hidden", "hidden-0", 0.5, "TANH"),
+        neuron_json("output", "output-0", -0.3, "IDENTITY"),
+    ];
+    let synapses = vec![
+        synapse_json("input-0", "hidden-0", 1.5),
+        synapse_json("input-1", "hidden-0", -0.8),
+        synapse_json("hidden-0", "output-0", 2.0),
+    ];
+    let envelope = creature_envelope(2, 1, &neurons, &synapses);
+    match memetic {
+        None => envelope,
+        Some(block) => {
+            let body = envelope
+                .strip_suffix('}')
+                .expect("the envelope is a JSON object");
+            format!(r#"{body},"memetic":{block}}}"#)
+        }
+    }
+}
+
+/// The UUID-keyed row array — `MemeticWeightWireRow[]`, the GRQ#4257 form.
+const ROW_FORM: &str = r#"{"biases":{"output-0":0.25},"weights":[
+    {"fromUUID":"input-0","toUUID":"hidden-0","weight":0.125},
+    {"fromUUID":"hidden-0","toUUID":"output-0","weight":-0.5}
+]}"#;
+
+/// The id-keyed map — `MemeticWeightsInterface`.
+const MAP_FORM: &str = r#"{"biases":{"-1":0.25},"weights":{
+    "1":[{"toId":-1,"weight":-0.5}]
+}}"#;
+
+#[test]
+fn row_form_memetic_creature_parses_compiles_and_scores() {
+    let creature = parse_creature_json(&creature_json(Some(ROW_FORM)))
+        .expect("the UUID row form must parse — GRQ#4257");
+
+    let memetic = creature
+        .memetic
+        .as_ref()
+        .expect("memetic survives the parse");
+    let rows = memetic
+        .weights
+        .rows()
+        .expect("the row form parses as MemeticWeights::Rows");
+    assert_eq!(rows.len(), 2);
+
+    compile_creature(&creature).expect("a memetic creature still compiles");
+    let components = compute_score_components(&creature).expect("and still scores");
+    assert_eq!(components.hidden_neuron_count, 1);
+    assert_eq!(components.synapse_count, 3);
+}
+
+#[test]
+fn map_form_memetic_creature_parses_compiles_and_scores() {
+    let creature = parse_creature_json(&creature_json(Some(MAP_FORM)))
+        .expect("the id-keyed map form must still parse");
+
+    let memetic = creature
+        .memetic
+        .as_ref()
+        .expect("memetic survives the parse");
+    let by_id = memetic
+        .weights
+        .by_id()
+        .expect("the map form parses as MemeticWeights::ById");
+    assert_eq!(by_id.len(), 1);
+
+    compile_creature(&creature).expect("a memetic creature still compiles");
+    compute_score_components(&creature).expect("and still scores");
+}
+
+#[test]
+fn memetic_weights_never_move_a_score_component() {
+    let plain = compute_score_components(
+        &parse_creature_json(&creature_json(None)).expect("the plain creature parses"),
+    )
+    .expect("the plain creature scores");
+
+    for (label, form) in [("row", ROW_FORM), ("map", MAP_FORM)] {
+        let scored = compute_score_components(
+            &parse_creature_json(&creature_json(Some(form))).expect("the memetic creature parses"),
+        )
+        .expect("the memetic creature scores");
+        assert_eq!(
+            scored.hidden_neuron_count, plain.hidden_neuron_count,
+            "{label} form moved hidden_neuron_count"
+        );
+        assert_eq!(
+            scored.synapse_count, plain.synapse_count,
+            "{label} form moved synapse_count"
+        );
+        assert!(
+            (scored.max_weight_bias - plain.max_weight_bias).abs() < f64::EPSILON,
+            "{label} form moved max_weight_bias"
+        );
+        assert!(
+            (scored.avg_weight_bias - plain.avg_weight_bias).abs() < f64::EPSILON,
+            "{label} form moved avg_weight_bias"
+        );
+        assert!(
+            (scored.squash_complexity_penalty - plain.squash_complexity_penalty).abs()
+                < f64::EPSILON,
+            "{label} form moved squash_complexity_penalty"
+        );
+    }
+}
+
+#[test]
+fn a_memetic_weights_value_that_is_neither_form_fails_loud() {
+    let err = parse_creature_json(&creature_json(Some(r#"{"weights":7}"#)))
+        .expect_err("a scalar `weights` is neither valid form and must be rejected");
+    let message = err.to_string();
+    assert!(
+        message.contains("weights"),
+        "the failure must name the offending field, was: {message}"
+    );
+}

--- a/rust_scorer/tests/memetic_wire_forms_scoring.rs
+++ b/rust_scorer/tests/memetic_wire_forms_scoring.rs
@@ -1,11 +1,11 @@
-//! GRQ#4259 / neat-core#569 — a creature carrying `memetic.weights` in either
-//! valid wire form flows through the scorer unchanged.
+//! neat-core#569 — a creature carrying `memetic.weights` in either valid wire
+//! form flows through the scorer unchanged.
 //!
 //! neat-core 0.10.0 retyped the public `MemeticExport::weights` field from
 //! `BTreeMap<String, Vec<MemeticWeightExport>>` to the `MemeticWeights` enum so
 //! that both NEAT-AI wire forms parse — the UUID-keyed row array written by
-//! `MemeticWireExport.ts` (the form that cost the fleet a Backprop stage,
-//! GRQ#4257) and the id-keyed map. `rust_scorer` never reads memetic weights,
+//! `MemeticWireExport.ts` (the form that cost the fleet a Backprop stage) and
+//! the id-keyed map. `rust_scorer` never reads memetic weights,
 //! but every creature it scores is parsed by neat-core, so this is the
 //! behaviour the acknowledged breaking bump has to preserve: both forms parse,
 //! neither changes any score component, and an invalid form still fails loud.
@@ -41,7 +41,8 @@ fn creature_json(memetic: Option<&str>) -> String {
     }
 }
 
-/// The UUID-keyed row array — `MemeticWeightWireRow[]`, the GRQ#4257 form.
+/// The UUID-keyed row array — `MemeticWeightWireRow[]`, the form NEAT-AI
+/// writes for any JSON that leaves the process.
 const ROW_FORM: &str = r#"{"biases":{"output-0":0.25},"weights":[
     {"fromUUID":"input-0","toUUID":"hidden-0","weight":0.125},
     {"fromUUID":"hidden-0","toUUID":"output-0","weight":-0.5}
@@ -55,7 +56,7 @@ const MAP_FORM: &str = r#"{"biases":{"-1":0.25},"weights":{
 #[test]
 fn row_form_memetic_creature_parses_compiles_and_scores() {
     let creature = parse_creature_json(&creature_json(Some(ROW_FORM)))
-        .expect("the UUID row form must parse — GRQ#4257");
+        .expect("the UUID-keyed row form must parse");
 
     let memetic = creature
         .memetic


### PR DESCRIPTION
Moves `neat-core.expected-version` from **0.9.0** to **0.10.0**, adds a test covering both valid wire forms of `memetic.weights`, and fixes the IF-tree fixtures so they emit legal creatures under the stricter neat-core.

## Why the bump

neat-core 0.10.0 (neat-core#569) models `memetic.weights` in both shapes NEAT-AI writes — the UUID-keyed **row array** produced by `MemeticWireExport.ts` for any JSON leaving the process, and the id-keyed **map**. Consumers built before it modelled only the map and fail with `Creature JSON error: invalid type: sequence, expected a map`.

That is live on the fleet: the batch scorer hits it and silently falls back to per-creature WASM scoring, so natively-scored creatures end up compared against WASM-scored ones. Confirmed against live samples, which carry `.memetic.weights` as an array.

## The fixture fix

Bumping the baseline surfaced four failing lib tests:

```
compile fixture: DuplicateSynapse { from_uuid: "const-one", to_uuid: "if-2" }
a deep spec must still graft cleanly: DuplicateSynapse { from_uuid: "const-one", to_uuid: "if-0" }
```

`if_tree_fixture.rs` reused a **single** `const-one` for all three synapse roles of an `IF` node. Any node whose branches are both leaves therefore emitted three synapses from that one constant to the same target — a repeated `(from, to)` pair. The TypeScript loader keys synapses by that pair and collapses duplicates, and `neat_core::compile_creature` now rejects them outright (neat-core#556), so the fixtures were building creatures that could never be scored consistently.

Each role now gets its own bias-1 constant — `const-one` (condition), `const-one-positive`, `const-one-negative` — emitted together ahead of the neurons that read them. All three hold `1.0`, so every weight, the synapse emission order and every resulting score are unchanged; only the wiring becomes legal. The reference evaluator's bit-exactness against the CPU pipeline is preserved for the same reason.

This is the fixture-side counterpart of the same rule Forests enforces in its own emitter.

## Verification

- `cargo test`: **285 lib + all integration tests pass** (was 281 passed / 4 failed).
- `cargo clippy --all-targets -- -D warnings`: clean. `cargo fmt --all` applied.
- `bats tests/scripts`: all 626 pass. The `source_private_repo_refs` guard (Issue #452) was failing on the new test file's comments; reworded to concept level.

Refs neat-core#569, neat-core#556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHbMCg7JQcqEEp4W8JJDZb