### PR TITLE
Pin cross-engine parity for (from, to, type)-keyed synapses before the rule relaxes (Issue #581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ section to the released version with its date.
 
 ### Added
 
+- **Parity guard for `(from, to, type)`-keyed synapses (Issue #581).**
+  `neat-core` 0.10.6 (NEAT-AI-core#577) relaxed the duplicate-synapse rule so one
+  source may feed an `IF` neuron through more than one role — the contribution
+  that must apply whichever way the node branches no longer needs an `IDENTITY`
+  relay purely to be a second distinct source. This engine already scored that
+  shape correctly, and the behaviour is now **pinned rather than assumed**. New
+  `rust_scorer/src/dual_role_fixture.rs` builds the relay-free creature (one
+  constant carrying all three roles, one input column carrying both branches),
+  the pre-#577 relay workaround describing the same function, the creature a
+  `(from, to)`-keyed loader is left holding, and the two shapes that must still
+  be refused (a repeated pair into a point-wise target; an exact repeated
+  triple). New `rust_scorer/tests/dual_role_parity.rs` asserts the synapse count
+  is identical in the raw JSON, the parsed export and the compiled network — the
+  Rust-side spelling of the `jsonSynapses === loadedSynapses` assertion
+  `NEAT-AI-Forests`' `ts_parity.rs` makes against `Creature.scoreDir` — that the
+  relaxed and relay forms activate bit-identically and score identically through
+  the real directory pipeline, that the dropped-edge creature scores
+  *differently* (so the guard cannot pass vacuously), and that both GPU kernels
+  agree with CPU within the `1e-3` cross-backend tolerance. Also new:
+  `fixture_json::constant_neuron_json`, which omits the `"squash"` key that
+  NEAT-AI's TypeScript loader refuses on a constant, so a fixture stays loadable
+  by both engines. No production scorer code changed — nothing in the scoring
+  path keys synapses by `(from, to)`. Fixture comments in `if_tree_fixture.rs`
+  and `shallow_fixture.rs` that stated the `(from, to)` rule as fact now record
+  it as the TypeScript loader's key (NEAT-AI#3873 is still open), with the
+  three-separate-constants split kept as a deliberate both-engines choice rather
+  than a requirement.
+
 - **Directory mode scores `forwardOnly: false` (recurrent) creatures
   (Issue #579).** The load-time guard in
   `rust_scorer/src/multi_score.rs` that rejected any creature directory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.68"
+version = "1.1.69"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -402,6 +402,64 @@ helper, these builders become its scorer-side consumers — the parity assertion
 are written against the semantics, not the builder, so the swap is a fixture
 change rather than a test rewrite.
 
+### Synapses are keyed by `(from, to, type)` (Issue #581)
+
+`NEAT-AI-core#577` relaxed the duplicate-synapse rule: the key is the
+`(fromUUID, toUUID, type)` **triple**, so one source may feed an `IF` neuron
+through more than one role. The contribution that must apply *whichever way the
+node branches* no longer needs an `IDENTITY` relay neuron existing purely to be
+a second distinct source. Every other squash sums its inward synapses regardless
+of role, so a repeated pair into a point-wise target is still refused — as
+`CreatureError::TypedDuplicateSynapse`, distinct from the
+`CreatureError::DuplicateSynapse` an exact repeated triple earns.
+
+This engine is the one that would **disagree first**, which is why the guard is
+pinned rather than assumed. `rust_scorer` resolves every synapse independently
+and sums each role's bucket; a loader keyed by `(from, to)` alone keeps one edge
+per ordered pair and silently drops the rest, so the same JSON means two
+different things:
+
+```mermaid
+flowchart LR
+    J["creature JSON<br/>A→IF positive<br/>A→IF negative"]
+    J --> RS["rust_scorer<br/>(from, to, type)"]
+    J --> TS["TypeScript loader<br/>(from, to) — NEAT-AI#3873 open"]
+    RS --> K["both edges kept<br/>each branch carries A"]
+    TS --> D["one edge kept<br/>one branch loses A"]
+    K --> S1["score X"]
+    D --> S2["score Y ≠ X"]
+    S1 --> W["divergence — a production<br/>'improvement' that was not real"]
+    S2 --> W
+```
+
+The fixtures live in
+[`rust_scorer/src/dual_role_fixture.rs`](rust_scorer/src/dual_role_fixture.rs):
+the relay-free creature (one constant carrying all three roles, one input column
+carrying both branches), the pre-#577 relay workaround that describes the *same*
+function, the creature a `(from, to)`-keyed loader is left holding, and the two
+shapes that must still be refused. They are consumed by
+[`tests/dual_role_parity.rs`](rust_scorer/tests/dual_role_parity.rs), which
+asserts that:
+
+- **nothing is dropped on load** — the synapse count is identical in the raw
+  JSON, the parsed export and the compiled network (the Rust-side spelling of
+  the `jsonSynapses === loadedSynapses` assertion `NEAT-AI-Forests`' `ts_parity.rs`
+  makes against `Creature.scoreDir`);
+- **the relaxed form and the relay workaround agree exactly** — bit-identical
+  activations and an identical loss through the real directory pipeline, so
+  upstream may drop the relay without moving a score;
+- **a dropped edge is detectable** — the `(from, to)`-keyed creature scores
+  differently, so the assertions above cannot pass vacuously;
+- **both GPU kernels agree** with CPU within the same `1e-3` cross-backend
+  tolerance, since the kernels bucket by synapse role too.
+
+Nothing in the scorer's own scoring path keys synapses by `(from, to)`: it
+iterates `creature.synapses` in declaration order and reports
+`synapse_count = creature.synapses.len()`. The TypeScript half of the rule
+(`NEAT-AI#3873`) is still open, so `if_tree_fixture.rs` keeps its three separate
+bias-1 constants — a conservative choice that keeps those fixtures loadable by
+**both** engines, not a requirement of this one.
+
 ### Cost function selector (Issues #120, #121)
 
 The `--cost <NAME>` flag selects which built-in loss function the scorer

--- a/docs/archive/pr-summaries/pr-summary-581.md
+++ b/docs/archive/pr-summaries/pr-summary-581.md
@@ -1,0 +1,156 @@
+# PR Summary — Issue #581
+
+## Summary
+
+`NEAT-AI-core#577` landed in **neat-core 0.10.6**: synapses are now keyed by the
+`(fromUUID, toUUID, type)` **triple**, so one source may feed an `IF` neuron
+through more than one role. The contribution that must apply *whichever way the
+node branches* no longer needs an `IDENTITY` relay neuron existing purely to be
+a second distinct source.
+
+`rust_scorer` is the engine that would **disagree first** if that relaxation
+were mishandled — it resolves every synapse independently and sums each role's
+bucket, whereas a loader keyed by `(from, to)` alone keeps one edge per ordered
+pair and silently drops the rest. That divergence already produced a production
+"improvement" that was not real (NEAT-AI-core#556: `rust_scorer` 0.356183
+against `Creature.scoreDir` 0.353147). This engine's behaviour is the correct
+one — this PR **pins** it rather than assuming it, so the parity guard lands
+with the rule change rather than after the first creature that needs it.
+
+No production scorer code changed: nothing in the scoring path keys synapses by
+`(from, to)`. Verified by reading the path — `scoring.rs:252`
+(`for synapse in &creature.synapses`) and `scoring.rs:316`
+(`synapse_count: creature.synapses.len()`). The only `(from, to)` keying in the
+repository is a **test-only** regression guard in `shallow_fixture.rs:204`,
+whose targets are point-wise squashes where the pair rule still holds; its
+comment is corrected rather than its assertion.
+
+Closes #581.
+
+### What changed
+
+| Change | File |
+|---|---|
+| Fixtures for the relaxed shape, the relay workaround, the dropped-edge creature and the two still-refused shapes | `rust_scorer/src/dual_role_fixture.rs` (new) |
+| Cross-engine parity suite | `rust_scorer/tests/dual_role_parity.rs` (new) |
+| `constant_neuron_json` — a constant without the `"squash"` key TypeScript refuses | `rust_scorer/src/fixture_json.rs` |
+| Fixture comments no longer state the `(from, to)` rule as fact | `rust_scorer/src/if_tree_fixture.rs`, `rust_scorer/src/shallow_fixture.rs` |
+| New contract section | `README.md` |
+| 0.10.6 recorded as widening, not breaking | `neat-core.expected-version` |
+
+### Deliberately out of scope
+
+The TypeScript half (`NEAT-AI#3873`) is still **open** — `Creature.ts:809` still
+asserts `"Connection already exists"` on the pair alone — so the live
+`Creature.scoreDir` leg of the comparison cannot run yet, and there is no
+TypeScript toolchain in this repository to run it from. The fixtures are `pub`
+so `NEAT-AI-Forests`' `ts_parity.rs` harness can score the *same* creatures the
+moment it lands; nothing in this PR waits on that. `if_tree_fixture.rs`
+therefore keeps its three separate bias-1 constants — now documented as a
+deliberate both-engines choice, not a requirement of this engine.
+
+## Evidence
+
+Backend/CLI change with no web interface, so no screenshot applies. The evidence
+is the test suite plus the quality gate.
+
+### The divergence being pinned
+
+```mermaid
+flowchart LR
+    J["creature JSON<br/>A→IF positive<br/>A→IF negative"]
+    J --> RS["rust_scorer<br/>(from, to, type)"]
+    J --> TS["TypeScript loader<br/>(from, to) — NEAT-AI#3873 open"]
+    RS --> K["both edges kept<br/>each branch carries A"]
+    TS --> D["one edge kept<br/>one branch loses A"]
+    K --> S1["score X"]
+    D --> S2["score Y ≠ X"]
+    S1 --> W["divergence — a production<br/>'improvement' that was not real"]
+    S2 --> W
+```
+
+### The two forms the suite proves equivalent
+
+```text
+  relay-free (post-#577)              relay workaround (pre-#577)
+
+  input-c ──cond──▶                   input-c ──cond──▶
+  const-1 ──cond──▶                   const-1 ──cond──▶
+  const-1 ──pos───▶  IF               const-1-pos ──pos───▶  IF
+  const-1 ──neg───▶ node              const-1-neg ──neg───▶ node
+  input-s ──pos───▶                   relay-pos ──pos───▶
+  input-s ──neg───▶                   relay-neg ──neg───▶
+                                        ▲ ▲
+                                   input-s ┘ └ input-s
+```
+
+### Test output
+
+```text
+$ cargo test -p rust_scorer --test dual_role_parity
+running 10 tests
+test every_declared_synapse_survives_the_load ... ok
+test cpu_activation_matches_the_independent_reference ... ok
+test the_condition_zero_boundary_keeps_the_shared_negative_edge ... ok
+test dropping_the_shared_negative_edge_changes_the_prediction ... ok
+test the_fixture_actually_repeats_an_ordered_pair ... ok
+test the_relay_free_and_relay_forms_activate_identically ... ok
+test directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one ... ok
+test gpu_matches_cpu_for_the_dual_role_creature ... ok
+test gpu_matches_cpu_for_the_relay_equivalent_creature ... ok
+test gpu_matches_cpu_on_the_dual_role_boundary_records ... ok
+
+test result: ok. 10 passed; 0 failed
+```
+
+The three GPU bodies **skipped** on this CPU-only container (no adapter), the
+same way every other GPU parity suite in the repository skips; the CPU
+assertions ran and gate the change everywhere.
+
+Full workspace suite: **0 failures** across all binaries plus 32 doctests.
+
+### Quality gate
+
+`./quality.sh < /dev/null` passes every stage **except** `codespell`, which is
+**not installed in this container** and cannot be installed (`pip`, `pipx` and
+`python3 -m ensurepip` are all absent — `/usr/bin/python3: No module named
+ensurepip`). Every other stage was run to completion:
+
+- shellcheck, workflow/doc validators, `check-neat-core-version.sh`,
+  `check-docs-cross-references.sh` (28/28 anchors resolve) — pass
+- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
+- `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features -D warnings` — clean
+- `cargo check`, `cargo build`, `cargo test --workspace --all-features` — clean
+- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
+- `cargo build --workspace --release` — clean
+- `npx markdownlint-cli2` over all 186 Markdown files — `0 issues`
+
+CI's `spell-check` job covers the one stage that could not run locally.
+
+## Test Plan
+
+New suite `rust_scorer/tests/dual_role_parity.rs` (10 tests):
+
+| Test | What it pins |
+|---|---|
+| `every_declared_synapse_survives_the_load` | Synapse count identical in raw JSON, parsed export and compiled network, for both forms — the Rust-side `jsonSynapses === loadedSynapses` assertion |
+| `the_fixture_actually_repeats_an_ordered_pair` | The fixture really does repeat a `(from, to)` pair, so the test above is not vacuous |
+| `cpu_activation_matches_the_independent_reference` | Bit-exact against a reference evaluator written from the decision semantics, 512 records |
+| `the_relay_free_and_relay_forms_activate_identically` | Dropping the `IDENTITY` relay moves no number, 512 records |
+| `the_condition_zero_boundary_keeps_the_shared_negative_edge` | `condition == 0` takes the negative branch (Issue #574's contract) *and* the shared source's negative edge still applies there — the edge a `(from, to)` loader drops |
+| `dropping_the_shared_negative_edge_changes_the_prediction` | The dropped-edge creature disagrees on > 100/512 records, so the divergence is detectable |
+| `directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one` | End-to-end through `score_from_creature_dir`: relaxed == relayed, relaxed != dropped, non-zero loss on all three |
+| `gpu_matches_cpu_for_the_dual_role_creature` | Private kernel agrees within `1e-3` relative — the kernels bucket by role too |
+| `gpu_matches_cpu_for_the_relay_equivalent_creature` | The shape production carries today keeps scoring the same on GPU |
+| `gpu_matches_cpu_on_the_dual_role_boundary_records` | Branch-boundary records do not disagree across backends |
+
+Unit tests in `rust_scorer/src/dual_role_fixture.rs` (10 tests) cover the fixture
+builders themselves, including the two shapes the relaxed rule must **still**
+refuse: a repeated pair into a point-wise target (`TypedDuplicateSynapse`) and an
+exact repeated `(from, to, type)` triple (`DuplicateSynapse`).
+
+Unit tests in `rust_scorer/src/fixture_json.rs` (2 tests) cover
+`constant_neuron_json`: the `"squash"` key is absent, and a squashless constant
+still compiles and activates correctly.
+
+No existing test was removed, disabled or weakened.

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -74,4 +74,17 @@
 # the guarantee from the binary's side: it fails against a map-only neat-core
 # (verified against 0.9.12 — `Creature JSON error: invalid type: sequence,
 # expected a map`) and passes against the sibling clone at 0.10.1.
+#
+# 0.10.0 still stays the baseline (Issue #581). neat-core 0.10.6 carries #577,
+# which relaxes `validate_no_duplicate_synapses` to key on the
+# `(fromUUID, toUUID, type)` triple so an `IF` target may read one source
+# through several roles; a repeated pair into any other squash becomes the new
+# `CreatureError::TypedDuplicateSynapse`. This is patch-level within the handled
+# 0.10 line and is **widening**, not breaking: every creature that compiled
+# before still compiles, and no rust_scorer code keys synapses by `(from, to)`.
+# Verified by the full quality gate against the sibling clone at 0.10.6, plus
+# `rust_scorer/tests/dual_role_parity.rs`, which pins that the relaxed shape
+# loads with every synapse intact, scores identically to the pre-#577 relay
+# workaround, and scores *differently* from the creature a `(from, to)`-keyed
+# loader is left holding.
 0.10.0

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.68"
+version = "1.1.69"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/dual_role_fixture.rs
+++ b/rust_scorer/src/dual_role_fixture.rs
@@ -1,0 +1,513 @@
+//! Cross-engine fixtures for `(from, to, type)`-keyed synapses — Issue #581.
+//!
+//! An `IF` neuron keeps a separate sum per synapse role, so a contribution that
+//! must apply **whichever way the node branches** needs two synapses into it —
+//! one `positive`, one `negative`. Under the old `(from, to)` uniqueness rule
+//! those two could not share a source, and the workaround was an `IDENTITY`
+//! relay neuron existing purely to be a second distinct source (455 of them had
+//! accumulated on one production creature). `NEAT-AI-core#577` relaxed the key
+//! to the `(from, to, type)` triple for `IF` targets, so the relay is no longer
+//! needed.
+//!
+//! This module builds the pair of creatures that pins what the scorer does with
+//! that shape:
+//!
+//! ```text
+//!   relay-free (post-#577)              relay workaround (pre-#577)
+//!
+//!   input-c ──cond──▶                   input-c ──cond──▶
+//!   const-1 ──cond──▶                   const-1 ──cond──▶
+//!   const-1 ──pos───▶  IF               const-1-pos ──pos───▶  IF
+//!   const-1 ──neg───▶ node              const-1-neg ──neg───▶ node
+//!   input-s ──pos───▶                   relay-pos ──pos───▶
+//!   input-s ──neg───▶                   relay-neg ──neg───▶
+//!                                         ▲ ▲
+//!                                    input-s ┘ └ input-s
+//! ```
+//!
+//! Both forms describe the *same* function, so the scorer must give them the
+//! *same* score — that equality is the parity assertion, and it is exact rather
+//! than approximate because the relay contributes `0.0 + 1.0 * x`.
+//!
+//! ## Why it is a cross-engine fixture
+//!
+//! `rust_scorer` resolves every synapse independently, so it keeps all six
+//! edges into the `IF` node and sums each role's bucket. A loader that keys by
+//! `(from, to)` alone keeps only one edge per pair and silently drops the
+//! second — measured against NEAT-AI 6.6.39, a creature of this shape loads
+//! with `jsonSynapses = 4` but `loadedSynapses = 3`. The two engines then score
+//! the same JSON differently, which is exactly the divergence that produced a
+//! production "improvement" that was not real (Issue #556). The creatures here
+//! are emitted through [`crate::fixture_json`] in the shape **both** engines
+//! accept, so `NEAT-AI-Forests`' `ts_parity.rs` harness can score them under
+//! `Creature.scoreDir` and compare against `jsonSynapses === loadedSynapses`
+//! once `NEAT-AI#3873` lands the TypeScript half of the rule.
+//!
+//! [`dropped_shared_branch_creature_json`] models the creature a `(from, to)`
+//! -keyed loader is left holding, so a test can prove the dropped synapse
+//! actually changes the answer rather than assuming it.
+
+use crate::fixture_json::{
+    constant_neuron_json, creature_envelope, neuron_json, synapse_json, typed_synapse_json,
+};
+use crate::if_tree_fixture::{TreeSpec, varied_inputs};
+
+/// UUID of the single constant every fixture here hangs its threshold and both
+/// branch constants off — one neuron for all three roles, which is the whole
+/// point of the relaxed rule.
+pub const CONST_ONE_UUID: &str = "const-one";
+
+/// UUID of the `IF` neuron under test.
+pub const IF_UUID: &str = "if-0";
+
+/// UUID of the single output neuron.
+pub const OUTPUT_UUID: &str = "output-0";
+
+/// UUID of the `IDENTITY` relay standing in for the shared source's `positive`
+/// edge in the pre-#577 workaround form.
+pub const RELAY_POSITIVE_UUID: &str = "relay-positive";
+
+/// UUID of the `IDENTITY` relay standing in for the shared source's `negative`
+/// edge in the pre-#577 workaround form.
+pub const RELAY_NEGATIVE_UUID: &str = "relay-negative";
+
+/// UUID of the constant feeding the `positive` branch in the workaround form —
+/// the second of the three constants #577 makes unnecessary.
+pub const CONST_ONE_POSITIVE_UUID: &str = "const-one-positive";
+
+/// UUID of the constant feeding the `negative` branch in the workaround form.
+pub const CONST_ONE_NEGATIVE_UUID: &str = "const-one-negative";
+
+/// Weight of the shared contribution that must apply on **either** branch.
+///
+/// Non-zero and not a power of two so a dropped copy cannot coincidentally
+/// cancel or round away.
+pub const SHARED_BRANCH_WEIGHT: f64 = 0.35;
+
+/// Input column the `IF` node splits on.
+#[must_use]
+pub fn condition_feature(spec: &TreeSpec) -> usize {
+    spec.feature(0)
+}
+
+/// Input column whose contribution is shared across both branches.
+///
+/// Distinct from [`condition_feature`] whenever the creature reads more than
+/// one column, so the shared term cannot be confused with the condition term.
+#[must_use]
+pub fn shared_feature(spec: &TreeSpec) -> usize {
+    (spec.feature(0) + 1) % spec.num_inputs
+}
+
+/// The `IF` node's condition, positive and negative edges, relay-free.
+///
+/// Emission order is fixed — `condition(input)`, `condition(-threshold)`,
+/// `positive(leaf high)`, `negative(leaf low)`, `positive(shared)`,
+/// `negative(shared)` — because `compile_creature` preserves it and
+/// [`dual_role_reference_output`] sums each bucket in the same order. That makes
+/// the reference bit-exact against the CPU pipeline rather than merely close.
+fn push_dual_role_synapses(spec: &TreeSpec, synapses: &mut Vec<String>) {
+    synapses.push(typed_synapse_json(
+        &format!("input-{}", condition_feature(spec)),
+        IF_UUID,
+        1.0,
+        Some("condition"),
+    ));
+    synapses.push(typed_synapse_json(
+        CONST_ONE_UUID,
+        IF_UUID,
+        -spec.threshold(0),
+        Some("condition"),
+    ));
+    synapses.push(typed_synapse_json(
+        CONST_ONE_UUID,
+        IF_UUID,
+        spec.leaf_value(1),
+        Some("positive"),
+    ));
+    synapses.push(typed_synapse_json(
+        CONST_ONE_UUID,
+        IF_UUID,
+        spec.leaf_value(0),
+        Some("negative"),
+    ));
+    let shared = format!("input-{}", shared_feature(spec));
+    synapses.push(typed_synapse_json(
+        &shared,
+        IF_UUID,
+        SHARED_BRANCH_WEIGHT,
+        Some("positive"),
+    ));
+    synapses.push(typed_synapse_json(
+        &shared,
+        IF_UUID,
+        SHARED_BRANCH_WEIGHT,
+        Some("negative"),
+    ));
+}
+
+/// The relay-free creature: two sources each feed the `IF` node through more
+/// than one role.
+///
+/// `const-one` carries all three roles (`condition`, `positive`, `negative`) and
+/// the shared input column carries both branches. Seven synapses, three
+/// neurons — the shape that is only legal once synapses are keyed by
+/// `(from, to, type)`.
+#[must_use]
+pub fn dual_role_if_creature_json(spec: &TreeSpec) -> String {
+    let neurons = vec![
+        constant_neuron_json(CONST_ONE_UUID, 1.0),
+        neuron_json("hidden", IF_UUID, 0.0, "IF"),
+        neuron_json("output", OUTPUT_UUID, 0.0, "IDENTITY"),
+    ];
+    let mut synapses = Vec::with_capacity(7);
+    push_dual_role_synapses(spec, &mut synapses);
+    synapses.push(synapse_json(IF_UUID, OUTPUT_UUID, 1.0));
+
+    creature_envelope(spec.num_inputs, 1, &neurons, &synapses)
+}
+
+/// The same function written the pre-#577 way: every repeated source split out
+/// behind an extra neuron.
+///
+/// Three constants replace the one, and two `IDENTITY` relays replace the
+/// shared column's direct branch edges. No ordered pair repeats, so this form
+/// was — and remains — legal under the old `(from, to)` key. It exists to be
+/// scored alongside [`dual_role_if_creature_json`]: the two must agree exactly.
+///
+/// Relay arithmetic is `0.0 + 1.0 * x`, and each `IF` bucket sums in the same
+/// order as the relay-free form, so the equality is bit-exact and not a
+/// tolerance.
+#[must_use]
+pub fn relay_equivalent_if_creature_json(spec: &TreeSpec) -> String {
+    let shared = format!("input-{}", shared_feature(spec));
+    let neurons = vec![
+        constant_neuron_json(CONST_ONE_UUID, 1.0),
+        constant_neuron_json(CONST_ONE_POSITIVE_UUID, 1.0),
+        constant_neuron_json(CONST_ONE_NEGATIVE_UUID, 1.0),
+        neuron_json("hidden", RELAY_POSITIVE_UUID, 0.0, "IDENTITY"),
+        neuron_json("hidden", RELAY_NEGATIVE_UUID, 0.0, "IDENTITY"),
+        neuron_json("hidden", IF_UUID, 0.0, "IF"),
+        neuron_json("output", OUTPUT_UUID, 0.0, "IDENTITY"),
+    ];
+    let mut synapses = vec![
+        synapse_json(&shared, RELAY_POSITIVE_UUID, 1.0),
+        synapse_json(&shared, RELAY_NEGATIVE_UUID, 1.0),
+        typed_synapse_json(
+            &format!("input-{}", condition_feature(spec)),
+            IF_UUID,
+            1.0,
+            Some("condition"),
+        ),
+        typed_synapse_json(
+            CONST_ONE_UUID,
+            IF_UUID,
+            -spec.threshold(0),
+            Some("condition"),
+        ),
+        typed_synapse_json(
+            CONST_ONE_POSITIVE_UUID,
+            IF_UUID,
+            spec.leaf_value(1),
+            Some("positive"),
+        ),
+        typed_synapse_json(
+            CONST_ONE_NEGATIVE_UUID,
+            IF_UUID,
+            spec.leaf_value(0),
+            Some("negative"),
+        ),
+        typed_synapse_json(
+            RELAY_POSITIVE_UUID,
+            IF_UUID,
+            SHARED_BRANCH_WEIGHT,
+            Some("positive"),
+        ),
+        typed_synapse_json(
+            RELAY_NEGATIVE_UUID,
+            IF_UUID,
+            SHARED_BRANCH_WEIGHT,
+            Some("negative"),
+        ),
+    ];
+    synapses.push(synapse_json(IF_UUID, OUTPUT_UUID, 1.0));
+
+    creature_envelope(spec.num_inputs, 1, &neurons, &synapses)
+}
+
+/// [`dual_role_if_creature_json`] with the shared source's **negative** edge
+/// removed — what a `(from, to)`-keyed loader is left holding.
+///
+/// Measured against NEAT-AI 6.6.39, loading the relay-free creature keeps only
+/// the first synapse of each repeated pair, so the shared contribution survives
+/// on one branch and vanishes on the other. Scoring this against the intact
+/// creature is how a test proves the dropped edge changes the answer instead of
+/// assuming it does.
+#[must_use]
+pub fn dropped_shared_branch_creature_json(spec: &TreeSpec) -> String {
+    let dropped = typed_synapse_json(
+        &format!("input-{}", shared_feature(spec)),
+        IF_UUID,
+        SHARED_BRANCH_WEIGHT,
+        Some("negative"),
+    );
+    let intact = dual_role_if_creature_json(spec);
+    let stripped = intact.replacen(&format!("{dropped},"), "", 1);
+    assert_ne!(
+        stripped, intact,
+        "the negative branch edge must be present to be dropped"
+    );
+    stripped
+}
+
+/// A creature whose repeated pair targets a **non-`IF`** neuron.
+///
+/// Every other squash sums its inward synapses regardless of role, so two from
+/// one source are exactly one with the summed weight — `neat-core` rejects this
+/// with `TypedDuplicateSynapse` (Issue #577). The fixture pins that the relaxed
+/// rule stayed narrow.
+#[must_use]
+pub fn dual_role_into_pointwise_creature_json(spec: &TreeSpec) -> String {
+    let neurons = vec![
+        neuron_json("hidden", "hidden-0", 0.0, "TANH"),
+        neuron_json("output", OUTPUT_UUID, 0.0, "IDENTITY"),
+    ];
+    let shared = format!("input-{}", shared_feature(spec));
+    let synapses = vec![
+        typed_synapse_json(&shared, "hidden-0", SHARED_BRANCH_WEIGHT, Some("positive")),
+        typed_synapse_json(&shared, "hidden-0", SHARED_BRANCH_WEIGHT, Some("negative")),
+        synapse_json("hidden-0", OUTPUT_UUID, 1.0),
+    ];
+
+    creature_envelope(spec.num_inputs, 1, &neurons, &synapses)
+}
+
+/// A creature repeating one exact `(from, to, type)` triple.
+///
+/// The triple is the whole key, so this stays a `DuplicateSynapse` rejection
+/// even for an `IF` target: relaxing the pair did not relax the triple.
+#[must_use]
+pub fn repeated_triple_creature_json(spec: &TreeSpec) -> String {
+    let repeated = typed_synapse_json(
+        &format!("input-{}", shared_feature(spec)),
+        IF_UUID,
+        SHARED_BRANCH_WEIGHT,
+        Some("positive"),
+    );
+    let intact = dual_role_if_creature_json(spec);
+    let doubled = intact.replacen(&repeated, &format!("{repeated},{repeated}"), 1);
+    assert_ne!(doubled, intact, "the positive edge must exist to be doubled");
+    doubled
+}
+
+/// Independent reference evaluation of the relay-free creature for one record.
+///
+/// Written from the decision semantics — descend positive when the condition sum
+/// is **strictly** greater than zero — and summing each bucket in the fixture's
+/// emission order, so the result is bit-identical to the CPU pipeline's `f32`
+/// activation.
+///
+/// # Panics
+///
+/// Panics if `inputs` is shorter than `spec.num_inputs`.
+#[must_use]
+pub fn dual_role_reference_output(spec: &TreeSpec, inputs: &[f32]) -> f32 {
+    assert!(
+        inputs.len() >= spec.num_inputs,
+        "reference evaluation needs {} inputs, got {}",
+        spec.num_inputs,
+        inputs.len()
+    );
+    let condition =
+        inputs[condition_feature(spec)] * 1.0f32 + 1.0f32 * ((-spec.threshold(0)) as f32);
+    let shared = inputs[shared_feature(spec)] * (SHARED_BRANCH_WEIGHT as f32);
+    let branch = if condition > 0.0 {
+        1.0f32 * (spec.leaf_value(1) as f32)
+    } else {
+        1.0f32 * (spec.leaf_value(0) as f32)
+    };
+    branch + shared
+}
+
+/// A packed `inputs || target` corpus for the dual-role creature.
+///
+/// Targets come from a **different** seed so the loss is non-degenerate: a
+/// zero-loss corpus would make a relative-error comparison vacuous and would
+/// hide a dropped branch edge behind a floor.
+#[must_use]
+pub fn dual_role_corpus_records(spec: &TreeSpec, num_records: usize) -> Vec<f32> {
+    let oracle = TreeSpec::new(spec.num_inputs, 1, spec.seed ^ 0x5A5A_5A5A);
+    let mut out = Vec::with_capacity(num_records * (spec.num_inputs + 1));
+    for r in 0..num_records {
+        let inputs = varied_inputs(spec.num_inputs, r);
+        let target = dual_role_reference_output(&oracle, &inputs);
+        out.extend_from_slice(&inputs);
+        out.push(target);
+    }
+    out
+}
+
+/// A packed corpus pinning the condition to its boundary — exactly on the
+/// threshold, one ULP below and one ULP above — so `condition == 0` (which must
+/// take the negative branch) is scored alongside its neighbours.
+#[must_use]
+pub fn dual_role_boundary_records(spec: &TreeSpec) -> Vec<f32> {
+    let feature = condition_feature(spec);
+    let threshold = spec.threshold(0) as f32;
+    let mut out = Vec::new();
+    for (i, x) in [threshold, threshold.next_down(), threshold.next_up()]
+        .into_iter()
+        .enumerate()
+    {
+        let mut inputs = varied_inputs(spec.num_inputs, i);
+        inputs[feature] = x;
+        let target = dual_role_reference_output(spec, &inputs);
+        out.extend_from_slice(&inputs);
+        out.push(target);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neat_core::creature::{compile_creature, parse_creature_json};
+    use neat_core::synapse_type::SynapseType;
+
+    const SPEC: TreeSpec = TreeSpec::new(4, 1, 4_242);
+
+    #[test]
+    fn the_shared_column_is_not_the_condition_column() {
+        assert_ne!(condition_feature(&SPEC), shared_feature(&SPEC));
+        // Edge case: a one-column creature has nowhere else to go, and the
+        // shared term legitimately lands on the condition column.
+        let narrow = TreeSpec::new(1, 1, 7);
+        assert_eq!(condition_feature(&narrow), shared_feature(&narrow));
+    }
+
+    #[test]
+    fn the_relay_free_creature_keeps_every_repeated_pair() {
+        let creature = parse_creature_json(&dual_role_if_creature_json(&SPEC)).expect("parse");
+        assert_eq!(creature.synapses.len(), 7);
+        let net = compile_creature(&creature).expect("compile");
+        assert_eq!(
+            net.synapses.len(),
+            7,
+            "compiling must drop no synapse — a (from, to)-keyed loader keeps only 5"
+        );
+    }
+
+    #[test]
+    fn the_if_neuron_carries_both_branch_roles_from_one_source() {
+        let creature = parse_creature_json(&dual_role_if_creature_json(&SPEC)).expect("parse");
+        let net = compile_creature(&creature).expect("compile");
+        let node = net
+            .neurons
+            .iter()
+            .find(|n| !n.is_constant && n.num_synapses == 6)
+            .expect("the IF node reads six synapses");
+        let start = node.start_synapse as usize;
+        let roles: Vec<SynapseType> = net.synapses[start..start + 6]
+            .iter()
+            .map(|s| SynapseType::from(s.synapse_type))
+            .collect();
+        assert_eq!(
+            roles,
+            vec![
+                SynapseType::Condition,
+                SynapseType::Condition,
+                SynapseType::Positive,
+                SynapseType::Negative,
+                SynapseType::Positive,
+                SynapseType::Negative,
+            ]
+        );
+    }
+
+    #[test]
+    fn both_forms_compile_to_the_same_synapse_roles_on_the_if_node() {
+        for json in [
+            dual_role_if_creature_json(&SPEC),
+            relay_equivalent_if_creature_json(&SPEC),
+        ] {
+            let creature = parse_creature_json(&json).expect("parse");
+            compile_creature(&creature).expect("compile");
+        }
+    }
+
+    #[test]
+    fn the_dropped_variant_loses_exactly_one_synapse() {
+        let dropped =
+            parse_creature_json(&dropped_shared_branch_creature_json(&SPEC)).expect("parse");
+        assert_eq!(dropped.synapses.len(), 6);
+        compile_creature(&dropped).expect("the stripped creature is still valid");
+    }
+
+    #[test]
+    fn a_repeated_triple_is_rejected() {
+        let creature = parse_creature_json(&repeated_triple_creature_json(&SPEC)).expect("parse");
+        let Err(err) = compile_creature(&creature) else {
+            panic!("an exact (from, to, type) repeat must still be refused");
+        };
+        assert!(
+            format!("{err}").contains("Duplicate"),
+            "expected a duplicate-synapse refusal, got {err}"
+        );
+    }
+
+    #[test]
+    fn a_repeated_pair_into_a_pointwise_target_is_rejected() {
+        let creature =
+            parse_creature_json(&dual_role_into_pointwise_creature_json(&SPEC)).expect("parse");
+        let Err(err) = compile_creature(&creature) else {
+            panic!("only an IF target may read one source through two roles");
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("role") || msg.contains("Duplicate"),
+            "expected a typed-duplicate refusal, got {msg}"
+        );
+    }
+
+    #[test]
+    fn the_reference_takes_the_negative_branch_when_the_condition_is_zero() {
+        let feature = condition_feature(&SPEC);
+        let threshold = SPEC.threshold(0) as f32;
+        let mut inputs = varied_inputs(SPEC.num_inputs, 0);
+        let shared = inputs[shared_feature(&SPEC)] * (SHARED_BRANCH_WEIGHT as f32);
+
+        inputs[feature] = threshold;
+        assert_eq!(
+            dual_role_reference_output(&SPEC, &inputs),
+            (SPEC.leaf_value(0) as f32) + shared,
+            "condition == 0 must take the negative branch, shared term included"
+        );
+        inputs[feature] = threshold.next_up();
+        assert_eq!(
+            dual_role_reference_output(&SPEC, &inputs),
+            (SPEC.leaf_value(1) as f32) + shared,
+            "condition > 0 must take the positive branch, shared term included"
+        );
+    }
+
+    #[test]
+    fn the_boundary_corpus_covers_the_node_three_times() {
+        let records = dual_role_boundary_records(&SPEC);
+        assert_eq!(records.len(), 3 * (SPEC.num_inputs + 1));
+    }
+
+    #[test]
+    fn the_corpus_targets_do_not_match_the_creature_exactly() {
+        // A zero-loss corpus would make the parity comparisons vacuous.
+        let records = dual_role_corpus_records(&SPEC, 32);
+        let width = SPEC.num_inputs + 1;
+        let differing = (0..32)
+            .filter(|r| {
+                let base = r * width;
+                let inputs = &records[base..base + SPEC.num_inputs];
+                records[base + SPEC.num_inputs] != dual_role_reference_output(&SPEC, inputs)
+            })
+            .count();
+        assert!(differing > 0, "every target reproduced the creature exactly");
+    }
+}

--- a/rust_scorer/src/dual_role_fixture.rs
+++ b/rust_scorer/src/dual_role_fixture.rs
@@ -296,7 +296,10 @@ pub fn repeated_triple_creature_json(spec: &TreeSpec) -> String {
     );
     let intact = dual_role_if_creature_json(spec);
     let doubled = intact.replacen(&repeated, &format!("{repeated},{repeated}"), 1);
-    assert_ne!(doubled, intact, "the positive edge must exist to be doubled");
+    assert_ne!(
+        doubled, intact,
+        "the positive edge must exist to be doubled"
+    );
     doubled
 }
 
@@ -508,6 +511,9 @@ mod tests {
                 records[base + SPEC.num_inputs] != dual_role_reference_output(&SPEC, inputs)
             })
             .count();
-        assert!(differing > 0, "every target reproduced the creature exactly");
+        assert!(
+            differing > 0,
+            "every target reproduced the creature exactly"
+        );
     }
 }

--- a/rust_scorer/src/fixture_json.rs
+++ b/rust_scorer/src/fixture_json.rs
@@ -38,6 +38,21 @@ pub fn neuron_json(kind: &str, uuid: &str, bias: f64, squash: &str) -> String {
     format!(r#"{{"type":"{kind}","uuid":"{uuid}","bias":{bias},"squash":"{squash}"}}"#)
 }
 
+/// One **constant** neuron object: `{"type":"constant","uuid":…,"bias":…}`.
+///
+/// Deliberately carries no `"squash"` key. A constant emits its bias unchanged,
+/// so the field would be inert here — and NEAT-AI's TypeScript loader rejects
+/// the creature outright when it is present (`constants should not have a
+/// squash was: IDENTITY`). Omitting it keeps a fixture loadable by **both**
+/// engines, which is what a cross-engine parity fixture needs (Issue #581).
+/// `neat_core::compile_creature` reads a missing squash as `IDENTITY`, so the
+/// arithmetic is identical to the four-field form.
+#[must_use]
+pub fn constant_neuron_json(uuid: &str, value: f64) -> String {
+    let value = json_number(value);
+    format!(r#"{{"type":"constant","uuid":"{uuid}","bias":{value}}}"#)
+}
+
 /// One synapse object: `{"fromUUID":…,"toUUID":…,"weight":…}`.
 #[must_use]
 pub fn synapse_json(from_uuid: &str, to_uuid: &str, weight: f64) -> String {
@@ -154,6 +169,38 @@ mod tests {
             neuron_json("output", "output-0", 0.0, "IDENTITY"),
             r#"{"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}"#
         );
+    }
+
+    #[test]
+    fn constant_neuron_json_omits_the_squash_key() {
+        // The absent key is the point: TypeScript refuses a constant that
+        // declares one, so a cross-engine fixture must not emit it.
+        assert_eq!(
+            constant_neuron_json("const-one", 1.0),
+            r#"{"type":"constant","uuid":"const-one","bias":1.0}"#
+        );
+    }
+
+    #[test]
+    fn a_squashless_constant_still_compiles() {
+        use neat_core::creature::compile_creature;
+        let json = creature_envelope(
+            1,
+            1,
+            &[
+                constant_neuron_json("const-one", 1.0),
+                neuron_json("output", "output-0", 0.0, "IDENTITY"),
+            ],
+            &[
+                synapse_json("input-0", "output-0", 1.0),
+                synapse_json("const-one", "output-0", 0.5),
+            ],
+        );
+        let creature = parse_creature_json(&json).expect("parses");
+        assert_eq!(creature.neurons[0].squash, None);
+        let mut net = compile_creature(&creature).expect("compiles");
+        // bias 1.0 through weight 0.5 plus the input passed straight through.
+        assert_eq!(net.activate(&[2.0], 1)[0], 2.5);
     }
 
     #[test]

--- a/rust_scorer/src/if_tree_fixture.rs
+++ b/rust_scorer/src/if_tree_fixture.rs
@@ -30,14 +30,18 @@
 //! neurons are hosted by both GPU kernels (Issue #312), so the fixture needs no
 //! reserved bias column in the corpus and works against any record layout.
 //!
-//! A creature may not carry two synapses between the same ordered pair of
-//! neurons — NEAT-AI's TypeScript loader keys synapses by `(from, to)` and
-//! collapses duplicates, and `neat_core::compile_creature` rejects them
-//! outright (NEAT-AI-core#556). One `IF` node reads up to **three** bias-1
-//! sources — condition, positive branch, negative branch — so it needs three
-//! distinct constants ([`BIAS_ONE_UUID`], [`BIAS_ONE_POSITIVE_UUID`],
-//! [`BIAS_ONE_NEGATIVE_UUID`]), not one reused three times. All three hold the
-//! same `1.0`, so the arithmetic is unchanged; only the wiring is legal.
+//! These fixtures give each of the `IF` node's three bias-1 sources its own
+//! constant ([`BIAS_ONE_UUID`], [`BIAS_ONE_POSITIVE_UUID`],
+//! [`BIAS_ONE_NEGATIVE_UUID`]) rather than reusing one three times. All three
+//! hold the same `1.0`, so the arithmetic is identical either way — the split
+//! is about the wiring, and it is now a **conservative choice, not a
+//! requirement**: `neat_core::compile_creature` keys synapses by the
+//! `(from, to, type)` triple since NEAT-AI-core#577, so an `IF` target may read
+//! one source through several roles. The split is kept here because NEAT-AI's
+//! TypeScript loader still keys on `(from, to)` alone (NEAT-AI#3873 is open),
+//! so these fixtures stay loadable by **both** engines. The relaxed shape has
+//! its own fixtures and its own parity guard in
+//! [`crate::dual_role_fixture`] / `tests/dual_role_parity.rs` (Issue #581).
 //!
 //! Once `NEAT-AI-core#555` lands its canonical fixture and graft helper, these
 //! builders become the scorer-side consumers of it; the parity assertions in
@@ -52,7 +56,9 @@ pub const BIAS_ONE_UUID: &str = "const-one";
 
 /// UUID of the constant neuron feeding the **positive** branch of an `IF` node
 /// whose high child is a leaf. Distinct from [`BIAS_ONE_UUID`] so the node does
-/// not carry two synapses from the same source (NEAT-AI-core#556).
+/// not carry two synapses from the same source — no longer required of an `IF`
+/// target since NEAT-AI-core#577, but kept so the fixture also loads under
+/// NEAT-AI's `(from, to)`-keyed TypeScript loader (Issue #581).
 pub const BIAS_ONE_POSITIVE_UUID: &str = "const-one-positive";
 
 /// UUID of the constant neuron feeding the **negative** branch of an `IF` node
@@ -63,7 +69,8 @@ pub const BIAS_ONE_NEGATIVE_UUID: &str = "const-one-negative";
 /// The three bias-1 constants an `IF` node hangs off, in emission order.
 ///
 /// Listed ahead of every hidden neuron that reads them, and all holding the
-/// same `1.0` — one per synapse role, so no `(from, to)` pair repeats.
+/// same `1.0` — one per synapse role, so no `(from, to)` pair repeats and the
+/// creature loads under either engine's key (see the module docs).
 fn bias_one_neurons() -> Vec<String> {
     vec![
         neuron_json("constant", BIAS_ONE_UUID, 1.0, "IDENTITY"),

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -20,6 +20,7 @@ pub mod cli;
 pub mod corpus_guard;
 pub mod cost;
 pub mod creature_width;
+pub mod dual_role_fixture;
 pub mod env_tuning;
 pub mod fixture_json;
 pub mod gpu;

--- a/rust_scorer/src/shallow_fixture.rs
+++ b/rust_scorer/src/shallow_fixture.rs
@@ -194,8 +194,14 @@ mod tests {
 
     #[test]
     fn shallow_creature_input_hidden_edges_are_distinct() {
-        // Regression guard: duplicate (input, hidden) pairs would let neat_core
-        // merge edges and silently shrink the synapse count, corrupting the A/B.
+        // Regression guard: the hidden neurons here carry point-wise squashes,
+        // which sum their inward synapses regardless of role — so two edges
+        // from one source are exactly one with the summed weight. That stays a
+        // `TypedDuplicateSynapse` refusal from `compile_creature` after
+        // NEAT-AI-core#577 relaxed the key to `(from, to, type)`: the relaxation
+        // covers `IF` targets only (Issue #581). A duplicate pair here would
+        // therefore fail the whole A/B rather than shrink it silently, and this
+        // guard names the offending edge instead.
         let json = shallow_creature_json(ENC_INPUTS, 1, ENC_HIDDEN, ENC_SYNAPSES);
         let creature = parse_creature_json(&json).expect("parse");
         let mut seen = std::collections::HashSet::new();

--- a/rust_scorer/tests/dual_role_parity.rs
+++ b/rust_scorer/tests/dual_role_parity.rs
@@ -1,0 +1,403 @@
+//! Issue #581 — parity guard for `(from, to, type)`-keyed synapses.
+//!
+//! `NEAT-AI-core#577` relaxed the duplicate-synapse rule so one source may feed
+//! an `IF` neuron through more than one role: the contribution that must apply
+//! **whichever way the node branches** no longer needs an `IDENTITY` relay
+//! purely to be a second distinct source. This engine is the one that would
+//! *disagree* first if that relaxation were mishandled — it resolves every
+//! synapse independently and sums each role's bucket, whereas a loader keyed by
+//! `(from, to)` alone keeps one edge per ordered pair and silently drops the
+//! rest. Two engines then score the same JSON differently, which is exactly the
+//! divergence that produced a production "improvement" that was not real
+//! (NEAT-AI-core#556: `rust_scorer` 0.356183 against `Creature.scoreDir`
+//! 0.353147).
+//!
+//! What this suite pins, using the fixtures in
+//! [`rust_scorer::dual_role_fixture`]:
+//!
+//! 1. **Nothing is dropped on load.** The relay-free creature parses and
+//!    compiles with every synapse its JSON declares — the Rust-side spelling of
+//!    the `jsonSynapses === loadedSynapses` assertion `NEAT-AI-Forests`'
+//!    `ts_parity.rs` makes against `Creature.scoreDir`, and the assertion that
+//!    would have caught the original divergence.
+//! 2. **The relaxed form and the relay workaround are the same function.** They
+//!    activate bit-identically and score identically through the real directory
+//!    pipeline, so upstream may drop the relay without moving a single score.
+//! 3. **A dropped edge is detectable, not assumed.** The creature a
+//!    `(from, to)`-keyed loader is left holding scores *differently*, so test 1
+//!    cannot pass vacuously.
+//! 4. **Both GPU kernels agree.** The kernels bucket by synapse role too, so the
+//!    relaxed shape is scored on GPU and compared against CPU when an adapter is
+//!    present.
+//!
+//! **Documented tolerance.** CPU↔CPU comparisons — reference, relay-equivalence
+//! and pipeline score — are exact (`==`), because both forms perform the same
+//! `f32` arithmetic in the same order. Cross-backend comparisons use the
+//! repository's established `1e-3` relative tolerance (Issue #82/#312/#574).
+//!
+//! GPU bodies skip cleanly when no adapter is available; the CPU assertions gate
+//! every run.
+//!
+//! **Still open upstream.** NEAT-AI#3873 (the TypeScript half) has not landed —
+//! `Creature.ts` still asserts `"Connection already exists"` on the pair alone.
+//! These fixtures are `pub` so the cross-engine harness can score the *same*
+//! creatures the moment it does; nothing here waits on that.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use neat_core::creature::{compile_creature, parse_creature_json};
+use neat_core::loss::mse_sum_batch_packed;
+use neat_core::network::CompiledNetwork;
+
+use rust_scorer::cost::CostKind;
+use rust_scorer::dual_role_fixture::{
+    dropped_shared_branch_creature_json, dual_role_boundary_records, dual_role_corpus_records,
+    dual_role_if_creature_json, dual_role_reference_output, relay_equivalent_if_creature_json,
+    shared_feature,
+};
+use rust_scorer::gpu::forward_mse_batched::{BatchedRunner, KernelKind};
+use rust_scorer::gpu::{GpuBackendLabel, GpuContext, GpuMode, resolve_backend, select_adapter};
+use rust_scorer::if_tree_fixture::{TreeSpec, records_to_le_bytes, varied_inputs};
+use rust_scorer::multi_score::score_from_creature_dir;
+use rust_scorer::scoring::ScoreResult;
+
+/// Cross-backend relative tolerance on a per-creature loss (Issue #82/#312).
+const CROSS_BACKEND_REL_TOLERANCE: f64 = 1e-3;
+
+const NUM_INPUTS: usize = 6;
+
+/// The creature under test: one `IF` node whose condition, positive and
+/// negative buckets are fed by repeated sources.
+fn spec() -> TreeSpec {
+    TreeSpec::new(NUM_INPUTS, 1, 581)
+}
+
+fn compile(json: &str) -> CompiledNetwork {
+    let creature = parse_creature_json(json).expect("fixture parses");
+    compile_creature(&creature).expect("fixture compiles")
+}
+
+/// Count `"fromUUID"` occurrences — the synapse count the *JSON* declares,
+/// read without going through the loader under test.
+fn declared_synapse_count(json: &str) -> usize {
+    json.matches(r#""fromUUID""#).count()
+}
+
+// --- 1. Nothing is dropped on load -------------------------------------------
+
+/// The Rust-side `jsonSynapses === loadedSynapses` assertion.
+///
+/// Counted three ways — from the raw JSON text, from the parsed export and from
+/// the compiled network — so neither the parser nor the compiler can quietly
+/// collapse a repeated `(from, to)` pair.
+#[test]
+fn every_declared_synapse_survives_the_load() {
+    let spec = spec();
+    for (label, json) in [
+        ("relay-free", dual_role_if_creature_json(&spec)),
+        ("relay-equivalent", relay_equivalent_if_creature_json(&spec)),
+    ] {
+        let declared = declared_synapse_count(&json);
+        let creature = parse_creature_json(&json).expect("parses");
+        let net = compile_creature(&creature).expect("compiles");
+        assert_eq!(
+            creature.synapses.len(),
+            declared,
+            "{label}: parsing dropped {} of {declared} synapses",
+            declared - creature.synapses.len()
+        );
+        assert_eq!(
+            net.synapses.len(),
+            declared,
+            "{label}: compiling dropped {} of {declared} synapses",
+            declared - net.synapses.len()
+        );
+    }
+}
+
+/// The relay-free creature really does repeat an ordered pair — otherwise the
+/// assertion above would be testing nothing. One source (`input-<shared>`)
+/// reaches the `IF` node twice, once per branch role.
+#[test]
+fn the_fixture_actually_repeats_an_ordered_pair() {
+    let spec = spec();
+    let creature = parse_creature_json(&dual_role_if_creature_json(&spec)).expect("parses");
+    let shared = format!("input-{}", shared_feature(&spec));
+    let repeats = creature
+        .synapses
+        .iter()
+        .filter(|s| s.from_uuid == shared)
+        .count();
+    assert_eq!(
+        repeats, 2,
+        "the shared source must feed the IF node through both branch roles"
+    );
+
+    let mut pairs = std::collections::HashSet::new();
+    let duplicated = creature
+        .synapses
+        .iter()
+        .filter(|s| !pairs.insert((s.from_uuid.clone(), s.to_uuid.clone())))
+        .count();
+    assert!(
+        duplicated > 0,
+        "a (from, to)-keyed loader would drop nothing from this fixture"
+    );
+}
+
+// --- 2. The relaxed form and the relay workaround agree ----------------------
+
+/// The compiled relay-free creature reproduces the independent reference
+/// evaluation bit-for-bit, including the shared term applied on both branches.
+#[test]
+fn cpu_activation_matches_the_independent_reference() {
+    let spec = spec();
+    let mut net = compile(&dual_role_if_creature_json(&spec));
+    for r in 0..512 {
+        let inputs = varied_inputs(NUM_INPUTS, r);
+        assert_eq!(
+            net.activate(&inputs, 1)[0],
+            dual_role_reference_output(&spec, &inputs),
+            "record {r}: the dual-role IF node did not evaluate as the reference decides"
+        );
+    }
+}
+
+/// Relaxing the rule must not move a number: the relay-free creature and the
+/// pre-#577 relay workaround activate identically on every record.
+#[test]
+fn the_relay_free_and_relay_forms_activate_identically() {
+    let spec = spec();
+    let mut relaxed = compile(&dual_role_if_creature_json(&spec));
+    let mut relayed = compile(&relay_equivalent_if_creature_json(&spec));
+    for r in 0..512 {
+        let inputs = varied_inputs(NUM_INPUTS, r);
+        assert_eq!(
+            relaxed.activate(&inputs, 1)[0],
+            relayed.activate(&inputs, 1)[0],
+            "record {r}: dropping the IDENTITY relay changed the prediction"
+        );
+    }
+}
+
+/// `condition == 0` takes the **negative** branch (Issue #574's contract), and
+/// the shared source's negative edge still applies there — that edge is the one
+/// a `(from, to)`-keyed loader drops.
+#[test]
+fn the_condition_zero_boundary_keeps_the_shared_negative_edge() {
+    let spec = spec();
+    let records = dual_role_boundary_records(&spec);
+    let width = NUM_INPUTS + 1;
+    let mut net = compile(&dual_role_if_creature_json(&spec));
+    let mut dropped = compile(&dropped_shared_branch_creature_json(&spec));
+
+    let mut negative_records = 0;
+    for r in 0..records.len() / width {
+        let base = r * width;
+        let inputs = &records[base..base + NUM_INPUTS];
+        let expected = records[base + NUM_INPUTS];
+        assert_eq!(
+            net.activate(inputs, 1)[0],
+            expected,
+            "boundary record {r}: scorer disagreed with the reference branch"
+        );
+        // On the negative branch the intact creature must differ from the one
+        // missing that branch's shared edge.
+        if net.activate(inputs, 1)[0] != dropped.activate(inputs, 1)[0] {
+            negative_records += 1;
+        }
+    }
+    assert!(
+        negative_records > 0,
+        "no boundary record took the negative branch — the guard proves nothing"
+    );
+}
+
+// --- 3. A dropped edge is detectable -----------------------------------------
+
+/// The creature a `(from, to)`-keyed loader is left holding predicts something
+/// else. Without this, "nothing was dropped" could hold trivially.
+#[test]
+fn dropping_the_shared_negative_edge_changes_the_prediction() {
+    let spec = spec();
+    let mut intact = compile(&dual_role_if_creature_json(&spec));
+    let mut dropped = compile(&dropped_shared_branch_creature_json(&spec));
+    let changed = (0..512)
+        .filter(|r| {
+            let inputs = varied_inputs(NUM_INPUTS, *r);
+            intact.activate(&inputs, 1)[0] != dropped.activate(&inputs, 1)[0]
+        })
+        .count();
+    assert!(
+        changed > 100,
+        "only {changed}/512 records notice the dropped branch edge — the divergence \
+         would be invisible"
+    );
+}
+
+// --- Full-pipeline scoring ---------------------------------------------------
+
+/// Both forms scored through the real directory pipeline must return the same
+/// loss, and the dropped variant must return a different one.
+///
+/// This is the end-to-end shape of the cross-engine comparison: the same corpus,
+/// the same cost, three creatures, scored the way production scores them.
+#[test]
+fn directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one() {
+    let spec = spec();
+    let root = temp_root("dual_role_directory");
+    let creatures_dir = root.join("creatures");
+    let data_dir = root.join("data");
+    std::fs::create_dir_all(&creatures_dir).expect("create creatures dir");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+
+    std::fs::write(
+        creatures_dir.join("relaxed.json"),
+        dual_role_if_creature_json(&spec),
+    )
+    .expect("write relaxed creature");
+    std::fs::write(
+        creatures_dir.join("relayed.json"),
+        relay_equivalent_if_creature_json(&spec),
+    )
+    .expect("write relayed creature");
+    std::fs::write(
+        creatures_dir.join("dropped.json"),
+        dropped_shared_branch_creature_json(&spec),
+    )
+    .expect("write dropped creature");
+
+    let n_records = 2_048;
+    let records = dual_role_corpus_records(&spec, n_records);
+    std::fs::write(data_dir.join("0.bin"), records_to_le_bytes(&records)).expect("write corpus");
+
+    let scores: BTreeMap<String, ScoreResult> = score_from_creature_dir(
+        &creatures_dir,
+        &data_dir,
+        GpuBackendLabel::CpuFallback,
+        CostKind::Mse,
+    )
+    .expect("CPU directory scoring");
+    assert_eq!(scores.len(), 3, "every candidate must be scored");
+
+    let error = |name: &str| scores.get(name).expect("candidate scored").error;
+    assert_eq!(
+        error("relaxed"),
+        error("relayed"),
+        "the relay-free creature and its relay workaround must score identically"
+    );
+    assert_ne!(
+        error("relaxed"),
+        error("dropped"),
+        "losing a branch edge must move the loss — otherwise the parity guard is vacuous"
+    );
+    for name in ["relaxed", "relayed", "dropped"] {
+        let result = scores.get(name).expect("candidate scored");
+        assert_eq!(result.record_count, n_records);
+        assert!(
+            result.error > 0.0,
+            "{name}: a zero loss would make the comparison vacuous"
+        );
+    }
+}
+
+// --- 4. GPU parity ------------------------------------------------------------
+
+/// Acquire a GPU context, or `None` when the host has no adapter.
+fn gpu_context(label: &str) -> Option<Arc<GpuContext>> {
+    if resolve_backend(GpuMode::Auto)
+        .map(|b| b.as_str() == "cpu-fallback")
+        .unwrap_or(true)
+    {
+        eprintln!("skipping {label}: no compatible adapter");
+        return None;
+    }
+    match select_adapter() {
+        Ok(Some(c)) if c.backend != GpuBackendLabel::CpuFallback => Some(Arc::new(c)),
+        _ => {
+            eprintln!("skipping {label}: select_adapter returned no context");
+            None
+        }
+    }
+}
+
+/// Score `json` on CPU and GPU and assert the per-creature losses agree within
+/// the documented cross-backend tolerance.
+fn assert_gpu_parity(label: &str, json: &str, records: &[f32]) {
+    let Some(ctx) = gpu_context(label) else {
+        return;
+    };
+    let template = compile(json);
+    let num_inputs = template.num_inputs;
+    let n_records = records.len() / (num_inputs + 1);
+    let mut nets: Vec<CompiledNetwork> = (0..4).map(|_| template.clone()).collect();
+
+    let cpu: Vec<f64> = nets
+        .iter_mut()
+        .map(|net| mse_sum_batch_packed(net, records, num_inputs, 1, true))
+        .collect();
+
+    let mut runner = BatchedRunner::new(ctx, &nets, num_inputs, 1, CostKind::Mse)
+        .unwrap_or_else(|e| panic!("{label} must be GPU-hostable: {e:?}"));
+    assert_eq!(
+        runner.kernel(),
+        KernelKind::Private,
+        "{label} routed to the wrong kernel"
+    );
+    let gpu = runner
+        .score_chunk(records, n_records)
+        .expect("GPU readback");
+
+    assert_eq!(cpu.len(), gpu.len());
+    for (i, (c, g)) in cpu.iter().zip(gpu.iter()).enumerate() {
+        let rel = (c - g).abs() / c.abs().max(1e-9);
+        assert!(
+            rel < CROSS_BACKEND_REL_TOLERANCE,
+            "{label} creature {i}: CPU={c} GPU={g} relative_error={rel} exceeds \
+             {CROSS_BACKEND_REL_TOLERANCE}"
+        );
+    }
+}
+
+/// The kernels bucket by synapse role as well, so a source feeding two roles is
+/// a shape they have to get right.
+#[test]
+fn gpu_matches_cpu_for_the_dual_role_creature() {
+    let spec = spec();
+    let records = dual_role_corpus_records(&spec, 2_048);
+    assert_gpu_parity("dual-role", &dual_role_if_creature_json(&spec), &records);
+}
+
+/// The relay workaround is the creature production carries today — it must keep
+/// scoring the same on GPU as the relaxed form replacing it.
+#[test]
+fn gpu_matches_cpu_for_the_relay_equivalent_creature() {
+    let spec = spec();
+    let records = dual_role_corpus_records(&spec, 2_048);
+    assert_gpu_parity(
+        "relay-equivalent",
+        &relay_equivalent_if_creature_json(&spec),
+        &records,
+    );
+}
+
+/// Branch-boundary records — condition on, just below and just above the
+/// threshold — must not disagree across backends either.
+#[test]
+fn gpu_matches_cpu_on_the_dual_role_boundary_records() {
+    let spec = spec();
+    let records = dual_role_boundary_records(&spec);
+    assert_gpu_parity(
+        "dual-role-boundary",
+        &dual_role_if_creature_json(&spec),
+        &records,
+    );
+}
+
+fn temp_root(name: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(name);
+    let _ = std::fs::remove_dir_all(&root);
+    root
+}


### PR DESCRIPTION
# PR Summary — Issue #581

## Summary

`NEAT-AI-core#577` landed in **neat-core 0.10.6**: synapses are now keyed by the
`(fromUUID, toUUID, type)` **triple**, so one source may feed an `IF` neuron
through more than one role. The contribution that must apply *whichever way the
node branches* no longer needs an `IDENTITY` relay neuron existing purely to be
a second distinct source.

`rust_scorer` is the engine that would **disagree first** if that relaxation
were mishandled — it resolves every synapse independently and sums each role's
bucket, whereas a loader keyed by `(from, to)` alone keeps one edge per ordered
pair and silently drops the rest. That divergence already produced a production
"improvement" that was not real (NEAT-AI-core#556: `rust_scorer` 0.356183
against `Creature.scoreDir` 0.353147). This engine's behaviour is the correct
one — this PR **pins** it rather than assuming it, so the parity guard lands
with the rule change rather than after the first creature that needs it.

No production scorer code changed: nothing in the scoring path keys synapses by
`(from, to)`. Verified by reading the path — `scoring.rs:252`
(`for synapse in &creature.synapses`) and `scoring.rs:316`
(`synapse_count: creature.synapses.len()`). The only `(from, to)` keying in the
repository is a **test-only** regression guard in `shallow_fixture.rs:204`,
whose targets are point-wise squashes where the pair rule still holds; its
comment is corrected rather than its assertion.

Closes #581.

### What changed

| Change | File |
|---|---|
| Fixtures for the relaxed shape, the relay workaround, the dropped-edge creature and the two still-refused shapes | `rust_scorer/src/dual_role_fixture.rs` (new) |
| Cross-engine parity suite | `rust_scorer/tests/dual_role_parity.rs` (new) |
| `constant_neuron_json` — a constant without the `"squash"` key TypeScript refuses | `rust_scorer/src/fixture_json.rs` |
| Fixture comments no longer state the `(from, to)` rule as fact | `rust_scorer/src/if_tree_fixture.rs`, `rust_scorer/src/shallow_fixture.rs` |
| New contract section | `README.md` |
| 0.10.6 recorded as widening, not breaking | `neat-core.expected-version` |

### Deliberately out of scope

The TypeScript half (`NEAT-AI#3873`) is still **open** — `Creature.ts:809` still
asserts `"Connection already exists"` on the pair alone — so the live
`Creature.scoreDir` leg of the comparison cannot run yet, and there is no
TypeScript toolchain in this repository to run it from. The fixtures are `pub`
so `NEAT-AI-Forests`' `ts_parity.rs` harness can score the *same* creatures the
moment it lands; nothing in this PR waits on that. `if_tree_fixture.rs`
therefore keeps its three separate bias-1 constants — now documented as a
deliberate both-engines choice, not a requirement of this engine.

## Evidence

Backend/CLI change with no web interface, so no screenshot applies. The evidence
is the test suite plus the quality gate.

### The divergence being pinned

```mermaid
flowchart LR
    J["creature JSON<br/>A→IF positive<br/>A→IF negative"]
    J --> RS["rust_scorer<br/>(from, to, type)"]
    J --> TS["TypeScript loader<br/>(from, to) — NEAT-AI#3873 open"]
    RS --> K["both edges kept<br/>each branch carries A"]
    TS --> D["one edge kept<br/>one branch loses A"]
    K --> S1["score X"]
    D --> S2["score Y ≠ X"]
    S1 --> W["divergence — a production<br/>'improvement' that was not real"]
    S2 --> W
```

### The two forms the suite proves equivalent

```text
  relay-free (post-#577)              relay workaround (pre-#577)

  input-c ──cond──▶                   input-c ──cond──▶
  const-1 ──cond──▶                   const-1 ──cond──▶
  const-1 ──pos───▶  IF               const-1-pos ──pos───▶  IF
  const-1 ──neg───▶ node              const-1-neg ──neg───▶ node
  input-s ──pos───▶                   relay-pos ──pos───▶
  input-s ──neg───▶                   relay-neg ──neg───▶
                                        ▲ ▲
                                   input-s ┘ └ input-s
```

### Test output

```text
$ cargo test -p rust_scorer --test dual_role_parity
running 10 tests
test every_declared_synapse_survives_the_load ... ok
test cpu_activation_matches_the_independent_reference ... ok
test the_condition_zero_boundary_keeps_the_shared_negative_edge ... ok
test dropping_the_shared_negative_edge_changes_the_prediction ... ok
test the_fixture_actually_repeats_an_ordered_pair ... ok
test the_relay_free_and_relay_forms_activate_identically ... ok
test directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one ... ok
test gpu_matches_cpu_for_the_dual_role_creature ... ok
test gpu_matches_cpu_for_the_relay_equivalent_creature ... ok
test gpu_matches_cpu_on_the_dual_role_boundary_records ... ok

test result: ok. 10 passed; 0 failed
```

The three GPU bodies **skipped** on this CPU-only container (no adapter), the
same way every other GPU parity suite in the repository skips; the CPU
assertions ran and gate the change everywhere.

Full workspace suite: **0 failures** across all binaries plus 32 doctests.

### Quality gate

`./quality.sh < /dev/null` passes every stage **except** `codespell`, which is
**not installed in this container** and cannot be installed (`pip`, `pipx` and
`python3 -m ensurepip` are all absent — `/usr/bin/python3: No module named
ensurepip`). Every other stage was run to completion:

- shellcheck, workflow/doc validators, `check-neat-core-version.sh`,
  `check-docs-cross-references.sh` (28/28 anchors resolve) — pass
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features -D warnings` — clean
- `cargo check`, `cargo build`, `cargo test --workspace --all-features` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- `cargo build --workspace --release` — clean
- `npx markdownlint-cli2` over all 186 Markdown files — `0 issues`

CI's `spell-check` job covers the one stage that could not run locally.

## Test Plan

New suite `rust_scorer/tests/dual_role_parity.rs` (10 tests):

| Test | What it pins |
|---|---|
| `every_declared_synapse_survives_the_load` | Synapse count identical in raw JSON, parsed export and compiled network, for both forms — the Rust-side `jsonSynapses === loadedSynapses` assertion |
| `the_fixture_actually_repeats_an_ordered_pair` | The fixture really does repeat a `(from, to)` pair, so the test above is not vacuous |
| `cpu_activation_matches_the_independent_reference` | Bit-exact against a reference evaluator written from the decision semantics, 512 records |
| `the_relay_free_and_relay_forms_activate_identically` | Dropping the `IDENTITY` relay moves no number, 512 records |
| `the_condition_zero_boundary_keeps_the_shared_negative_edge` | `condition == 0` takes the negative branch (Issue #574's contract) *and* the shared source's negative edge still applies there — the edge a `(from, to)` loader drops |
| `dropping_the_shared_negative_edge_changes_the_prediction` | The dropped-edge creature disagrees on > 100/512 records, so the divergence is detectable |
| `directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one` | End-to-end through `score_from_creature_dir`: relaxed == relayed, relaxed != dropped, non-zero loss on all three |
| `gpu_matches_cpu_for_the_dual_role_creature` | Private kernel agrees within `1e-3` relative — the kernels bucket by role too |
| `gpu_matches_cpu_for_the_relay_equivalent_creature` | The shape production carries today keeps scoring the same on GPU |
| `gpu_matches_cpu_on_the_dual_role_boundary_records` | Branch-boundary records do not disagree across backends |

Unit tests in `rust_scorer/src/dual_role_fixture.rs` (10 tests) cover the fixture
builders themselves, including the two shapes the relaxed rule must **still**
refuse: a repeated pair into a point-wise target (`TypedDuplicateSynapse`) and an
exact repeated `(from, to, type)` triple (`DuplicateSynapse`).

Unit tests in `rust_scorer/src/fixture_json.rs` (2 tests) cover
`constant_neuron_json`: the `"squash"` key is absent, and a squashless constant
still compiles and activates correctly.

No existing test was removed, disabled or weakened.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt6wle7g-fa82c4`<!-- vibe-worker-issue-581 -->