### PR TITLE
Directory mode rejects forwardOnly=false — the recurrent maths already exists in cli.rs, only the batch loop hard-codes the flag (Issue #579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ section to the released version with its date.
 
 ### Added
 
+- **Directory mode scores `forwardOnly: false` (recurrent) creatures
+  (Issue #579).** The load-time guard in
+  `rust_scorer/src/multi_score.rs` that rejected any creature directory
+  containing a recurrent creature is gone. The per-chunk worker pool now carries
+  a `worker_forward_only` vector alongside `worker_creature_idx`, so each worker
+  passes **its own creature's** flag to `cost::accumulate_cost_sum` instead of a
+  hard-coded `true`; with `forward_only = false` the upstream kernel clears the
+  network state before every record, which keeps records independent and
+  therefore keeps the Rayon record partition valid. A directory may mix
+  forward-only and recurrent creatures, each entry's `forwardOnly` JSON field
+  now reports the creature's own flag, and `rust_scorer <dir>` reports the same
+  `error` as `rust_scorer <file>` for the same recurrent creature. The GPU path
+  needed no shader change — both kernels already zero every non-input activation
+  per `(creature, record)` thread. Recurrent creatures lose the upstream SIMD
+  batch kernels (gated on `forward_only`) and fall to the scalar per-record
+  scan; forward-only creatures in the same batch are unaffected. New coverage:
+  `rust_scorer/tests/recurrent_directory_tdd.rs` (reset semantics, single-creature
+  parity, mixed batch) plus two `rust_scorer/tests/cost_parity.rs` tests
+  (chunk-vs-per-record dispatch bit-identical for all eight costs; the
+  `forward_only` flag is load-bearing on a back edge). The pre-#579
+  `directory_mode_rejects_forward_only_false` test is replaced by
+  `directory_mode_accepts_forward_only_false` — a deliberate behaviour change.
 - **Binary-level regression gate for creatures carrying a `memetic` block
   (stSoftwareAU/NEAT-AI#3813).** `rust_scorer/tests/memetic_creature_parse.rs`
   feeds two committed fixtures — `rust_scorer/tests/fixtures/memetic_creature.json`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.2"
+version = "0.10.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.67"
+version = "1.1.68"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -133,7 +133,46 @@ rust_scorer <creature.json | creatures_dir> <training_data_dir>
 
 - `creature.json` path: scores one creature and returns the existing single-object output.
 - `creatures_dir` path: scores every `*.json` in that directory in one pass over training data and returns one JSON object keyed by each file's stem (filename without extension or folders).
-- Directory mode requires `forwardOnly: true` and matching `input` / `output` shape across all files.
+- Directory mode requires a matching `input` / `output` shape across all files. Since **Issue #579** it accepts `forwardOnly: false` creatures — see [Recurrent creatures in directory mode](#recurrent-creatures-in-directory-mode-issue-579) below.
+
+### Recurrent creatures in directory mode (Issue #579)
+
+A creature directory may mix `forwardOnly: true` and `forwardOnly: false`
+creatures. Each is scored under **its own** flag, so a recurrent creature in a
+batch gets the same per-record state reset the single-creature path applies —
+`neat_core::loss::packed_record_scan` calls `CompiledNetwork::reset_state()`
+before every record, a back edge therefore reads `0.0`, and records stay
+independent. Independence is what keeps the batch path valid: a chunk is still
+partitioned across Rayon workers, and each creature's `forwardOnly` follows its
+worker.
+
+```mermaid
+flowchart LR
+    L["load_creatures_from_dir()"] --> W["worker pool<br/>(worker → creature, forwardOnly)"]
+    W --> C["accumulate_cost_sum(..., forward_only)"]
+    C -->|true| S["SIMD 8-way / 4-way batch<br/>(state carried — no back edges)"]
+    C -->|false| R["scalar packed_record_scan<br/>reset_state() per record"]
+    S --> F["per-creature error"]
+    R --> F
+```
+
+Consequences worth knowing before you batch a recurrent population:
+
+- **Same answer as single-creature mode.** `rust_scorer <dir>` and
+  `rust_scorer <file>` report the same `error` for the same recurrent creature
+  (pinned by `rust_scorer/tests/recurrent_directory_tdd.rs`).
+- **`forwardOnly` is echoed per creature** in the directory JSON, so a caller
+  can see which entries took the recurrent path.
+- **Recurrent creatures lose the SIMD batch kernels** (upstream gates the 8-way
+  and 4-way paths on `forward_only`) and fall to the scalar per-record scan —
+  several times slower *for those creatures only*. Forward-only creatures
+  sharing the batch are unaffected; `reset_state()` costs O(neurons) stores per
+  record.
+- **The GPU path needs no change.** Both `forward_mse_batched` and
+  `forward_mse_scratch` zero every non-input activation per
+  `(creature, record)` thread, so a GPU thread never carries state between
+  records — the reset semantics hold on GPU by construction, and the
+  hostability/topology probes classify neuron counts only.
 
 ### GPU mode (Issues #80 / #83)
 
@@ -1104,7 +1143,10 @@ forward-only path and the per-record recurrent path:
 - **Per-record recurrent path.** `forwardOnly: false` creatures use
   `TrainingDataIterator` to feed `[inputs..., targets...]` packed records into
   the same `accumulate_cost_sum` helper one record at a time, so every
-  supported cost works here too.
+  supported cost works here too. Directory mode (Issue #579) passes a whole
+  chunk to the same helper with `forward_only = false`; the per-record reset
+  inside `packed_record_scan` makes the two numerically identical, pinned per
+  cost by `rust_scorer/tests/cost_parity.rs`.
 - **`CATEGORICAL_ERROR` dispatches** through `categorical_error_sum_batch_packed`
   (landed via [`NEAT-AI-core#88`](https://github.com/stSoftwareAU/NEAT-AI-core/issues/88);
   unblocked here in #134) — the dispatch returns the integer count of

--- a/docs/archive/pr-summaries/pr-summary-579.md
+++ b/docs/archive/pr-summaries/pr-summary-579.md
@@ -1,0 +1,135 @@
+# PR Summary — Issue #579
+
+## Summary
+
+Directory mode now scores `forwardOnly: false` (recurrent) creatures instead of
+refusing to load them. Closes #579.
+
+The guard in `load_creatures_from_dir` was a correctness stopgap for a hard-coded
+boolean: the per-chunk hot loop passed a literal `true` to
+`cost::accumulate_cost_sum`, so without the guard a recurrent creature would have
+been scored with network state leaking across records — silently wrong. The flag
+is now threaded per worker, and the guard is gone.
+
+- **`rust_scorer/src/multi_score.rs`**
+  - Deleted the load-time `forwardOnly=false` rejection.
+  - Built `worker_forward_only` alongside the existing `worker_creature_idx`, so
+    the `par_iter` closure indexes the owning creature's flag with the
+    `worker_idx` it already carries. The empty-chunk cost-dispatch probe now uses
+    worker 0's flag rather than a literal `true`.
+  - Both result builders (CPU and GPU) report the creature's **own**
+    `forwardOnly`, not the batch's former precondition.
+  - Module docs gained a "Recurrent creatures" section; the
+    `gpu_directory_compatible` doc no longer cites `forwardOnly=false` as a load
+    failure.
+- **Docs** — README directory-mode bullet, a new
+  [Recurrent creatures in directory mode](../../../README.md#recurrent-creatures-in-directory-mode-issue-579)
+  section with a Mermaid dispatch diagram, the cost-dispatch note, and a
+  `CHANGELOG.md` entry.
+
+Everything downstream was already flag-driven, so nothing else needed to change:
+
+- `cost::accumulate_cost_sum` forwards `forward_only` to
+  `neat_core::loss::*_sum_batch_packed` for all eight costs.
+- With `forward_only = false` the upstream `packed_record_scan` calls
+  `CompiledNetwork::reset_state()` before every record, so records stay
+  **independent** — which is what keeps partitioning a chunk across Rayon workers
+  valid for a recurrent creature. No restructuring of the worker-split machinery.
+- **The GPU path needs no change** (issue item 3, confirmed by reading the code):
+  `forward_mse_batched.wgsl` and `forward_mse_scratch.wgsl` zero every non-input
+  activation per `(creature, record)` thread, so a GPU thread never carries state
+  between records; `gpu_directory_probe_for_dir` and `gpu_directory_compatible`
+  classify neuron counts and squashes only, never `forwardOnly`.
+
+**Expected cost:** recurrent creatures lose the upstream 8-way/4-way SIMD batch
+kernels (both gated on `forward_only`) and fall to the scalar `packed_record_scan`
+— several times slower **for those creatures only**. Forward-only creatures in the
+same batch are untouched, and `reset_state()` is O(num_neurons) stores per record.
+This is a capability change, not a performance change, so no before/after
+benchmark applies.
+
+## Evidence
+
+Backend/CLI change — there is no web interface to screenshot. The evidence is the
+test suite plus the dispatch change itself.
+
+```mermaid
+flowchart LR
+    L["load_creatures_from_dir()<br/>#579: no forwardOnly guard"] --> W["worker pool<br/>worker → (creature, forwardOnly)"]
+    W --> C["accumulate_cost_sum(..., worker_forward_only[worker_idx])"]
+    C -->|true| S["SIMD 8-way / 4-way batch<br/>state carried (no back edges)"]
+    C -->|false| R["scalar packed_record_scan<br/>reset_state() before each record"]
+    S --> F["per-creature error"]
+    R --> F
+```
+
+Full local gate results:
+
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings …` — clean.
+- `cargo check`, `cargo build`, `RUSTDOCFLAGS=-D warnings cargo doc`,
+  `cargo build --release` — all clean.
+- `cargo test --workspace --all-features -- --test-threads=2` — every suite
+  passes (285 unit tests, 32 doc-tests, and every integration suite including the
+  three new recurrent tests).
+- `markdownlint-cli2` — 0 issues.
+- **`./quality.sh` cannot complete in this container**: its codespell preflight
+  exits before the Rust steps with `spell-check: codespell is not installed.`, and
+  the image has no `pip`/`ensurepip` to install it (`/usr/bin/python3: No module
+  named pip`). Every other gate step was run individually, in `quality.sh`'s own
+  order, with the results above. The codespell CI job still gates the PR.
+
+Answering the issue's open question 4 ("is there any test proving
+`rust_scorer <creatures_dir>` and `rust_scorer <creature.json>` produce identical
+errors for the same creature?"): there is now —
+`recurrent_directory_tdd::directory_mode_recurrent_score_matches_single_creature_mode`
+compares the two paths' `error` and `score` **bit-for-bit**.
+
+## Test Plan
+
+Added — `rust_scorer/tests/recurrent_directory_tdd.rs` (new file; all fixtures use
+exact binary fractions so every partial sum is exact in `f64`, making the
+comparisons independent of how a chunk is partitioned across workers):
+
+- `directory_mode_scores_forward_only_false` — a directory holding a creature with
+  a genuine back edge exits 0, emits JSON, reports `forwardOnly: false`, scores
+  every record, and produces the **reset-semantics** error (`0.1171875`, the
+  analytic value for `output = 0.5 × input`). A leaked activation gives a
+  different number, so this is the regression test for the hard-coded `true`.
+- `directory_mode_recurrent_score_matches_single_creature_mode` — directory mode
+  and single-creature mode agree bit-for-bit on `error` and `score`.
+- `directory_mode_mixes_forward_only_and_recurrent_creatures` — a **mixed** batch:
+  the recurrent creature keeps reset semantics, the forward-only creature beside
+  it is unaffected, each entry reports its own `forwardOnly`, and both match their
+  single-creature runs.
+
+Added — `rust_scorer/tests/cost_parity.rs`:
+
+- `recurrent_chunk_dispatch_matches_per_record_dispatch_for_every_cost` — for all
+  eight costs, handing a whole chunk to `accumulate_cost_sum` with
+  `forward_only = false` (what directory mode does) is bit-identical to the
+  one-record-at-a-time loop the single-creature path runs. Nine records, so the
+  fixture crosses the SIMD-batch boundary the forward-only paths use.
+- `recurrent_flag_changes_the_chunk_sum_on_a_back_edge` — the flag is load-bearing:
+  on a creature with a back edge, skipping the reset changes the sum, and the
+  reset value matches the analytic expectation.
+
+Modified — `rust_scorer/tests/directory_mode_tdd.rs`:
+
+- `directory_mode_rejects_forward_only_false` → `directory_mode_accepts_forward_only_false`.
+  **This is a deliberate business-logic change**: the old test pinned the exact
+  behaviour the issue asks to remove, so it could not be kept as-is. The
+  replacement holds the load-time contract (exit 0, real JSON, the creature's own
+  flag echoed back) and its doc comment records the swap.
+
+## Out of scope
+
+The issue also lists three items beyond its "Proposed work", left untouched here
+and unchanged by this PR:
+
+- **One bad creature aborts the whole batch** — a per-creature `{"error": …}` entry
+  is a contract change the TypeScript caller must sign off on first.
+- **No CLI early-exit / streaming flag** — `score_from_creature_dir_with_early_exit`
+  remains a library-only API.
+- **`--gpu auto` declines the GPU for deep ScratchOnly and Mixed pools** — that
+  routing is Issue #317/#467 policy backed by fleet benchmarks, and revisiting it
+  needs its own before/after evidence.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.67"
+version = "1.1.68"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -22,6 +22,19 @@
 //! `par_iter_mut` over per-creature worker networks, which oversubscribed the
 //! global Rayon pool with `creatures × workers` tasks.
 //!
+//! ## Recurrent creatures (Issue #579)
+//!
+//! A directory may mix `forwardOnly: true` and `forwardOnly: false` creatures.
+//! Each worker carries its own creature's flag into `accumulate_cost_sum`, so a
+//! recurrent creature is scored exactly as the single-creature path scores it:
+//! `forward_only = false` makes the upstream kernel call
+//! `CompiledNetwork::reset_state` before every record, which keeps records
+//! independent and therefore keeps the per-worker record partition above valid.
+//! The cost is that recurrent creatures lose the 8-way/4-way SIMD batch
+//! kernels (upstream gates both on `forward_only`) and fall to the scalar
+//! per-record scan — several times slower for **those creatures only**;
+//! forward-only creatures sharing the batch are untouched.
+//!
 //! ## Task granularity (Issue #537)
 //!
 //! `NEAT_SCORER_WORKER_SPLIT=k` multiplies that worker budget by `k`, so each
@@ -231,12 +244,10 @@ fn load_creatures_from_dir(creatures_dir: &Path) -> Result<Vec<LoadedCreature>, 
         // file is opened (no fallback, no re-derivation from `neurons`).
         validate_creature_width(&creature)
             .map_err(|e| format!("Creature '{}': {e}", path.display()))?;
-        if !creature.forward_only {
-            return Err(format!(
-                "Creature '{}' has forwardOnly=false; multi-creature directory mode requires forwardOnly=true for every creature",
-                path.display()
-            ));
-        }
+        // Issue #579: `forwardOnly=false` is accepted here. The per-chunk hot
+        // loop threads each creature's own flag into `accumulate_cost_sum`, so
+        // a recurrent creature is scored with the per-record state reset the
+        // single-creature path applies — no state leaks across records.
 
         loaded.push(LoadedCreature {
             key,
@@ -640,11 +651,17 @@ fn score_from_creature_dir_cpu(
         worker_offsets.push(acc);
     }
 
-    // Reverse map: each worker → its owning creature index.
+    // Reverse map: each worker → its owning creature index, plus that
+    // creature's own `forwardOnly` flag (Issue #579). The flag is resolved
+    // per worker so the hot loop indexes it with the same `worker_idx` the
+    // `par_iter` already carries, instead of chasing back through the
+    // creature list inside the parallel closure.
     let mut worker_creature_idx: Vec<usize> = Vec::with_capacity(total_workers);
+    let mut worker_forward_only: Vec<bool> = Vec::with_capacity(total_workers);
     for (ci, &w) in workers_per.iter().enumerate() {
         for _ in 0..w {
             worker_creature_idx.push(ci);
+            worker_forward_only.push(loaded[ci].creature.forward_only);
         }
     }
 
@@ -685,7 +702,9 @@ fn score_from_creature_dir_cpu(
             &[],
             num_inputs,
             num_outputs,
-            true,
+            // Issue #579: worker 0 belongs to creature 0, so probe with that
+            // creature's own flag rather than a hard-coded `true`.
+            worker_forward_only[0],
         )?;
     }
 
@@ -760,7 +779,12 @@ fn score_from_creature_dir_cpu(
                         &floats[range.clone()],
                         num_inputs,
                         num_outputs,
-                        true,
+                        // Issue #579: each worker scores with its own
+                        // creature's flag. `false` makes the upstream kernel
+                        // clear the network state before every record, so a
+                        // recurrent creature's records stay independent and
+                        // partitioning the chunk across workers stays valid.
+                        worker_forward_only[worker_idx],
                     )?;
                 } else {
                     *sum = 0.0;
@@ -909,7 +933,9 @@ fn score_from_creature_dir_cpu(
                 record_count: scored,
                 hidden_neurons,
                 synapse_count,
-                forward_only: true,
+                // Issue #579: report the creature's own flag, not the batch's
+                // former `forwardOnly=true` precondition.
+                forward_only: loaded_creature.creature.forward_only,
                 training_read_backend: training_read_backend.clone(),
                 gpu_backend,
                 read_buf_len: Some(fused_read_buf_len),
@@ -959,8 +985,13 @@ fn score_from_creature_dir_cpu(
 /// * `Ok(())` — either the set is GPU-hostable, or it could not even be
 ///   loaded/compiled. Load/compile failures are deliberately *not* treated as
 ///   GPU-incompatibility: they are left for the normal scoring path to surface
-///   with its existing, precise error message (e.g. shape mismatch,
-///   `forwardOnly=false`).
+///   with its existing, precise error message (e.g. shape mismatch, an invalid
+///   observation width).
+///
+/// Issue #579: `forwardOnly` plays no part in this classification — it only
+/// counts neurons and squashes. A recurrent creature is as GPU-hostable as a
+/// forward-only one of the same shape, because both kernels zero every
+/// non-input activation per `(creature, record)` thread.
 ///
 /// # Examples
 ///
@@ -974,7 +1005,7 @@ fn score_from_creature_dir_cpu(
 /// }
 /// ```
 pub fn gpu_directory_compatible(creatures_dir: &Path) -> Result<(), GpuPrepareError> {
-    // A load failure here (missing dir, shape mismatch, forwardOnly=false, …)
+    // A load failure here (missing dir, shape mismatch, bad width, …)
     // is not a GPU-hostability question — return Ok so the real scoring path
     // re-runs the load and reports the precise error itself.
     let loaded = match load_creatures_from_dir(creatures_dir) {
@@ -1415,7 +1446,12 @@ fn score_from_creature_dir_gpu_impl(
                 record_count: total_records,
                 hidden_neurons,
                 synapse_count,
-                forward_only: true,
+                // Issue #579: report the creature's own flag. The kernels zero
+                // every non-input activation per `(creature, record)` thread,
+                // so a GPU thread never carries state between records — the
+                // reset semantics `forwardOnly=false` requires hold here
+                // without a shader change.
+                forward_only: loaded_creature.creature.forward_only,
                 training_read_backend: training_read_backend.clone(),
                 gpu_backend,
                 read_buf_len: Some(fused_read_buf_len),

--- a/rust_scorer/tests/cost_parity.rs
+++ b/rust_scorer/tests/cost_parity.rs
@@ -531,3 +531,130 @@ fn parity_rmse_ranks_creatures_same_order_as_mse() {
         "expected strictly increasing error levels across the fixed datasets"
     );
 }
+
+/// Issue #579 — recurrent (`forward_only = false`) fixture with a genuine back
+/// edge: `output-0` (neuron index 2) feeds `hidden-0` (neuron index 1), which
+/// the compiler evaluates first. With the per-record reset the edge reads a
+/// cleared activation; without it, it reads the previous record's output.
+fn recurrent_1_in_1_out() -> CompiledNetwork {
+    let json = creature_envelope(
+        1,
+        1,
+        &[
+            neuron_json("hidden", "hidden-0", 0.0, "IDENTITY"),
+            neuron_json("output", "output-0", 0.0, "IDENTITY"),
+        ],
+        &[
+            synapse_json("input-0", "hidden-0", 0.5),
+            synapse_json("hidden-0", "output-0", 1.0),
+            // Back edge — the reason this creature is not forward-only.
+            synapse_json("output-0", "hidden-0", 0.5),
+        ],
+    );
+    compile_creature(&parse_creature_json(&json).expect("parse recurrent_1_in_1_out"))
+        .expect("compile recurrent_1_in_1_out")
+}
+
+/// Every cost the CLI accepts, in declaration order.
+const EVERY_COST: [CostKind; 8] = [
+    CostKind::Mse,
+    CostKind::Rmse,
+    CostKind::Mae,
+    CostKind::Mape,
+    CostKind::Msle,
+    CostKind::Hinge,
+    CostKind::CrossEntropy,
+    CostKind::CategoricalError,
+];
+
+/// Positive-only records so every cost (including the log-based ones) stays in
+/// its defined domain. Nine records cross the SIMD-batch boundary the
+/// forward-only paths use, proving the recurrent dispatch never takes it.
+const RECURRENT_PAIRS: [(f32, f32); 9] = [
+    (0.5, 0.25),
+    (0.25, 0.125),
+    (0.75, 0.5),
+    (0.125, 0.0625),
+    (0.625, 0.75),
+    (0.375, 0.25),
+    (0.875, 0.5),
+    (0.1875, 0.125),
+    (0.9375, 0.875),
+];
+
+/// Issue #579 — directory mode hands a **whole chunk** of records to
+/// `accumulate_cost_sum` with `forward_only = false`, whereas the
+/// single-creature recurrent path hands over one record at a time. For every
+/// supported cost the two must agree bit-for-bit: `packed_record_scan` resets
+/// the network state before each record, so records stay independent and the
+/// chunk sum accumulates in the same f64 order as the per-record loop.
+///
+/// This is the numerical contract that lets a recurrent creature be scored in
+/// a batch at all — without it, partitioning a chunk across workers would
+/// change the answer.
+#[test]
+fn recurrent_chunk_dispatch_matches_per_record_dispatch_for_every_cost() {
+    let chunk = pack_pairs(&RECURRENT_PAIRS);
+
+    for cost in EVERY_COST {
+        let mut chunk_net = recurrent_1_in_1_out();
+        let chunk_sum = accumulate_cost_sum(cost, &mut chunk_net, &chunk, 1, 1, false)
+            .expect("chunked recurrent dispatch must succeed");
+
+        let mut record_net = recurrent_1_in_1_out();
+        let mut per_record_sum = 0.0_f64;
+        for pair in RECURRENT_PAIRS {
+            let record = pack_pairs(&[pair]);
+            per_record_sum += accumulate_cost_sum(cost, &mut record_net, &record, 1, 1, false)
+                .expect("per-record recurrent dispatch must succeed");
+        }
+
+        assert_eq!(
+            chunk_sum.to_bits(),
+            per_record_sum.to_bits(),
+            "{}: chunked recurrent sum {chunk_sum} must be bit-identical to the per-record sum {per_record_sum}",
+            cost.as_str(),
+        );
+    }
+}
+
+/// Issue #579 — the `forward_only` argument is load-bearing, not cosmetic: on
+/// a creature with a back edge, skipping the per-record reset leaks the
+/// previous record's output into the next activation and changes the answer.
+/// Three records keep the dispatch on the scalar scan for both flag values, so
+/// the only difference under test is the reset itself.
+#[test]
+fn recurrent_flag_changes_the_chunk_sum_on_a_back_edge() {
+    // Zero targets, so each record's error is the square of the creature's
+    // output and a leaked activation cannot cancel out of the sum.
+    let pairs: [(f32, f32); 3] = [(0.5, 0.0), (0.25, 0.0), (0.75, 0.0)];
+    let chunk = pack_pairs(&pairs);
+
+    let mut reset_net = recurrent_1_in_1_out();
+    let reset_sum = accumulate_cost_sum(CostKind::Mse, &mut reset_net, &chunk, 1, 1, false)
+        .expect("reset dispatch must succeed");
+
+    let mut leaking_net = recurrent_1_in_1_out();
+    let leaking_sum = accumulate_cost_sum(CostKind::Mse, &mut leaking_net, &chunk, 1, 1, true)
+        .expect("forward-only dispatch must succeed");
+
+    assert_ne!(
+        reset_sum.to_bits(),
+        leaking_sum.to_bits(),
+        "a back edge must make forward_only load-bearing (both sums were {reset_sum})",
+    );
+
+    // The reset value is analytically exact: `output = 0.5 * input`, so each
+    // record contributes `(target - 0.5 * input)^2` over one output.
+    let expected: f64 = pairs
+        .iter()
+        .map(|&(input, target)| {
+            let diff = target as f64 - 0.5 * input as f64;
+            diff * diff
+        })
+        .sum();
+    assert!(
+        (reset_sum - expected).abs() < EPS_SMOOTH,
+        "reset semantics must clear the back edge: actual={reset_sum}, expected={expected}",
+    );
+}

--- a/rust_scorer/tests/directory_mode_tdd.rs
+++ b/rust_scorer/tests/directory_mode_tdd.rs
@@ -523,8 +523,15 @@ fn directory_mode_auto_shallow_scratch_topology_keeps_gpu() {
     }
 }
 
+/// Issue #579 replaced the pre-#579 `directory_mode_rejects_forward_only_false`
+/// guard: directory mode no longer refuses `forwardOnly: false` creatures at
+/// load time, it scores them with the same per-record state reset the
+/// single-creature path applies. The reset semantics and the single-creature
+/// parity are pinned in `tests/recurrent_directory_tdd.rs`; this test keeps the
+/// load-time contract itself — no error, real JSON, the creature's own flag
+/// reported back.
 #[test]
-fn directory_mode_rejects_forward_only_false() {
+fn directory_mode_accepts_forward_only_false() {
     let bin = env!("CARGO_BIN_EXE_rust_scorer");
     let tmp = tempfile::tempdir().expect("create tempdir");
     let creatures_dir = tmp.path().join("creatures");
@@ -540,10 +547,18 @@ fn directory_mode_rejects_forward_only_false() {
         .arg(&data_dir)
         .output()
         .expect("spawn scorer");
-    assert!(!output.status.success(), "forwardOnly=false should fail");
-    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("forwardOnly=false"),
-        "expected forwardOnly error, got: {stderr}",
+        output.status.success(),
+        "forwardOnly=false must be scored, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be JSON");
+    let entry = parsed.get("a").expect("missing `a` key");
+    assert_eq!(
+        entry.get("forwardOnly").and_then(|v| v.as_bool()),
+        Some(false),
+        "the reported forwardOnly must be the creature's own flag, got: {entry}",
     );
 }

--- a/rust_scorer/tests/recurrent_directory_tdd.rs
+++ b/rust_scorer/tests/recurrent_directory_tdd.rs
@@ -1,0 +1,202 @@
+//! Issue #579 — directory mode must score `forwardOnly: false` (recurrent)
+//! creatures natively, with the same per-record reset semantics the
+//! single-creature path already applies.
+//!
+//! Every fixture here is deliberately **dyadic**: inputs, weights and targets
+//! are exact binary fractions, so each per-record error and every partial sum
+//! is exact in `f64`. That makes the assertions independent of how the batch
+//! path partitions a chunk across Rayon workers (which re-associates the f64
+//! partial sums) — a directory-mode error may be compared bit-for-bit against
+//! the single-creature error without a tolerance.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+/// Exact-binary inputs; targets are all `0.0`, so a record's error is the
+/// square of the creature's output.
+const INPUTS: [f32; 8] = [0.5, 1.0, 0.25, 0.75, 0.5, 0.25, 1.0, 0.75];
+
+/// Mean squared error of the recurrent creature under **reset** semantics:
+/// `output = 0.5 * input` (the back edge reads a cleared activation), so the
+/// per-record error is `0.25 * input²`.
+const RECURRENT_EXPECTED_ERROR: f64 = 0.117_187_5;
+
+/// Mean squared error of the feed-forward creature: `output = 0.25 * input`,
+/// so the per-record error is `0.062_5 * input²`.
+const FORWARD_EXPECTED_ERROR: f64 = 0.029_296_875;
+
+fn write_training_data(dir: &Path) {
+    let mut file = std::fs::File::create(dir.join("0.bin")).expect("create data file");
+    for &input in &INPUTS {
+        file.write_all(&input.to_le_bytes()).expect("write input");
+        file.write_all(&0.0_f32.to_le_bytes())
+            .expect("write target");
+    }
+}
+
+/// 1-in / 1-out creature carrying a genuine **back edge**: `output-0` (neuron
+/// index 2) feeds `hidden-0` (neuron index 1), which the compiler evaluates
+/// first. Under `forwardOnly: false` the activation buffer is cleared before
+/// every record, so that edge contributes `0.0` and `output = 0.5 * input`.
+/// Under `forwardOnly: true` it would instead read the previous record's
+/// output — which is exactly the state leak this mode must not introduce.
+fn recurrent_creature() -> String {
+    r#"{"input":1,"output":1,"forwardOnly":false,"semanticVersion":"4.0.0","neurons":[{"type":"hidden","uuid":"hidden-0","bias":0.0,"squash":"IDENTITY"},{"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}],"synapses":[{"fromUUID":"input-0","toUUID":"hidden-0","weight":0.5},{"fromUUID":"hidden-0","toUUID":"output-0","weight":1.0},{"fromUUID":"output-0","toUUID":"hidden-0","weight":0.5}]}"#
+        .to_string()
+}
+
+/// Plain feed-forward creature sharing the recurrent fixture's 1-in / 1-out
+/// shape (directory mode still requires one shape across the batch).
+fn forward_creature() -> String {
+    r#"{"input":1,"output":1,"forwardOnly":true,"semanticVersion":"4.0.0","neurons":[{"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}],"synapses":[{"fromUUID":"input-0","toUUID":"output-0","weight":0.25}]}"#
+        .to_string()
+}
+
+fn run_scorer(creature_path: &Path, data_dir: &Path) -> serde_json::Value {
+    let bin = env!("CARGO_BIN_EXE_rust_scorer");
+    let output = Command::new(bin)
+        .arg(creature_path)
+        .arg(data_dir)
+        .output()
+        .expect("spawn scorer");
+    assert!(
+        output.status.success(),
+        "scorer must exit 0 for '{}', stderr:\n{}",
+        creature_path.display(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout must be JSON")
+}
+
+fn field_f64(entry: &serde_json::Value, name: &str) -> f64 {
+    entry
+        .get(name)
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or_else(|| panic!("missing numeric `{name}` in {entry}"))
+}
+
+/// Issue #579 — a directory containing a recurrent creature is scored, not
+/// rejected, and the reported error is the reset-semantics value.
+#[test]
+fn directory_mode_scores_forward_only_false() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let creatures_dir = tmp.path().join("creatures");
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir(&data_dir).expect("create data dir");
+    std::fs::write(creatures_dir.join("rec.json"), recurrent_creature()).expect("write rec");
+    write_training_data(&data_dir);
+
+    let parsed = run_scorer(&creatures_dir, &data_dir);
+    let entry = parsed
+        .get("rec")
+        .expect("missing `rec` key in directory JSON");
+
+    assert_eq!(
+        field_f64(entry, "error").to_bits(),
+        RECURRENT_EXPECTED_ERROR.to_bits(),
+        "recurrent creature must be scored with per-record state reset, got {entry}",
+    );
+    assert_eq!(
+        entry
+            .get("forwardOnly")
+            .and_then(serde_json::Value::as_bool),
+        Some(false),
+        "the reported forwardOnly must be the creature's own flag, got {entry}",
+    );
+    assert_eq!(
+        entry.get("recordCount").and_then(serde_json::Value::as_u64),
+        Some(INPUTS.len() as u64),
+        "every record must be scored, got {entry}",
+    );
+}
+
+/// Issue #579 — the directory path and the single-creature path must agree
+/// exactly for the same recurrent creature: one engine, one answer.
+#[test]
+fn directory_mode_recurrent_score_matches_single_creature_mode() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let creatures_dir = tmp.path().join("creatures");
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir(&data_dir).expect("create data dir");
+    let single_path = tmp.path().join("rec.json");
+    std::fs::write(&single_path, recurrent_creature()).expect("write single");
+    std::fs::write(creatures_dir.join("rec.json"), recurrent_creature()).expect("write rec");
+    write_training_data(&data_dir);
+
+    let single = run_scorer(&single_path, &data_dir);
+    let batch = run_scorer(&creatures_dir, &data_dir);
+    let entry = batch
+        .get("rec")
+        .expect("missing `rec` key in directory JSON");
+
+    assert_eq!(
+        field_f64(entry, "error").to_bits(),
+        field_f64(&single, "error").to_bits(),
+        "directory error must be bit-identical to single-creature error\nsingle={single}\nbatch={entry}",
+    );
+    assert_eq!(
+        field_f64(entry, "score").to_bits(),
+        field_f64(&single, "score").to_bits(),
+        "directory score must be bit-identical to single-creature score",
+    );
+}
+
+/// Issue #579 — a mixed batch: the recurrent creature keeps its reset
+/// semantics while the forward-only creature beside it is unaffected, and both
+/// match their single-creature runs.
+#[test]
+fn directory_mode_mixes_forward_only_and_recurrent_creatures() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let creatures_dir = tmp.path().join("creatures");
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir(&data_dir).expect("create data dir");
+    std::fs::write(creatures_dir.join("rec.json"), recurrent_creature()).expect("write rec");
+    std::fs::write(creatures_dir.join("fwd.json"), forward_creature()).expect("write fwd");
+    let single_rec = tmp.path().join("rec.json");
+    let single_fwd = tmp.path().join("fwd.json");
+    std::fs::write(&single_rec, recurrent_creature()).expect("write single rec");
+    std::fs::write(&single_fwd, forward_creature()).expect("write single fwd");
+    write_training_data(&data_dir);
+
+    let batch = run_scorer(&creatures_dir, &data_dir);
+    let rec = batch.get("rec").expect("missing `rec` key");
+    let fwd = batch.get("fwd").expect("missing `fwd` key");
+
+    assert_eq!(
+        field_f64(rec, "error").to_bits(),
+        RECURRENT_EXPECTED_ERROR.to_bits(),
+        "recurrent creature in a mixed batch keeps reset semantics, got {rec}",
+    );
+    assert_eq!(
+        field_f64(fwd, "error").to_bits(),
+        FORWARD_EXPECTED_ERROR.to_bits(),
+        "forward-only creature in a mixed batch is unaffected, got {fwd}",
+    );
+    assert_eq!(
+        rec.get("forwardOnly").and_then(serde_json::Value::as_bool),
+        Some(false),
+        "recurrent entry must report forwardOnly=false, got {rec}",
+    );
+    assert_eq!(
+        fwd.get("forwardOnly").and_then(serde_json::Value::as_bool),
+        Some(true),
+        "forward-only entry must report forwardOnly=true, got {fwd}",
+    );
+
+    let single_rec = run_scorer(&single_rec, &data_dir);
+    let single_fwd = run_scorer(&single_fwd, &data_dir);
+    assert_eq!(
+        field_f64(rec, "error").to_bits(),
+        field_f64(&single_rec, "error").to_bits(),
+        "mixed-batch recurrent error must match its single-creature run",
+    );
+    assert_eq!(
+        field_f64(fwd, "error").to_bits(),
+        field_f64(&single_fwd, "error").to_bits(),
+        "mixed-batch forward-only error must match its single-creature run",
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #579

## Summary

Directory mode now scores `forwardOnly: false` (recurrent) creatures instead of
refusing to load them. Closes #579.

The guard in `load_creatures_from_dir` was a correctness stopgap for a hard-coded
boolean: the per-chunk hot loop passed a literal `true` to
`cost::accumulate_cost_sum`, so without the guard a recurrent creature would have
been scored with network state leaking across records — silently wrong. The flag
is now threaded per worker, and the guard is gone.

- **`rust_scorer/src/multi_score.rs`**
  - Deleted the load-time `forwardOnly=false` rejection.
  - Built `worker_forward_only` alongside the existing `worker_creature_idx`, so
    the `par_iter` closure indexes the owning creature's flag with the
    `worker_idx` it already carries. The empty-chunk cost-dispatch probe now uses
    worker 0's flag rather than a literal `true`.
  - Both result builders (CPU and GPU) report the creature's **own**
    `forwardOnly`, not the batch's former precondition.
  - Module docs gained a "Recurrent creatures" section; the
    `gpu_directory_compatible` doc no longer cites `forwardOnly=false` as a load
    failure.
- **Docs** — README directory-mode bullet, a new
  [Recurrent creatures in directory mode](../../../README.md#recurrent-creatures-in-directory-mode-issue-579)
  section with a Mermaid dispatch diagram, the cost-dispatch note, and a
  `CHANGELOG.md` entry.

Everything downstream was already flag-driven, so nothing else needed to change:

- `cost::accumulate_cost_sum` forwards `forward_only` to
  `neat_core::loss::*_sum_batch_packed` for all eight costs.
- With `forward_only = false` the upstream `packed_record_scan` calls
  `CompiledNetwork::reset_state()` before every record, so records stay
  **independent** — which is what keeps partitioning a chunk across Rayon workers
  valid for a recurrent creature. No restructuring of the worker-split machinery.
- **The GPU path needs no change** (issue item 3, confirmed by reading the code):
  `forward_mse_batched.wgsl` and `forward_mse_scratch.wgsl` zero every non-input
  activation per `(creature, record)` thread, so a GPU thread never carries state
  between records; `gpu_directory_probe_for_dir` and `gpu_directory_compatible`
  classify neuron counts and squashes only, never `forwardOnly`.

**Expected cost:** recurrent creatures lose the upstream 8-way/4-way SIMD batch
kernels (both gated on `forward_only`) and fall to the scalar `packed_record_scan`
— several times slower **for those creatures only**. Forward-only creatures in the
same batch are untouched, and `reset_state()` is O(num_neurons) stores per record.
This is a capability change, not a performance change, so no before/after
benchmark applies.

## Evidence

Backend/CLI change — there is no web interface to screenshot. The evidence is the
test suite plus the dispatch change itself.

```mermaid
flowchart LR
    L["load_creatures_from_dir()<br/>#579: no forwardOnly guard"] --> W["worker pool<br/>worker → (creature, forwardOnly)"]
    W --> C["accumulate_cost_sum(..., worker_forward_only[worker_idx])"]
    C -->|true| S["SIMD 8-way / 4-way batch<br/>state carried (no back edges)"]
    C -->|false| R["scalar packed_record_scan<br/>reset_state() before each record"]
    S --> F["per-creature error"]
    R --> F
```

Full local gate results:

- `cargo clippy --workspace --all-targets --all-features -- -D warnings …` — clean.
- `cargo check`, `cargo build`, `RUSTDOCFLAGS=-D warnings cargo doc`,
  `cargo build --release` — all clean.
- `cargo test --workspace --all-features -- --test-threads=2` — every suite
  passes (285 unit tests, 32 doc-tests, and every integration suite including the
  three new recurrent tests).
- `markdownlint-cli2` — 0 issues.
- **`./quality.sh` cannot complete in this container**: its codespell preflight
  exits before the Rust steps with `spell-check: codespell is not installed.`, and
  the image has no `pip`/`ensurepip` to install it (`/usr/bin/python3: No module
  named pip`). Every other gate step was run individually, in `quality.sh`'s own
  order, with the results above. The codespell CI job still gates the PR.

Answering the issue's open question 4 ("is there any test proving
`rust_scorer <creatures_dir>` and `rust_scorer <creature.json>` produce identical
errors for the same creature?"): there is now —
`recurrent_directory_tdd::directory_mode_recurrent_score_matches_single_creature_mode`
compares the two paths' `error` and `score` **bit-for-bit**.

## Test Plan

Added — `rust_scorer/tests/recurrent_directory_tdd.rs` (new file; all fixtures use
exact binary fractions so every partial sum is exact in `f64`, making the
comparisons independent of how a chunk is partitioned across workers):

- `directory_mode_scores_forward_only_false` — a directory holding a creature with
  a genuine back edge exits 0, emits JSON, reports `forwardOnly: false`, scores
  every record, and produces the **reset-semantics** error (`0.1171875`, the
  analytic value for `output = 0.5 × input`). A leaked activation gives a
  different number, so this is the regression test for the hard-coded `true`.
- `directory_mode_recurrent_score_matches_single_creature_mode` — directory mode
  and single-creature mode agree bit-for-bit on `error` and `score`.
- `directory_mode_mixes_forward_only_and_recurrent_creatures` — a **mixed** batch:
  the recurrent creature keeps reset semantics, the forward-only creature beside
  it is unaffected, each entry reports its own `forwardOnly`, and both match their
  single-creature runs.

Added — `rust_scorer/tests/cost_parity.rs`:

- `recurrent_chunk_dispatch_matches_per_record_dispatch_for_every_cost` — for all
  eight costs, handing a whole chunk to `accumulate_cost_sum` with
  `forward_only = false` (what directory mode does) is bit-identical to the
  one-record-at-a-time loop the single-creature path runs. Nine records, so the
  fixture crosses the SIMD-batch boundary the forward-only paths use.
- `recurrent_flag_changes_the_chunk_sum_on_a_back_edge` — the flag is load-bearing:
  on a creature with a back edge, skipping the reset changes the sum, and the
  reset value matches the analytic expectation.

Modified — `rust_scorer/tests/directory_mode_tdd.rs`:

- `directory_mode_rejects_forward_only_false` → `directory_mode_accepts_forward_only_false`.
  **This is a deliberate business-logic change**: the old test pinned the exact
  behaviour the issue asks to remove, so it could not be kept as-is. The
  replacement holds the load-time contract (exit 0, real JSON, the creature's own
  flag echoed back) and its doc comment records the swap.

## Out of scope

The issue also lists three items beyond its "Proposed work", left untouched here
and unchanged by this PR:

- **One bad creature aborts the whole batch** — a per-creature `{"error": …}` entry
  is a contract change the TypeScript caller must sign off on first.
- **No CLI early-exit / streaming flag** — `score_from_creature_dir_with_early_exit`
  remains a library-only API.
- **`--gpu auto` declines the GPU for deep ScratchOnly and Mixed pools** — that
  routing is Issue #317/#467 policy backed by fleet benchmarks, and revisiting it
  needs its own before/after evidence.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt65783r-bf9346`<!-- vibe-worker-issue-579 -->