### PR TITLE
dual_role_parity: bit-exact score equality between the relay-free and relay forms fails on x86-64 (2 ULP) (Issue #585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ section to the released version with its date.
   is identical in the raw JSON, the parsed export and the compiled network — the
   Rust-side spelling of the `jsonSynapses === loadedSynapses` assertion
   `NEAT-AI-Forests`' `ts_parity.rs` makes against `Creature.scoreDir` — that the
-  relaxed and relay forms activate bit-identically and score identically through
-  the real directory pipeline, that the dropped-edge creature scores
+  relaxed and relay forms activate bit-identically and score equal through
+  the real directory pipeline (see the Issue #585 entry below for the exact
+  bound each comparison carries), that the dropped-edge creature scores
   *differently* (so the guard cannot pass vacuously), and that both GPU kernels
   agree with CPU within the `1e-3` cross-backend tolerance. Also new:
   `fixture_json::constant_neuron_json`, which omits the `"squash"` key that
@@ -187,6 +188,33 @@ section to the released version with its date.
   `docs/performance-baseline.md`.
 
 ### Fixed
+
+- **`dual_role_parity` no longer demands bit-exact equality from a reduction
+  that is free to re-associate (Issue #585).**
+  `directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one`
+  asserted `==` between the relay-free creature's directory-pipeline score and
+  its relay workaround's, and failed by 2 ULP
+  (`1.3229378675896557` vs `…73`). The cause is not the architecture it was
+  reported on and not the extra `IDENTITY` relay: directory scoring folds each
+  creature's chunk from as many `f64` partial sums as that creature was allotted
+  workers, and `workers_per_creature_split` allots a **ragged** count when
+  `activation_threads` is not a multiple of the population (3 creatures on 8
+  threads → `[3, 3, 2]`, Issue #537). Two creatures then reduce the identical
+  per-record errors in a different association order. The reported failure
+  reproduces bit-for-bit under `NEAT_SCORER_ACTIVATION_THREADS=8` on aarch64 and
+  disappears at `6`, `7` or `12`. The parity contract now states a bound per
+  comparison: **bit-exact** for every per-record activation and for the
+  whole-corpus loss reduced in one partition (new
+  `the_whole_corpus_loss_is_bit_identical_between_the_forms`, which calls
+  `mse_sum_batch_packed` over all 2,048 records), **`1e-12` relative** for the
+  directory-pipeline score, and the unchanged **`1e-3` relative** cross-backend
+  tolerance. Measured drift across thread counts `1..=16` is ≤ `6.1e-15`; a
+  dropped branch edge still moves the loss by `9.0e-3`, so the guard separates a
+  real divergence by ten orders of magnitude. New
+  `multi_score::tests::a_ragged_worker_allotment_partitions_the_same_chunk_differently`
+  pins the mechanism, and the README
+  "Synapses are keyed by `(from, to, type)`" section carries the bound table.
+  No production scoring code changed.
 
 - **A `wgpu` device lost mid-run falls back to CPU instead of panicking
   (Issue #583).** `wgpu` reports a lost device *fatally* — `Device::poll` calls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.71"
+version = "1.1.72"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -484,13 +484,52 @@ asserts that:
   JSON, the parsed export and the compiled network (the Rust-side spelling of
   the `jsonSynapses === loadedSynapses` assertion `NEAT-AI-Forests`' `ts_parity.rs`
   makes against `Creature.scoreDir`);
-- **the relaxed form and the relay workaround agree exactly** — bit-identical
-  activations and an identical loss through the real directory pipeline, so
-  upstream may drop the relay without moving a score;
+- **the relaxed form and the relay workaround agree** — bit-identical
+  activations, a bit-identical whole-corpus loss, and an equal score through the
+  real directory pipeline, so upstream may drop the relay without moving a
+  score;
 - **a dropped edge is detectable** — the `(from, to)`-keyed creature scores
   differently, so the assertions above cannot pass vacuously;
 - **both GPU kernels agree** with CPU within the same `1e-3` cross-backend
   tolerance, since the kernels bucket by synapse role too.
+
+#### Which comparisons are bit-exact (Issue #585)
+
+The parity contract is exact **where the two forms reduce in the same order**,
+and a stated tolerance where the pipeline is free to reduce them differently:
+
+| Comparison | Bound | Why |
+|---|---|---|
+| CPU activation vs the independent reference | bit-exact | one record, one evaluation order |
+| relay-free vs relay activation, per record | bit-exact | the relay contributes `0.0 + 1.0 · x`; each `IF` bucket sums in the same order |
+| relay-free vs relay whole-corpus loss (`mse_sum_batch_packed`, one partition) | bit-exact | the same per-record errors summed in the same order |
+| relay-free vs relay **directory-pipeline** score | `1e-12` relative | the pipeline folds each creature's chunk from as many `f64` partials as it was allotted workers |
+| CPU vs GPU per-creature loss | `1e-3` relative | the repository-wide cross-backend tolerance (Issues #82/#312/#574) |
+
+The pipeline row is not a weakening of the rule — it is the `f64` reduction
+being associative only to within rounding.
+`multi_score::workers_per_creature_split` allots a **ragged** worker count when
+`activation_threads` is not a multiple of the population (3 creatures on 8
+threads → `[3, 3, 2]`, Issue #537), so two creatures scoring the identical
+records group their per-record errors differently:
+
+```mermaid
+flowchart LR
+    R["2,048 records<br/>identical per-record errors"]
+    R --> A["relaxed — 3 workers<br/>683 + 683 + 682"]
+    R --> B["relayed — 2 workers<br/>1024 + 1024"]
+    A --> SA["Σ f64 → 1.3229378675896557"]
+    B --> SB["Σ f64 → 1.3229378675896573"]
+    SA --> D["2 ULP apart — reduction noise,<br/>not a difference in the function"]
+    SB --> D
+```
+
+Asserting `==` there made the suite fail on any host whose thread count made the
+split ragged — the reported x86-64 failure reproduces bit-for-bit under
+`NEAT_SCORER_ACTIVATION_THREADS=8` and disappears at `6`, `7` or `12`, on any
+architecture. The largest drift measured across thread counts `1..=16` is
+`6.1e-15`; a dropped branch edge — the divergence the guard exists to catch —
+moves the loss by `9.0e-3`, ten orders of magnitude clear of the bound.
 
 Nothing in the scorer's own scoring path keys synapses by `(from, to)`: it
 iterates `creature.synapses` in declaration order and reports

--- a/docs/archive/pr-summaries/pr-summary-585.md
+++ b/docs/archive/pr-summaries/pr-summary-585.md
@@ -1,0 +1,122 @@
+# Bound the dual-role parity score comparison to the reduction it can hold (Issue #585)
+
+## Summary
+
+`tests/dual_role_parity.rs::directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one`
+asserted **bit-exact** equality between the relay-free creature's
+directory-pipeline score and its relay workaround's, and failed by 2 ULP
+(`1.3229378675896557` vs `1.3229378675896573`). Closes #585.
+
+The reported cause — x86-64, or the relay's extra `IDENTITY` neuron changing the
+association order of the creature's own arithmetic — is not the cause. Directory
+scoring folds each creature's chunk from **as many `f64` partial sums as that
+creature was allotted workers**, and `multi_score::workers_per_creature_split`
+allots a *ragged* count when `activation_threads` is not a multiple of the
+population (3 creatures on 8 threads → `[3, 3, 2]`, Issue #537). The three
+fixtures sort as `dropped`, `relaxed`, `relayed`, so `relaxed` reduces
+`683 + 683 + 682` records while `relayed` reduces `1024 + 1024` — the same
+per-record errors, a different association order, the last bits of an `f64` sum
+apart. Nothing architecture-specific: the reported failure reproduces
+bit-for-bit on this **aarch64** host under `NEAT_SCORER_ACTIVATION_THREADS=8`,
+and disappears at `6`, `7` or `12`.
+
+Encoding the contract (the issue's option 2 — a stated tolerance where the
+requirement is not genuinely testable, bit-exactness where it is):
+
+| Comparison | Bound |
+|---|---|
+| CPU activation vs the independent reference | bit-exact (unchanged) |
+| relay-free vs relay activation, per record | bit-exact (unchanged) |
+| relay-free vs relay whole-corpus loss, one partition | bit-exact (**new test**) |
+| relay-free vs relay **directory-pipeline** score | `1e-12` relative (**was `==`**) |
+| CPU vs GPU per-creature loss | `1e-3` relative (unchanged) |
+
+Option 1 (forcing the two forms to reduce in an identical order) was rejected:
+it would require every creature in a directory to receive the same worker count,
+idling up to `n_creatures - 1` threads whenever the population is smaller than
+the thread budget — a throughput regression to buy a property the new bit-exact
+test already pins where it is real. No production scoring code changed.
+
+## Evidence
+
+Backend/CLI change with no web interface, so no screenshot: the evidence is the
+reproduction and the gate.
+
+**Reproduced, then fixed** — `directory_scoring_agrees_…` swept across activation
+thread counts, before and after:
+
+| `NEAT_SCORER_ACTIVATION_THREADS` | worker allotment | before | after |
+|---|---|---|---|
+| 3, 6, 12 | `[1,1,1]` / `[2,2,2]` / `[4,4,4]` | pass | pass |
+| 5 | `[2,2,1]` | **FAIL** (`…6573` vs `…6493`) | pass |
+| 7 | `[3,2,2]` | pass | pass |
+| 8 | `[3,3,2]` | **FAIL** (`…6557` vs `…6573` — the issue's exact values) | pass |
+
+Measured relative differences at the two failing counts:
+
+```text
+threads=5: parity_drift=6.04e-15  dropped_gap=9.01e-3
+threads=8: parity_drift=1.17e-15  dropped_gap=9.01e-3
+```
+
+The `1e-12` bound sits ~165× above the worst drift and ~2× above the
+`n_records × f64::EPSILON` ≈ `4.5e-13` re-association bound for this
+2,048-record corpus, while a dropped branch edge — the divergence the guard
+exists to catch — stays `9.0e-3` away, ten orders of magnitude clear.
+
+```mermaid
+flowchart LR
+    R["2,048 records<br/>identical per-record errors"]
+    R --> A["relaxed — 3 workers<br/>683 + 683 + 682"]
+    R --> B["relayed — 2 workers<br/>1024 + 1024"]
+    A --> SA["Σ f64 → 1.3229378675896557"]
+    B --> SB["Σ f64 → 1.3229378675896573"]
+    SA --> D["2 ULP apart — reduction noise,<br/>not a difference in the function"]
+    SB --> D
+    D --> T["bit-exact where the order is fixed;<br/>1e-12 where the pipeline may re-associate"]
+```
+
+**Quality gate.** `./quality.sh < /dev/null` runs clean up to the `codespell`
+preflight, which cannot run on this container — `codespell` is not installed and
+the image has no `pip`/`ensurepip` (`/usr/bin/python3: No module named pip`).
+Every remaining step was then run individually and passed: `cargo fmt --all`,
+`cargo clippy --workspace --all-targets --all-features -D warnings`,
+`cargo check`, `cargo build --workspace`,
+`cargo test --workspace --all-features -- --test-threads=2` (0 failures),
+`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`,
+`cargo build --workspace --release`, plus `markdownlint-cli2` (0 issues in 188
+files). CI runs the spell-check job for real.
+
+## Test Plan
+
+Added:
+
+- `rust_scorer/tests/dual_role_parity.rs::the_whole_corpus_loss_is_bit_identical_between_the_forms`
+  — reduces all 2,048 records through one `mse_sum_batch_packed` call per form
+  and asserts the relay-free and relay losses are equal **to the bit**, with the
+  dropped-edge creature differing. This is where "the relay changes nothing" is
+  genuinely testable, and it is the assertion that would fail if the relaxed
+  shape were ever mis-scored.
+- `rust_scorer/src/multi_score.rs::tests::a_ragged_worker_allotment_partitions_the_same_chunk_differently`
+  — calls `workers_per_creature_split(3, 8, 1, usize::MAX)` and
+  `partition_packed_record_ranges` and asserts the same chunk is split into a
+  different number of sub-ranges, each still tiling the whole buffer. Pins the
+  mechanism as a fact about the partition rather than an observation about one
+  host.
+
+Modified (documented behaviour change):
+
+- `directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one` —
+  the relaxed-vs-relayed comparison is now `relative_difference ≤ 1e-12`
+  (`CPU_PIPELINE_REL_TOLERANCE`) instead of `==`, and the dropped-creature
+  comparison is strengthened from `assert_ne!` to "differs by more than `1e6 ×`
+  the tolerance", so loosening one end cannot quietly weaken the other. No test
+  was removed or commented out.
+
+Docs updated to state the same contract: the README
+"Synapses are keyed by `(from, to, type)`" section (bound table, mechanism,
+Mermaid diagram), the `dual_role_fixture.rs` module and
+`relay_equivalent_if_creature_json` doc comments (which claimed the score
+equality was "bit-exact and not a tolerance"), the `dual_role_parity.rs` module
+"Documented tolerance" paragraph, and the CHANGELOG (new `Fixed` entry; the
+Issue #581 `Added` entry's "score identically" wording corrected).

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.71"
+version = "1.1.72"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/dual_role_fixture.rs
+++ b/rust_scorer/src/dual_role_fixture.rs
@@ -26,8 +26,13 @@
 //! ```
 //!
 //! Both forms describe the *same* function, so the scorer must give them the
-//! *same* score — that equality is the parity assertion, and it is exact rather
-//! than approximate because the relay contributes `0.0 + 1.0 * x`.
+//! *same* score — that equality is the parity assertion. Because the relay
+//! contributes `0.0 + 1.0 * x`, the equality is **bit-exact** wherever the two
+//! forms reduce in the same order: every per-record activation, and a
+//! whole-corpus loss summed in one partition. Through the directory pipeline it
+//! is a stated tolerance instead — that pipeline reduces each creature in as
+//! many `f64` partials as it was allotted workers, and the allotment is ragged
+//! when the thread count is not a multiple of the population (Issue #585).
 //!
 //! ## Why it is a cross-engine fixture
 //!
@@ -173,11 +178,13 @@ pub fn dual_role_if_creature_json(spec: &TreeSpec) -> String {
 /// Three constants replace the one, and two `IDENTITY` relays replace the
 /// shared column's direct branch edges. No ordered pair repeats, so this form
 /// was — and remains — legal under the old `(from, to)` key. It exists to be
-/// scored alongside [`dual_role_if_creature_json`]: the two must agree exactly.
+/// scored alongside [`dual_role_if_creature_json`]: the two must agree.
 ///
 /// Relay arithmetic is `0.0 + 1.0 * x`, and each `IF` bucket sums in the same
-/// order as the relay-free form, so the equality is bit-exact and not a
-/// tolerance.
+/// order as the relay-free form, so every activation — and any loss reduced in
+/// the same order over the same records — is bit-identical. Only the directory
+/// pipeline's `f64` reduction can re-associate between the two (Issue #585),
+/// and only within the tolerance `tests/dual_role_parity.rs` states.
 #[must_use]
 pub fn relay_equivalent_if_creature_json(spec: &TreeSpec) -> String {
     let shared = format!("input-{}", shared_feature(spec));

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -1628,6 +1628,34 @@ mod tests {
         assert_eq!(w, vec![1; 50]);
     }
 
+    /// Issue #585: a ragged worker allotment makes two creatures reduce the
+    /// *same* chunk in a different number of `f64` partials, so their scores
+    /// agree to a tolerance rather than to the bit. This is the mechanism the
+    /// `dual_role_parity` score comparison documents — pinned here as a fact
+    /// about the partition, not as an observation about one host.
+    #[test]
+    fn a_ragged_worker_allotment_partitions_the_same_chunk_differently() {
+        // 3 creatures on 8 threads: the first two get 3 workers, the third 2.
+        let w = workers_per_creature_split(3, 8, 1, usize::MAX);
+        assert_eq!(w, vec![3, 3, 2]);
+
+        let vpr = 7;
+        let n_records = 2_048;
+        let three = partition_packed_record_ranges(vpr, n_records, w[0]);
+        let two = partition_packed_record_ranges(vpr, n_records, w[2]);
+        assert_ne!(
+            three.len(),
+            two.len(),
+            "the allotment must yield a different number of record sub-ranges"
+        );
+        // Both still tile the whole chunk — the records are the same, only the
+        // grouping of their per-record errors differs.
+        for ranges in [&three, &two] {
+            assert_eq!(ranges[0].start, 0);
+            assert_eq!(ranges[ranges.len() - 1].end, n_records * vpr);
+        }
+    }
+
     #[test]
     fn partition_packed_record_ranges_covers_full_buffer_with_no_overlap() {
         // 7 records / 3 workers → [3, 2, 2]; ranges should tile [0, 7*vpr).

--- a/rust_scorer/tests/dual_role_parity.rs
+++ b/rust_scorer/tests/dual_role_parity.rs
@@ -21,8 +21,9 @@
 //!    `ts_parity.rs` makes against `Creature.scoreDir`, and the assertion that
 //!    would have caught the original divergence.
 //! 2. **The relaxed form and the relay workaround are the same function.** They
-//!    activate bit-identically and score identically through the real directory
-//!    pipeline, so upstream may drop the relay without moving a single score.
+//!    activate bit-identically, reduce to a bit-identical loss over the whole
+//!    corpus, and score equal through the real directory pipeline, so upstream
+//!    may drop the relay without moving a score.
 //! 3. **A dropped edge is detectable, not assumed.** The creature a
 //!    `(from, to)`-keyed loader is left holding scores *differently*, so test 1
 //!    cannot pass vacuously.
@@ -30,10 +31,24 @@
 //!    relaxed shape is scored on GPU and compared against CPU when an adapter is
 //!    present.
 //!
-//! **Documented tolerance.** CPU↔CPU comparisons — reference, relay-equivalence
-//! and pipeline score — are exact (`==`), because both forms perform the same
-//! `f32` arithmetic in the same order. Cross-backend comparisons use the
-//! repository's established `1e-3` relative tolerance (Issue #82/#312/#574).
+//! **Documented tolerance (Issue #585).** Bit-exactness is asserted wherever
+//! the two forms genuinely perform the same `f32` arithmetic in the same order:
+//! every per-record activation (against the independent reference and against
+//! each other) and the whole-corpus loss reduced in **one** partition by
+//! `mse_sum_batch_packed`. The **directory pipeline** score is compared within
+//! [`CPU_PIPELINE_REL_TOLERANCE`] instead, because that pipeline splits each
+//! creature's chunk across the workers it was allotted and folds the `f64`
+//! partials back — and `multi_score::workers_per_creature_split` allots a
+//! *ragged* count when `activation_threads` is not a multiple of the population
+//! (3 creatures on 8 threads → `[3, 3, 2]`, Issue #537). Two creatures in one
+//! directory then reduce the same per-record errors in a different association
+//! order, which moves the last bits of an `f64` sum: this assertion was `==`
+//! and failed by 2 ULP on any host whose thread count made the split ragged.
+//! Re-association is bounded by `n_records × f64::EPSILON` (≈ 4.5e-13 for this
+//! corpus; ≤ 6.1e-15 measured across thread counts 1..=16), so the `1e-12`
+//! bound holds while the dropped-edge creature stays 9.0e-3 away — ten orders
+//! of magnitude clear of the bound. Cross-backend comparisons keep
+//! the repository's established `1e-3` relative tolerance (Issue #82/#312/#574).
 //!
 //! GPU bodies skip cleanly when no adapter is available; the CPU assertions gate
 //! every run.
@@ -66,7 +81,29 @@ use rust_scorer::scoring::ScoreResult;
 /// Cross-backend relative tolerance on a per-creature loss (Issue #82/#312).
 const CROSS_BACKEND_REL_TOLERANCE: f64 = 1e-3;
 
+/// Relative tolerance between two **directory-pipeline** CPU scores of the same
+/// corpus (Issue #585).
+///
+/// The pipeline reduces each creature's per-record errors in as many `f64`
+/// partial sums as that creature was allotted workers, and the allotment is
+/// ragged whenever `activation_threads` is not a multiple of the population, so
+/// two creatures scoring the same records can re-associate the reduction
+/// differently. The re-association error is bounded by
+/// `n_records × f64::EPSILON` — ≈ 4.5e-13 for the 2,048-record corpus here —
+/// and is not a difference in the function being scored: the identical-order
+/// reduction is asserted bit-exactly by
+/// [`the_whole_corpus_loss_is_bit_identical_between_the_forms`].
+const CPU_PIPELINE_REL_TOLERANCE: f64 = 1e-12;
+
+/// Number of records every corpus in this suite carries.
+const CORPUS_RECORDS: usize = 2_048;
+
 const NUM_INPUTS: usize = 6;
+
+/// Relative difference between two losses, symmetric in its arguments.
+fn relative_difference(a: f64, b: f64) -> f64 {
+    (a - b).abs() / a.abs().max(b.abs()).max(f64::MIN_POSITIVE)
+}
 
 /// The creature under test: one `IF` node whose condition, positive and
 /// negative buckets are fed by repeated sources.
@@ -237,6 +274,44 @@ fn dropping_the_shared_negative_edge_changes_the_prediction() {
     );
 }
 
+// --- Whole-corpus loss, reduced in one partition ------------------------------
+
+/// The bit-exact half of the score contract (Issue #585).
+///
+/// Reduced in a single partition — one `mse_sum_batch_packed` call over the
+/// whole corpus — the two forms sum the same per-record errors in the same
+/// order, so their losses are equal to the last bit. This is where "the relay
+/// changes nothing" is genuinely testable: no worker partition, no host thread
+/// count, nothing between the two numbers but the creatures themselves.
+#[test]
+fn the_whole_corpus_loss_is_bit_identical_between_the_forms() {
+    let spec = spec();
+    let records = dual_role_corpus_records(&spec, CORPUS_RECORDS);
+    let loss = |json: &str| {
+        let mut net = compile(json);
+        mse_sum_batch_packed(&mut net, &records, NUM_INPUTS, 1, true)
+    };
+
+    let relaxed = loss(&dual_role_if_creature_json(&spec));
+    let relayed = loss(&relay_equivalent_if_creature_json(&spec));
+    let dropped = loss(&dropped_shared_branch_creature_json(&spec));
+
+    assert!(
+        relaxed > 0.0,
+        "a zero loss would make the comparison vacuous"
+    );
+    assert_eq!(
+        relaxed, relayed,
+        "reduced in one partition, the relay-free creature and its relay \
+         workaround must sum to the same bits"
+    );
+    assert_ne!(
+        relaxed, dropped,
+        "losing a branch edge must move the loss — otherwise the parity guard \
+         is vacuous"
+    );
+}
+
 // --- Full-pipeline scoring ---------------------------------------------------
 
 /// Both forms scored through the real directory pipeline must return the same
@@ -244,6 +319,16 @@ fn dropping_the_shared_negative_edge_changes_the_prediction() {
 ///
 /// This is the end-to-end shape of the cross-engine comparison: the same corpus,
 /// the same cost, three creatures, scored the way production scores them.
+///
+/// Issue #585 — the pipeline comparison is bounded by
+/// [`CPU_PIPELINE_REL_TOLERANCE`], not `==`. The pipeline splits each creature's
+/// chunk across the workers it was allotted, and that allotment is ragged when
+/// `activation_threads` is not a multiple of the population, so two creatures
+/// can fold the same per-record errors into a different number of `f64`
+/// partials. The bits of the *function* are pinned by
+/// [`the_whole_corpus_loss_is_bit_identical_between_the_forms`]; what this test
+/// pins is that nothing larger than reduction noise separates the two forms
+/// end to end, while the dropped-edge creature stays orders of magnitude away.
 #[test]
 fn directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one() {
     let spec = spec();
@@ -269,7 +354,7 @@ fn directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one() {
     )
     .expect("write dropped creature");
 
-    let n_records = 2_048;
+    let n_records = CORPUS_RECORDS;
     let records = dual_role_corpus_records(&spec, n_records);
     std::fs::write(data_dir.join("0.bin"), records_to_le_bytes(&records)).expect("write corpus");
 
@@ -283,15 +368,23 @@ fn directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one() {
     assert_eq!(scores.len(), 3, "every candidate must be scored");
 
     let error = |name: &str| scores.get(name).expect("candidate scored").error;
-    assert_eq!(
+    let parity_drift = relative_difference(error("relaxed"), error("relayed"));
+    assert!(
+        parity_drift <= CPU_PIPELINE_REL_TOLERANCE,
+        "the relay-free creature and its relay workaround must score the same: \
+         relaxed={} relayed={} relative_difference={parity_drift} exceeds \
+         {CPU_PIPELINE_REL_TOLERANCE}",
         error("relaxed"),
-        error("relayed"),
-        "the relay-free creature and its relay workaround must score identically"
+        error("relayed")
     );
-    assert_ne!(
+    let dropped_gap = relative_difference(error("relaxed"), error("dropped"));
+    assert!(
+        dropped_gap > CPU_PIPELINE_REL_TOLERANCE * 1e6,
+        "losing a branch edge must move the loss far beyond reduction noise — \
+         otherwise the parity guard is vacuous: relaxed={} dropped={} \
+         relative_difference={dropped_gap}",
         error("relaxed"),
-        error("dropped"),
-        "losing a branch edge must move the loss — otherwise the parity guard is vacuous"
+        error("dropped")
     );
     for name in ["relaxed", "relayed", "dropped"] {
         let result = scores.get(name).expect("candidate scored");


### PR DESCRIPTION
# Bound the dual-role parity score comparison to the reduction it can hold (Issue #585)

## Summary

`tests/dual_role_parity.rs::directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one`
asserted **bit-exact** equality between the relay-free creature's
directory-pipeline score and its relay workaround's, and failed by 2 ULP
(`1.3229378675896557` vs `1.3229378675896573`). Closes #585.

The reported cause — x86-64, or the relay's extra `IDENTITY` neuron changing the
association order of the creature's own arithmetic — is not the cause. Directory
scoring folds each creature's chunk from **as many `f64` partial sums as that
creature was allotted workers**, and `multi_score::workers_per_creature_split`
allots a *ragged* count when `activation_threads` is not a multiple of the
population (3 creatures on 8 threads → `[3, 3, 2]`, Issue #537). The three
fixtures sort as `dropped`, `relaxed`, `relayed`, so `relaxed` reduces
`683 + 683 + 682` records while `relayed` reduces `1024 + 1024` — the same
per-record errors, a different association order, the last bits of an `f64` sum
apart. Nothing architecture-specific: the reported failure reproduces
bit-for-bit on this **aarch64** host under `NEAT_SCORER_ACTIVATION_THREADS=8`,
and disappears at `6`, `7` or `12`.

Encoding the contract (the issue's option 2 — a stated tolerance where the
requirement is not genuinely testable, bit-exactness where it is):

| Comparison | Bound |
|---|---|
| CPU activation vs the independent reference | bit-exact (unchanged) |
| relay-free vs relay activation, per record | bit-exact (unchanged) |
| relay-free vs relay whole-corpus loss, one partition | bit-exact (**new test**) |
| relay-free vs relay **directory-pipeline** score | `1e-12` relative (**was `==`**) |
| CPU vs GPU per-creature loss | `1e-3` relative (unchanged) |

Option 1 (forcing the two forms to reduce in an identical order) was rejected:
it would require every creature in a directory to receive the same worker count,
idling up to `n_creatures - 1` threads whenever the population is smaller than
the thread budget — a throughput regression to buy a property the new bit-exact
test already pins where it is real. No production scoring code changed.

## Evidence

Backend/CLI change with no web interface, so no screenshot: the evidence is the
reproduction and the gate.

**Reproduced, then fixed** — `directory_scoring_agrees_…` swept across activation
thread counts, before and after:

| `NEAT_SCORER_ACTIVATION_THREADS` | worker allotment | before | after |
|---|---|---|---|
| 3, 6, 12 | `[1,1,1]` / `[2,2,2]` / `[4,4,4]` | pass | pass |
| 5 | `[2,2,1]` | **FAIL** (`…6573` vs `…6493`) | pass |
| 7 | `[3,2,2]` | pass | pass |
| 8 | `[3,3,2]` | **FAIL** (`…6557` vs `…6573` — the issue's exact values) | pass |

Measured relative differences at the two failing counts:

```text
threads=5: parity_drift=6.04e-15  dropped_gap=9.01e-3
threads=8: parity_drift=1.17e-15  dropped_gap=9.01e-3
```

The `1e-12` bound sits ~165× above the worst drift and ~2× above the
`n_records × f64::EPSILON` ≈ `4.5e-13` re-association bound for this
2,048-record corpus, while a dropped branch edge — the divergence the guard
exists to catch — stays `9.0e-3` away, ten orders of magnitude clear.

```mermaid
flowchart LR
    R["2,048 records<br/>identical per-record errors"]
    R --> A["relaxed — 3 workers<br/>683 + 683 + 682"]
    R --> B["relayed — 2 workers<br/>1024 + 1024"]
    A --> SA["Σ f64 → 1.3229378675896557"]
    B --> SB["Σ f64 → 1.3229378675896573"]
    SA --> D["2 ULP apart — reduction noise,<br/>not a difference in the function"]
    SB --> D
    D --> T["bit-exact where the order is fixed;<br/>1e-12 where the pipeline may re-associate"]
```

**Quality gate.** `./quality.sh < /dev/null` runs clean up to the `codespell`
preflight, which cannot run on this container — `codespell` is not installed and
the image has no `pip`/`ensurepip` (`/usr/bin/python3: No module named pip`).
Every remaining step was then run individually and passed: `cargo fmt --all`,
`cargo clippy --workspace --all-targets --all-features -D warnings`,
`cargo check`, `cargo build --workspace`,
`cargo test --workspace --all-features -- --test-threads=2` (0 failures),
`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`,
`cargo build --workspace --release`, plus `markdownlint-cli2` (0 issues in 188
files). CI runs the spell-check job for real.

## Test Plan

Added:

- `rust_scorer/tests/dual_role_parity.rs::the_whole_corpus_loss_is_bit_identical_between_the_forms`
  — reduces all 2,048 records through one `mse_sum_batch_packed` call per form
  and asserts the relay-free and relay losses are equal **to the bit**, with the
  dropped-edge creature differing. This is where "the relay changes nothing" is
  genuinely testable, and it is the assertion that would fail if the relaxed
  shape were ever mis-scored.
- `rust_scorer/src/multi_score.rs::tests::a_ragged_worker_allotment_partitions_the_same_chunk_differently`
  — calls `workers_per_creature_split(3, 8, 1, usize::MAX)` and
  `partition_packed_record_ranges` and asserts the same chunk is split into a
  different number of sub-ranges, each still tiling the whole buffer. Pins the
  mechanism as a fact about the partition rather than an observation about one
  host.

Modified (documented behaviour change):

- `directory_scoring_agrees_between_the_forms_and_separates_the_dropped_one` —
  the relaxed-vs-relayed comparison is now `relative_difference ≤ 1e-12`
  (`CPU_PIPELINE_REL_TOLERANCE`) instead of `==`, and the dropped-creature
  comparison is strengthened from `assert_ne!` to "differs by more than `1e6 ×`
  the tolerance", so loosening one end cannot quietly weaken the other. No test
  was removed or commented out.

Docs updated to state the same contract: the README
"Synapses are keyed by `(from, to, type)`" section (bound table, mechanism,
Mermaid diagram), the `dual_role_fixture.rs` module and
`relay_equivalent_if_creature_json` doc comments (which claimed the score
equality was "bit-exact and not a tolerance"), the `dual_role_parity.rs` module
"Documented tolerance" paragraph, and the CHANGELOG (new `Fixed` entry; the
Issue #581 `Added` entry's "score identically" wording corrected).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mt9csrw5-2f7b02`<!-- vibe-worker-issue-585 -->