### PR TITLE
Pin the memetic creature parse at the binary boundary (NEAT-AI#3813)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ section to the released version with its date.
 
 ### Added
 
+- **Binary-level regression gate for creatures carrying a `memetic` block
+  (stSoftwareAU/NEAT-AI#3813).** `rust_scorer/tests/memetic_creature_parse.rs`
+  feeds two committed fixtures — `rust_scorer/tests/fixtures/memetic_creature.json`
+  and `memetic_creature_empty_weights.json`, trimmed evolved exports carrying a
+  populated `memetic` block — to the **compiled** `rust_scorer` binary, so the
+  `fs::read_to_string` → `parse_creature_json` path the CLI actually uses is the
+  one under test. They cover the array-form `memetic.weights`, the empty
+  `"weights": []` that every creature evolved without a memetic pass exports, and
+  array-form `weights` one snapshot deeper in `memetic.ancestry[]`. Against a
+  map-only neat-core the binary died with
+  `Creature JSON error: invalid type: sequence, expected a map` before doing any
+  work and NEAT-AI evolve fell back to WASM scoring on every call; the tests now
+  fail loud on that exact string and assert the run reaches real work instead.
+  The neat-core baseline stays **0.10.0** — the release that carries the tolerant
+  deserialiser — with the reasoning recorded in `neat-core.expected-version`.
 - **CPU/GPU parity contract for `IF` decision-tree creatures (Issue #574).**
   `rust_scorer/src/if_tree_fixture.rs` builds the canonical tree fixtures
   `NEAT-AI-Forests` will generate — depth-1 stump, nested tree, mixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.65"
+version = "1.1.66"
 dependencies = [
  "bytemuck",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/docs/archive/pr-summaries/pr-summary-neat-ai-3813.md
+++ b/docs/archive/pr-summaries/pr-summary-neat-ai-3813.md
@@ -1,0 +1,122 @@
+# PR summary — stSoftwareAU/NEAT-AI#3813
+
+## Summary
+
+`rust_scorer` used to die before doing any work on **any** creature carrying a
+`memetic` block:
+
+```text
+Error: Creature JSON error: invalid type: sequence, expected a map at line 1 column 567
+```
+
+NEAT-AI serialises `memetic.weights` as a JSON **array** — usually the empty
+array `[]`, because a creature evolved without a memetic pass still writes the
+key — while the Rust `MemeticExport::weights` field was a map. Every NEAT-AI
+evolve run therefore fell back to WASM scoring, hundreds of times per
+`./quality.sh`, and the native batch path was effectively dead while every run
+still looked green.
+
+neat-core fixed the deserialiser in **0.10.0** (`MemeticWeights`, neat-core #569
+/ GRQ#4257, hardened by #570). This repo already consumes it — the
+`neat-core.expected-version` baseline was moved to 0.10.0 in #576 — so nothing
+was left to bump. What was missing was a gate holding the guarantee **from the
+binary's side**, which is what this change adds.
+
+- `rust_scorer/tests/memetic_creature_parse.rs` — new regression test feeding
+  committed fixtures to the **compiled** `rust_scorer` binary, so the
+  `fs::read_to_string` → `parse_creature_json` path the CLI actually takes is
+  the path under test.
+- `rust_scorer/tests/fixtures/memetic_creature.json` — trimmed evolved export
+  with a populated array-form `memetic.weights`.
+- `rust_scorer/tests/fixtures/memetic_creature_empty_weights.json` — the same
+  creature with `"weights": []`, the shape that fires in practice.
+- Both fixtures carry `memetic.ancestry[]` snapshots whose `weights` are also
+  array-form (one populated, one empty).
+- `neat-core.expected-version` — records why the baseline **stays** 0.10.0: that
+  release *is* the one carrying the fix, and 0.10.1 is non-breaking patch drift
+  the gate already allows.
+
+The fixtures are the identity creature the existing smoke test scores, plus a
+`memetic` block, so a parse regression is the only way they can fail — they
+still score against `identity_data.bin` with near-zero error.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. The evidence is the
+bidirectional verification the issue asks for, run against two sibling
+`NEAT-AI-core` checkouts.
+
+### Against the old, map-only neat-core (0.9.12)
+
+```text
+$ ./target/debug/rust_scorer --gpu off rust_scorer/tests/fixtures/memetic_creature.json /tmp/empty
+Error: Creature JSON error: invalid type: sequence, expected a map at line 27 column 15
+exit=1
+$ ./target/debug/rust_scorer --gpu off rust_scorer/tests/fixtures/memetic_creature_empty_weights.json /tmp/empty
+Error: Creature JSON error: invalid type: sequence, expected a map at line 27 column 15
+exit=1
+```
+
+The new CLI-level tests are red there (the library-level assertions cannot even
+compile against 0.9.12, which has no `MemeticWeights`):
+
+```text
+running 2 tests
+test cli_reaches_the_corpus_check_instead_of_dying_on_the_memetic_block ... FAILED
+test cli_scores_a_creature_carrying_a_populated_memetic_block ... FAILED
+
+memetic_creature.json: the memetic parse regression is back:
+Error: Creature JSON error: invalid type: sequence, expected a map at line 27 column 15
+```
+
+### Against the pinned neat-core (sibling clone at 0.10.1)
+
+The manual reproduction from stSoftwareAU/NEAT-AI#3810 now reaches real work:
+
+```text
+$ ./target/debug/rust_scorer --gpu off rust_scorer/tests/fixtures/memetic_creature.json /tmp/empty
+Error: No .bin files found in training data directory '/tmp/empty'
+$ ./target/debug/rust_scorer --gpu off rust_scorer/tests/fixtures/memetic_creature_empty_weights.json /tmp/empty
+Error: No .bin files found in training data directory '/tmp/empty'
+```
+
+```text
+running 5 tests
+test an_empty_memetic_weight_array_parses_to_no_rows ... ok
+test a_populated_memetic_weight_array_keeps_its_rows ... ok
+test ancestry_snapshots_keep_their_array_form_weights ... ok
+test cli_reaches_the_corpus_check_instead_of_dying_on_the_memetic_block ... ok
+test cli_scores_a_creature_carrying_a_populated_memetic_block ... ok
+
+test result: ok. 5 passed; 0 failed
+```
+
+### Where the gate sits
+
+```mermaid
+flowchart LR
+    F["fixtures/memetic_creature*.json<br/>populated memetic block"] --> B["rust_scorer binary<br/>(CARGO_BIN_EXE)"]
+    B --> R["fs::read_to_string"] --> P["neat_core::parse_creature_json"]
+    P -- "map-only core (&lt; 0.10.0)" --> X["invalid type: sequence,<br/>expected a map — test FAILS"]
+    P -- "pinned core (0.10.x)" --> W["scores, or 'No .bin files found'<br/>on an empty corpus — test PASSES"]
+```
+
+## Test Plan
+
+`rust_scorer/tests/memetic_creature_parse.rs`:
+
+- `cli_scores_a_creature_carrying_a_populated_memetic_block` — the binary scores
+  both fixtures against `identity_data.bin`; near-zero error and 4 records, so
+  the memetic block changes no score component.
+- `cli_reaches_the_corpus_check_instead_of_dying_on_the_memetic_block` — the
+  stSoftwareAU/NEAT-AI#3810 manual check as a test: with an empty data
+  directory the first failure must be `No .bin files found`, never
+  `invalid type: sequence, expected a map`.
+- `an_empty_memetic_weight_array_parses_to_no_rows` — `"weights": []` parses to
+  the row form with no rows, and the rest of the memetic block survives.
+- `a_populated_memetic_weight_array_keeps_its_rows` — the populated array keeps
+  its `fromUUID` / `toUUID` row.
+- `ancestry_snapshots_keep_their_array_form_weights` — both `memetic.ancestry[]`
+  snapshots survive with their array-form `weights`, populated and empty.
+
+Full local gate: `./quality.sh < /dev/null`.

--- a/docs/archive/pr-summaries/pr-summary-neat-ai-3813.md
+++ b/docs/archive/pr-summaries/pr-summary-neat-ai-3813.md
@@ -16,8 +16,8 @@ evolve run therefore fell back to WASM scoring, hundreds of times per
 `./quality.sh`, and the native batch path was effectively dead while every run
 still looked green.
 
-neat-core fixed the deserialiser in **0.10.0** (`MemeticWeights`, neat-core #569
-/ GRQ#4257, hardened by #570). This repo already consumes it — the
+neat-core fixed the deserialiser in **0.10.0** (`MemeticWeights`, neat-core #569,
+hardened by #570). This repo already consumes it — the
 `neat-core.expected-version` baseline was moved to 0.10.0 in #576 — so nothing
 was left to bump. What was missing was a gate holding the guarantee **from the
 binary's side**, which is what this change adds.

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -64,4 +64,14 @@
 # `rust_scorer/tests/memetic_wire_forms_scoring.rs`, which asserts a creature
 # carrying either wire form parses, compiles and scores identically to the same
 # creature without one.
+#
+# 0.10.0 stays the baseline (NEAT-AI#3813). 0.10.0 IS the release carrying the
+# tolerant `memetic.weights` deserialiser that unbreaks `rust_scorer` on every
+# evolved creature, so there is no newer version to move to. neat-core has since
+# published 0.10.1 (#570 deserialiser tests, #571 float round-trip); both are
+# patch-level within the handled 0.10 line, which this gate allows and which
+# needs no acknowledgement. `rust_scorer/tests/memetic_creature_parse.rs` pins
+# the guarantee from the binary's side: it fails against a map-only neat-core
+# (verified against 0.9.12 — `Creature JSON error: invalid type: sequence,
+# expected a map`) and passes against the sibling clone at 0.10.1.
 0.10.0

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.65"
+version = "1.1.66"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/tests/fixtures/memetic_creature.json
+++ b/rust_scorer/tests/fixtures/memetic_creature.json
@@ -1,0 +1,57 @@
+{
+  "input": 1,
+  "output": 1,
+  "forwardOnly": true,
+  "semanticVersion": "4.0.0",
+  "neurons": [
+    {
+      "type": "output",
+      "uuid": "output-0",
+      "bias": 0.0,
+      "squash": "IDENTITY"
+    }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "output-0",
+      "weight": 1.0
+    }
+  ],
+  "memetic": {
+    "generation": 3,
+    "score": 0.708,
+    "biases": {
+      "output-0": -0.1116
+    },
+    "weights": [
+      {
+        "fromUUID": "input-0",
+        "toUUID": "output-0",
+        "weight": 1.0
+      }
+    ],
+    "ancestry": [
+      {
+        "generation": 2,
+        "score": 0.681,
+        "biases": {
+          "output-0": -0.0904
+        },
+        "weights": [
+          {
+            "fromUUID": "input-0",
+            "toUUID": "output-0",
+            "weight": 0.9871
+          }
+        ]
+      },
+      {
+        "generation": 1,
+        "score": 0.652,
+        "biases": {},
+        "weights": []
+      }
+    ]
+  }
+}

--- a/rust_scorer/tests/fixtures/memetic_creature_empty_weights.json
+++ b/rust_scorer/tests/fixtures/memetic_creature_empty_weights.json
@@ -1,0 +1,51 @@
+{
+  "input": 1,
+  "output": 1,
+  "forwardOnly": true,
+  "semanticVersion": "4.0.0",
+  "neurons": [
+    {
+      "type": "output",
+      "uuid": "output-0",
+      "bias": 0.0,
+      "squash": "IDENTITY"
+    }
+  ],
+  "synapses": [
+    {
+      "fromUUID": "input-0",
+      "toUUID": "output-0",
+      "weight": 1.0
+    }
+  ],
+  "memetic": {
+    "generation": 3,
+    "score": 0.708,
+    "biases": {
+      "output-0": -0.1116
+    },
+    "weights": [],
+    "ancestry": [
+      {
+        "generation": 2,
+        "score": 0.681,
+        "biases": {
+          "output-0": -0.0904
+        },
+        "weights": [
+          {
+            "fromUUID": "input-0",
+            "toUUID": "output-0",
+            "weight": 0.9871
+          }
+        ]
+      },
+      {
+        "generation": 1,
+        "score": 0.652,
+        "biases": {},
+        "weights": []
+      }
+    ]
+  }
+}

--- a/rust_scorer/tests/memetic_creature_parse.rs
+++ b/rust_scorer/tests/memetic_creature_parse.rs
@@ -1,0 +1,218 @@
+//! stSoftwareAU/NEAT-AI#3813 — a real evolved creature export carrying a
+//! populated `memetic` block parses through the **binary's** own path.
+//!
+//! Every NEAT-AI evolve run exports `memetic.weights` as a JSON array — usually
+//! the empty array `[]`, because a creature evolved without a memetic pass still
+//! writes the key. Against a map-only `MemeticExport::weights` the CLI died
+//! before doing any work:
+//!
+//! ```text
+//! Error: Creature JSON error: invalid type: sequence, expected a map at line 1 column 567
+//! ```
+//!
+//! NEAT-AI evolve then fell back to WASM scoring hundreds of times per
+//! `./quality.sh`, so the native batch path — the whole point of this binary —
+//! was effectively dead while every run still looked green.
+//!
+//! `rust_scorer/tests/memetic_wire_forms_scoring.rs` covers the two wire forms
+//! at the *library* boundary with JSON built in-process. This file is the
+//! regression gate for the shapes that actually fire in the wild, fed to the
+//! **compiled binary** through committed fixtures — the same
+//! `fs::read_to_string` → `parse_creature_json` path
+//! `rust_scorer <creature.json> <data_dir>` takes:
+//!
+//! * `memetic.weights: []` — the empty row array, the shape on essentially
+//!   every evolved creature.
+//! * `memetic.weights: [{fromUUID, toUUID, weight}, …]` — the populated row
+//!   array.
+//! * `memetic.ancestry[].weights` — the same two shapes one snapshot deeper.
+//!
+//! These assertions cannot hold against a `neat-core` older than 0.10.0: the
+//! row form is rejected there with `invalid type: sequence, expected a map`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use neat_core::creature::parse_creature_json;
+
+/// The serde message the map-only deserialiser produced for every memetic
+/// creature. Named once so each assertion below points at the same regression.
+const SEQUENCE_EXPECTED_MAP: &str = "invalid type: sequence, expected a map";
+
+/// Both fixtures are the identity creature the smoke test already scores, plus
+/// a `memetic` block — so a parse regression is the only way they can fail.
+const MEMETIC_FIXTURES: [&str; 2] = [
+    "memetic_creature.json",
+    "memetic_creature_empty_weights.json",
+];
+
+/// Resolve `tests/fixtures/<name>` relative to this crate.
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+/// A fresh temporary directory holding a copy of `identity_data.bin`, so
+/// concurrent tests never share a data directory.
+fn identity_data_dir() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let src = fixture("identity_data.bin");
+    let dst = tmp.path().join("identity_data.bin");
+    std::fs::copy(&src, &dst)
+        .unwrap_or_else(|e| panic!("copy fixture {} -> {}: {e}", src.display(), dst.display()));
+    tmp
+}
+
+/// Run the compiled `rust_scorer` against a fixture creature and a data
+/// directory, with the GPU explicitly off (the manual reproduction in
+/// NEAT-AI#3810 uses `--gpu off`, and it keeps the test hardware-independent).
+fn run_scorer(creature: &str, data_dir: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rust_scorer"))
+        .arg("--gpu")
+        .arg("off")
+        .arg(fixture(creature))
+        .arg(data_dir)
+        .output()
+        .expect("failed to spawn rust_scorer binary")
+}
+
+#[test]
+fn cli_scores_a_creature_carrying_a_populated_memetic_block() {
+    for name in MEMETIC_FIXTURES {
+        let data_dir = identity_data_dir();
+        let output = run_scorer(name, data_dir.path());
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+        assert!(
+            !stderr.contains(SEQUENCE_EXPECTED_MAP),
+            "{name}: the memetic parse regression is back:\n{stderr}"
+        );
+        assert!(
+            output.status.success(),
+            "{name}: rust_scorer exited with {:?}\nstderr:\n{stderr}",
+            output.status.code(),
+        );
+
+        let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+        let parsed: serde_json::Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("{name}: stdout is not JSON: {e}\n{stdout}"));
+
+        // The memetic block is metadata the scorer never applies, so the
+        // identity creature must still score exactly as it does without one.
+        let error = parsed
+            .get("error")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or_else(|| panic!("{name}: missing `error` in scorer JSON"));
+        assert!(
+            error.abs() < 1e-6,
+            "{name}: expected near-zero error, got {error}"
+        );
+
+        let record_count = parsed
+            .get("recordCount")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_else(|| panic!("{name}: missing `recordCount` in scorer JSON"));
+        assert_eq!(record_count, 4, "{name}: expected 4 records");
+    }
+}
+
+/// The manual reproduction from NEAT-AI#3810, as a test: pointed at a data
+/// directory with no `.bin` files, the binary must get *past* the creature
+/// parse and fail on the missing corpus instead.
+#[test]
+fn cli_reaches_the_corpus_check_instead_of_dying_on_the_memetic_block() {
+    for name in MEMETIC_FIXTURES {
+        let empty_dir = tempfile::tempdir().expect("create tempdir");
+        let output = run_scorer(name, empty_dir.path());
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+        assert!(
+            !stderr.contains(SEQUENCE_EXPECTED_MAP),
+            "{name}: the memetic parse regression is back:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("No .bin files found in training data directory"),
+            "{name}: expected the corpus check to be the first failure, got:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn an_empty_memetic_weight_array_parses_to_no_rows() {
+    let json = std::fs::read_to_string(fixture("memetic_creature_empty_weights.json"))
+        .expect("read the empty-weights fixture");
+    let creature = parse_creature_json(&json).expect("`\"weights\": []` must parse");
+
+    let memetic = creature
+        .memetic
+        .as_ref()
+        .expect("memetic survives the parse");
+    let rows = memetic
+        .weights
+        .rows()
+        .expect("an empty array is the row form, not the map form");
+    assert!(
+        rows.is_empty(),
+        "an empty array carries no rows, got {rows:?}"
+    );
+    assert_eq!(
+        memetic.biases.get("output-0").copied(),
+        Some(-0.1116),
+        "the rest of the memetic block survives alongside the empty array"
+    );
+}
+
+#[test]
+fn a_populated_memetic_weight_array_keeps_its_rows() {
+    let json = std::fs::read_to_string(fixture("memetic_creature.json"))
+        .expect("read the populated-weights fixture");
+    let creature = parse_creature_json(&json).expect("the populated row array must parse");
+
+    let memetic = creature
+        .memetic
+        .as_ref()
+        .expect("memetic survives the parse");
+    let rows = memetic
+        .weights
+        .rows()
+        .expect("the row array is the row form");
+    assert_eq!(rows.len(), 1, "the fixture carries one weight row");
+    assert_eq!(rows[0].from_uuid.as_deref(), Some("input-0"));
+    assert_eq!(rows[0].to_uuid.as_deref(), Some("output-0"));
+}
+
+/// `memetic.ancestry[]` is another memetic record and carries `weights` in the
+/// same array form — including the empty array. Both fixtures must keep every
+/// snapshot, with its rows intact.
+#[test]
+fn ancestry_snapshots_keep_their_array_form_weights() {
+    for name in MEMETIC_FIXTURES {
+        let json = std::fs::read_to_string(fixture(name)).unwrap_or_else(|e| panic!("{name}: {e}"));
+        let creature = parse_creature_json(&json)
+            .unwrap_or_else(|e| panic!("{name}: array-form ancestry weights must parse: {e}"));
+
+        let ancestry = creature
+            .memetic
+            .as_ref()
+            .expect("memetic survives the parse")
+            .extra
+            .get("ancestry")
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| panic!("{name}: the ancestry list survives the parse"));
+        assert_eq!(ancestry.len(), 2, "{name}: both snapshots survive");
+
+        let populated = ancestry[0]
+            .get("weights")
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| panic!("{name}: the first snapshot keeps array-form weights"));
+        assert_eq!(populated.len(), 1, "{name}: its single row survives");
+
+        let empty = ancestry[1]
+            .get("weights")
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| panic!("{name}: the second snapshot keeps array-form weights"));
+        assert!(empty.is_empty(), "{name}: its empty array survives");
+    }
+}


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/NEAT-AI#3813 here, in the dependency's own repo.

Regression gate feeding committed populated-memetic fixtures (including \

**Head:** `issue-3813-memetic-creature-parse-regression` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/NEAT-AI#3813: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.