### PR TITLE
Expose the Issue #308 early-exit hook to subprocess callers via --race-stdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ section to the released version with its date.
 
 ### Added
 
+- **`--race-stdio`: the Issue #308 early-exit hook, reachable from a
+  subprocess caller (NEAT-AI#3928).** `score_from_creature_dir_with_early_exit`
+  is a library entrypoint, so the callback that decides which creatures to
+  abandon has to be Rust linked into this crate — every NEAT-AI deployment
+  drives `rust_scorer` as a **subprocess** and therefore could never register
+  one. The hook shipped and nothing called it. `--race-stdio` closes that gap
+  with a line-delimited protocol on the directory path: after each scored chunk
+  the scorer writes
+  `{"racing":"chunk","chunk":N,"partials":[{"index","key","partialError","recordsScored"}]}`
+  to stdout and blocks for exactly one verdict line on stdin —
+  `{"verdict":"continue"}`, `{"verdict":"abort","creatures":[i,…]}` or
+  `{"verdict":"abortAll"}` — then prints the usual result map. Answering
+  `continue` every time reproduces the non-racing directory scores
+  **bit-identically** (`rust_scorer/tests/racing_stdio_cli.rs`). A closed
+  stdin, an empty line, a malformed verdict or an unknown verdict name aborts
+  the sweep and exits non-zero rather than silently completing a full-corpus
+  sweep the caller never asked for; `--gpu on` and a single-creature file
+  target are refused for the same reason (the hook is CPU directory mode only).
+  New `rust_scorer/src/racing_stdio.rs` (protocol driver, generic over the
+  streams so it is unit-testable without a subprocess) and
+  `multi_score::score_from_creature_dir_sampled_with_early_exit`, which composes
+  the hook with the Issue #310 sampler.
+
 - **Parity guard for `(from, to, type)`-keyed synapses (Issue #581).**
   `neat-core` 0.10.6 (NEAT-AI-core#577) relaxed the duplicate-synapse rule so one
   source may feed an `IF` neuron through more than one role — the contribution

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.72"
+version = "1.1.73"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -984,6 +984,44 @@ flowchart TD
     G --> H
 ```
 
+#### Driving early exit from a subprocess caller: `--race-stdio` (NEAT-AI#3928)
+
+The API above is a **library** entrypoint — the callback must be Rust linked
+into this crate. Callers that run `rust_scorer` as a subprocess (every NEAT-AI
+deployment) had no way to register one, so the hook was implemented and never
+reached. `--race-stdio` exposes it over line-delimited JSON on the directory
+path:
+
+```bash
+rust_scorer --gpu off --race-stdio creatures/ training_data/
+```
+
+After each scored chunk the scorer writes one line to stdout and **blocks**
+until the caller answers with exactly one verdict line on stdin:
+
+```text
+scorer → caller  {"racing":"chunk","chunk":1,"partials":[{"index":0,"key":"alpha","partialError":0.51,"recordsScored":1024}]}
+caller → scorer  {"verdict":"continue"}
+caller → scorer  {"verdict":"abort","creatures":[2,5]}
+caller → scorer  {"verdict":"abortAll"}
+```
+
+The result map is printed after the sweep exactly as in plain directory mode,
+so a caller consumes `{"racing":…}` lines as they arrive and parses whatever
+remains as the result.
+
+- **Parity:** answering `continue` every time reproduces the non-racing
+  directory scores bit-identically (`tests/racing_stdio_cli.rs`).
+- **Fail loud:** a closed stdin, an empty line, a malformed verdict or an
+  unknown verdict name aborts the sweep and exits non-zero. Degrading to
+  "continue" would hand back a full-corpus score the caller never agreed to —
+  indistinguishable from a race that saved nothing.
+- **CPU directory mode only:** the GPU kernel has no early-exit surface, so
+  `--gpu on` is rejected, as is a single-creature file target. `--sample-rate`
+  composes normally.
+- **Probing:** `--race-stdio` appears in `--help`, so a caller can detect
+  whether the installed binary supports racing before asking for it.
+
 For forward-only single-creature fused scoring, activation parallelism also
 defaults to a **host-aware** worker count (every logical CPU on mid/large hosts;
 clamped on low-RAM machines so compiled-network clones stay within memory).

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.72"
+version = "1.1.73"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/cli.rs
+++ b/rust_scorer/src/cli.rs
@@ -35,6 +35,7 @@ use crate::creature_width::validate_creature_width;
 use crate::gpu::{GpuBackendLabel, GpuMode, ScoringPath};
 use crate::host_report::{DEFAULT_REPORT_RECORD_BYTES, HostReport};
 use crate::multi_score::{score_from_creature_dir_gpu_sampled, score_from_creature_dir_sampled};
+use crate::racing_stdio::RacingStdio;
 use crate::read_tuning::{
     training_read_backend_label, training_read_target_bytes_from_env_for_readers,
 };
@@ -140,6 +141,26 @@ struct Cli {
     /// `--sample-rate` is `1` or absent.
     #[arg(long, value_name = "PHASE", default_value_t = 0)]
     sample_phase: u64,
+
+    /// Race the directory-mode batch over stdio: publish per-chunk partial
+    /// scores on stdout and read one abandon verdict per chunk from stdin
+    /// (Issue #308's early-exit hook, consumed by NEAT-AI#3928).
+    ///
+    /// Only valid with a **creatures directory** positional argument. After
+    /// every scored chunk the scorer writes one line
+    /// `{"racing":"chunk","chunk":N,"partials":[…]}` and blocks until the
+    /// caller answers with exactly one of `{"verdict":"continue"}`,
+    /// `{"verdict":"abort","creatures":[i,…]}`, or `{"verdict":"abortAll"}`.
+    /// The result map is printed afterwards exactly as in plain directory
+    /// mode; answering `continue` every time reproduces the full-corpus scores
+    /// bit-identically.
+    ///
+    /// Runs on the CPU directory path — the GPU kernel has no early-exit
+    /// surface — so `--gpu on` is rejected rather than silently full-scoring.
+    /// A closed stdin, or a malformed or unknown verdict, aborts the sweep with
+    /// a non-zero exit.
+    #[arg(long)]
+    race_stdio: bool,
 
     /// Print the detected host resources and every resolved knob as one JSON
     /// object, then exit — score nothing (Issue #545).
@@ -267,6 +288,26 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         None => SampleSpec::full(),
     };
 
+    // NEAT-AI#3928: `--race-stdio` drives the Issue #308 early-exit hook, which
+    // exists only on the CPU directory path. Refuse the combinations that could
+    // not honour it rather than silently full-scoring a caller who asked to
+    // race — a full-corpus sweep is exactly what racing is meant to avoid, and
+    // it would look like a working race that never saved anything.
+    if cli.race_stdio {
+        if cli.creature_stdin {
+            return Err(
+                "--race-stdio scores a creatures directory; it cannot be combined with --creature-stdin"
+                    .to_string(),
+            );
+        }
+        if matches!(mode, GpuMode::On) {
+            return Err(
+                "--race-stdio has no GPU kernel: the early-exit hook is CPU directory mode only (drop --gpu on, or drop --race-stdio)"
+                    .to_string(),
+            );
+        }
+    }
+
     // Issue #121/#339/#316: `--gpu on` with a cost the kernels cannot serve is a
     // hard error. The batched/scratch kernels host MSE and RMSE (squared-error
     // sum, RMSE via a host-side `sqrt`) and MAE (absolute-error sum); every
@@ -335,7 +376,20 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
 
     let creature_path = &cli.args[0];
     let data_path = &cli.args[1];
+    if cli.race_stdio && !creature_path.is_dir() {
+        return Err(format!(
+            "--race-stdio requires a creatures directory; '{}' is not a directory",
+            creature_path.display()
+        ));
+    }
     if creature_path.is_dir() {
+        // NEAT-AI#3928: racing owns the whole directory sweep — it runs on the
+        // CPU path with the caller's policy in the loop, so it is resolved
+        // before any GPU routing.
+        if cli.race_stdio {
+            return run_racing_directory(creature_path, data_path, cli.cost, &sample)
+                .map(RunOutput::Multi);
+        }
         // Issue #205: under `--gpu auto`, a non-MSE cost makes
         // `auto_should_use_gpu` return false, so the directory path runs on
         // CPU. That fallback was otherwise silent (only the
@@ -467,6 +521,40 @@ fn run(cli: &Cli) -> Result<RunOutput, String> {
         )
         .map(|r| RunOutput::Single(Box::new(r)))
     }
+}
+
+/// Score a creatures directory with the caller's racing policy in the loop
+/// (NEAT-AI#3928).
+///
+/// Each scored chunk is published on stdout and one verdict is read back from
+/// stdin by [`RacingStdio`]; a protocol fault becomes this function's `Err`, so
+/// the binary exits non-zero with the reason rather than returning a result the
+/// caller's policy never agreed to.
+fn run_racing_directory(
+    creatures_dir: &Path,
+    data_path: &Path,
+    cost: CostKind,
+    sample: &SampleSpec,
+) -> Result<BTreeMap<String, ScoreResult>, String> {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut driver = RacingStdio::new(stdin.lock(), stdout.lock());
+    let scored = multi_score::score_from_creature_dir_sampled_with_early_exit(
+        creatures_dir,
+        data_path,
+        // The early-exit hook is CPU-only, so the reported backend is the same
+        // `cpu-fallback` label every other CPU directory sweep carries.
+        GpuBackendLabel::CpuFallback,
+        cost,
+        sample,
+        |partials| driver.on_chunk(partials),
+    );
+    // A protocol fault wins over the scoring outcome: the sweep it aborted
+    // produced partial scores for creatures the caller never abandoned.
+    if let Some(failure) = driver.failure() {
+        return Err(failure.to_string());
+    }
+    scored
 }
 
 fn score_from_json(
@@ -795,6 +883,7 @@ mod tests {
             cost: CostKind::default(),
             sample_rate: None,
             sample_phase: 0,
+            race_stdio: false,
             host_report: false,
             record_bytes: DEFAULT_REPORT_RECORD_BYTES,
             args: vec![creature.to_path_buf(), data.to_path_buf()],
@@ -1197,6 +1286,7 @@ mod tests {
             cost: CostKind::default(),
             sample_rate: None,
             sample_phase: 0,
+            race_stdio: false,
             host_report: false,
             record_bytes: DEFAULT_REPORT_RECORD_BYTES,
             args: vec![PathBuf::from("/tmp/creature.json"), PathBuf::from("/tmp")],
@@ -1217,6 +1307,7 @@ mod tests {
             cost: CostKind::default(),
             sample_rate: None,
             sample_phase: 0,
+            race_stdio: false,
             host_report: false,
             record_bytes: DEFAULT_REPORT_RECORD_BYTES,
             args: vec![PathBuf::from("/tmp")],

--- a/rust_scorer/src/lib.rs
+++ b/rust_scorer/src/lib.rs
@@ -29,6 +29,7 @@ pub mod host_resources;
 pub mod if_tree_fixture;
 pub mod multi_score;
 pub mod prod_fixture;
+pub mod racing_stdio;
 pub mod read_tuning;
 pub mod sampling;
 pub mod scoring;

--- a/rust_scorer/src/multi_score.rs
+++ b/rust_scorer/src/multi_score.rs
@@ -561,6 +561,33 @@ where
     )
 }
 
+/// [`score_from_creature_dir_with_early_exit`] over a sub-sampled corpus.
+///
+/// Composes the Issue #308 early-exit hook with the Issue #310 record-level
+/// sampler so a caller can race candidates against a sampled corpus rather than
+/// having to pick one of the two. `SampleSpec::full()` makes this identical to
+/// [`score_from_creature_dir_with_early_exit`].
+pub fn score_from_creature_dir_sampled_with_early_exit<F>(
+    creatures_dir: &Path,
+    data_path: &Path,
+    gpu_backend: GpuBackendLabel,
+    cost: CostKind,
+    sample: &SampleSpec,
+    mut on_chunk: F,
+) -> Result<BTreeMap<String, ScoreResult>, String>
+where
+    F: FnMut(&[PartialScore]) -> EarlyExit,
+{
+    score_from_creature_dir_cpu(
+        creatures_dir,
+        data_path,
+        gpu_backend,
+        cost,
+        Some(&mut on_chunk),
+        sample,
+    )
+}
+
 /// Shared CPU directory-mode implementation behind [`score_from_creature_dir`]
 /// (no callback) and [`score_from_creature_dir_with_early_exit`] (Issue #308).
 ///

--- a/rust_scorer/src/racing_stdio.rs
+++ b/rust_scorer/src/racing_stdio.rs
@@ -168,7 +168,7 @@ impl<R: BufRead, W: Write> RacingStdio<R, W> {
         }
         let verdict: Verdict = serde_json::from_str(trimmed).map_err(|e| {
             format!(
-                "--race-stdio: unparseable verdict after chunk {}: {e} (line: {trimmed})",
+                "--race-stdio: unparsable verdict after chunk {}: {e} (line: {trimmed})",
                 self.chunk
             )
         })?;
@@ -249,12 +249,12 @@ mod tests {
     }
 
     #[test]
-    fn unparseable_verdict_fails_loud() {
+    fn unparsable_verdict_fails_loud() {
         let (exit, _, failure) = drive("not json\n", &[partial(0, "a", 0.1, 8)]);
         assert_eq!(exit, EarlyExit::AbortAll);
         let failure = failure.expect("malformed verdict must be recorded as a failure");
         assert!(
-            failure.contains("unparseable verdict"),
+            failure.contains("unparsable verdict"),
             "unexpected failure: {failure}"
         );
     }

--- a/rust_scorer/src/racing_stdio.rs
+++ b/rust_scorer/src/racing_stdio.rs
@@ -1,0 +1,286 @@
+//! Line-delimited stdio racing protocol for directory-mode early exit
+//! (Issue #308 surface; consumed by NEAT-AI#3928).
+//!
+//! [`score_from_creature_dir_with_early_exit`](crate::multi_score::score_from_creature_dir_with_early_exit)
+//! is a **library** entrypoint: the callback that decides which creatures to
+//! abandon has to be Rust code linked into this crate. Callers that drive the
+//! binary as a subprocess — every NEAT-AI deployment does — had no way to
+//! supply one, so the early-exit path was implemented and never reached.
+//!
+//! This module is that missing surface. Under `--race-stdio` the scorer writes
+//! one JSON line per scored chunk to stdout and blocks reading exactly one
+//! verdict line from stdin, so the caller's own policy makes the decision:
+//!
+//! ```text
+//! scorer → caller  {"racing":"chunk","chunk":1,"partials":[{"index":0,"key":"a","partialError":0.51,"recordsScored":1024}]}
+//! caller → scorer  {"verdict":"continue"}
+//! caller → scorer  {"verdict":"abort","creatures":[0,2]}
+//! caller → scorer  {"verdict":"abortAll"}
+//! ```
+//!
+//! The final result map is printed after the sweep exactly as in plain
+//! directory mode, so a caller reads chunk events until the stream stops
+//! producing them and then parses what remains.
+//!
+//! **Fail loud, never silently full-score.** A closed stdin, a malformed
+//! verdict, an unknown verdict, or a write failure aborts the sweep and makes
+//! the process exit non-zero with the reason on stderr. Degrading to
+//! "continue" would hand the caller a full-corpus score it never asked for —
+//! cheap to mistake for a working race.
+
+use std::io::{BufRead, Write};
+
+use serde::{Deserialize, Serialize};
+
+use crate::multi_score::{EarlyExit, PartialScore};
+
+/// One creature's running score, as serialised on the wire.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PartialScoreLine<'a> {
+    /// Creature index within the loaded directory (sorted file order). This is
+    /// the value a verdict names in `creatures`.
+    index: usize,
+    /// Creature id — the `.json` file stem, matching the result-map key.
+    key: &'a str,
+    /// Mean error over the records scored so far.
+    partial_error: f64,
+    /// How many records this creature has been scored against so far.
+    records_scored: usize,
+}
+
+/// One chunk event written to stdout.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChunkEvent<'a> {
+    /// Constant discriminator so a caller can tell a racing event apart from
+    /// the result JSON on the same stream.
+    racing: &'static str,
+    /// 1-based chunk counter, for diagnostics and protocol-desync detection.
+    chunk: u64,
+    /// One entry per still-active creature.
+    partials: Vec<PartialScoreLine<'a>>,
+}
+
+/// Caller verdict read back from stdin after each chunk event.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(tag = "verdict", rename_all = "camelCase")]
+enum Verdict {
+    /// Keep scoring every active creature.
+    Continue,
+    /// Stop scoring the listed creature indices.
+    Abort {
+        /// Creature indices to abandon; unknown indices are ignored by the
+        /// scoring loop.
+        creatures: Vec<usize>,
+    },
+    /// Stop the sweep entirely.
+    AbortAll,
+}
+
+/// Drives the racing protocol over an arbitrary reader/writer pair.
+///
+/// Generic over the streams so the protocol is testable without a subprocess;
+/// [`RacingStdio::on_chunk`] is the closure handed to
+/// `score_from_creature_dir_sampled_with_early_exit`.
+pub struct RacingStdio<R: BufRead, W: Write> {
+    reader: R,
+    writer: W,
+    chunk: u64,
+    failure: Option<String>,
+}
+
+impl<R: BufRead, W: Write> RacingStdio<R, W> {
+    /// Build a protocol driver over `reader` (verdicts in) and `writer`
+    /// (chunk events out).
+    pub fn new(reader: R, writer: W) -> Self {
+        Self {
+            reader,
+            writer,
+            chunk: 0,
+            failure: None,
+        }
+    }
+
+    /// Handle one scored chunk: publish the partials, block for the verdict.
+    ///
+    /// On any protocol fault the reason is recorded and [`EarlyExit::AbortAll`]
+    /// is returned so the sweep stops immediately; [`RacingStdio::failure`]
+    /// then reports it to the caller, which turns it into a non-zero exit.
+    pub fn on_chunk(&mut self, partials: &[PartialScore]) -> EarlyExit {
+        if self.failure.is_some() {
+            return EarlyExit::AbortAll;
+        }
+        match self.exchange(partials) {
+            Ok(exit) => exit,
+            Err(reason) => {
+                self.failure = Some(reason);
+                EarlyExit::AbortAll
+            }
+        }
+    }
+
+    /// The protocol fault that stopped the sweep, if any.
+    pub fn failure(&self) -> Option<&str> {
+        self.failure.as_deref()
+    }
+
+    fn exchange(&mut self, partials: &[PartialScore]) -> Result<EarlyExit, String> {
+        self.chunk += 1;
+        let event = ChunkEvent {
+            racing: "chunk",
+            chunk: self.chunk,
+            partials: partials
+                .iter()
+                .map(|p| PartialScoreLine {
+                    index: p.creature_index,
+                    key: &p.key,
+                    partial_error: p.partial_error,
+                    records_scored: p.records_scored,
+                })
+                .collect(),
+        };
+        let line = serde_json::to_string(&event)
+            .map_err(|e| format!("--race-stdio: failed to serialise chunk event: {e}"))?;
+        writeln!(self.writer, "{line}")
+            .map_err(|e| format!("--race-stdio: failed to write chunk event: {e}"))?;
+        self.writer
+            .flush()
+            .map_err(|e| format!("--race-stdio: failed to flush chunk event: {e}"))?;
+
+        let mut reply = String::new();
+        let read = self
+            .reader
+            .read_line(&mut reply)
+            .map_err(|e| format!("--race-stdio: failed to read verdict: {e}"))?;
+        if read == 0 {
+            return Err(format!(
+                "--race-stdio: verdict stream closed after chunk {} (expected one verdict per chunk)",
+                self.chunk
+            ));
+        }
+        let trimmed = reply.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "--race-stdio: empty verdict line after chunk {}",
+                self.chunk
+            ));
+        }
+        let verdict: Verdict = serde_json::from_str(trimmed).map_err(|e| {
+            format!(
+                "--race-stdio: unparseable verdict after chunk {}: {e} (line: {trimmed})",
+                self.chunk
+            )
+        })?;
+        Ok(match verdict {
+            Verdict::Continue => EarlyExit::Continue,
+            Verdict::Abort { creatures } => EarlyExit::AbortCreatures(creatures),
+            Verdict::AbortAll => EarlyExit::AbortAll,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn partial(index: usize, key: &str, error: f64, records: usize) -> PartialScore {
+        PartialScore {
+            creature_index: index,
+            key: key.to_string(),
+            partial_error: error,
+            records_scored: records,
+        }
+    }
+
+    fn drive(verdicts: &str, partials: &[PartialScore]) -> (EarlyExit, String, Option<String>) {
+        let mut driver = RacingStdio::new(Cursor::new(verdicts.as_bytes().to_vec()), Vec::new());
+        let exit = driver.on_chunk(partials);
+        let failure = driver.failure().map(str::to_string);
+        let written = String::from_utf8(driver.writer).expect("utf8 chunk event");
+        (exit, written, failure)
+    }
+
+    #[test]
+    fn publishes_one_chunk_event_and_returns_continue() {
+        let (exit, written, failure) = drive(
+            "{\"verdict\":\"continue\"}\n",
+            &[partial(0, "alpha", 0.25, 128)],
+        );
+        assert_eq!(exit, EarlyExit::Continue);
+        assert_eq!(failure, None);
+        let parsed: serde_json::Value =
+            serde_json::from_str(written.trim()).expect("chunk event is one JSON line");
+        assert_eq!(parsed["racing"], "chunk");
+        assert_eq!(parsed["chunk"], 1);
+        assert_eq!(parsed["partials"][0]["index"], 0);
+        assert_eq!(parsed["partials"][0]["key"], "alpha");
+        assert_eq!(parsed["partials"][0]["partialError"], 0.25);
+        assert_eq!(parsed["partials"][0]["recordsScored"], 128);
+    }
+
+    #[test]
+    fn abort_verdict_maps_to_abort_creatures() {
+        let (exit, _, failure) = drive(
+            "{\"verdict\":\"abort\",\"creatures\":[2,5]}\n",
+            &[partial(0, "a", 0.1, 8)],
+        );
+        assert_eq!(exit, EarlyExit::AbortCreatures(vec![2, 5]));
+        assert_eq!(failure, None);
+    }
+
+    #[test]
+    fn abort_all_verdict_stops_the_sweep() {
+        let (exit, _, failure) = drive("{\"verdict\":\"abortAll\"}\n", &[partial(0, "a", 0.1, 8)]);
+        assert_eq!(exit, EarlyExit::AbortAll);
+        assert_eq!(failure, None);
+    }
+
+    #[test]
+    fn closed_verdict_stream_fails_loud() {
+        let (exit, _, failure) = drive("", &[partial(0, "a", 0.1, 8)]);
+        assert_eq!(exit, EarlyExit::AbortAll);
+        let failure = failure.expect("closed stdin must be recorded as a failure");
+        assert!(
+            failure.contains("verdict stream closed"),
+            "unexpected failure: {failure}"
+        );
+    }
+
+    #[test]
+    fn unparseable_verdict_fails_loud() {
+        let (exit, _, failure) = drive("not json\n", &[partial(0, "a", 0.1, 8)]);
+        assert_eq!(exit, EarlyExit::AbortAll);
+        let failure = failure.expect("malformed verdict must be recorded as a failure");
+        assert!(
+            failure.contains("unparseable verdict"),
+            "unexpected failure: {failure}"
+        );
+    }
+
+    #[test]
+    fn unknown_verdict_name_fails_loud_rather_than_continuing() {
+        let (exit, _, failure) = drive("{\"verdict\":\"carryOn\"}\n", &[partial(0, "a", 0.1, 8)]);
+        assert_eq!(exit, EarlyExit::AbortAll);
+        assert!(
+            failure.is_some(),
+            "unknown verdict must not be a silent continue"
+        );
+    }
+
+    #[test]
+    fn a_recorded_failure_keeps_aborting_without_reading_more() {
+        let mut driver = RacingStdio::new(Cursor::new(Vec::new()), Vec::new());
+        assert_eq!(
+            driver.on_chunk(&[partial(0, "a", 0.1, 8)]),
+            EarlyExit::AbortAll
+        );
+        let first = driver.failure().map(str::to_string);
+        assert_eq!(
+            driver.on_chunk(&[partial(0, "a", 0.1, 16)]),
+            EarlyExit::AbortAll
+        );
+        assert_eq!(driver.failure().map(str::to_string), first);
+    }
+}

--- a/rust_scorer/tests/racing_stdio_cli.rs
+++ b/rust_scorer/tests/racing_stdio_cli.rs
@@ -298,7 +298,7 @@ fn a_malformed_verdict_exits_non_zero() {
     let run = race(&creatures, &data, |_| Some("{\"verdict\":42}".to_string()));
     assert!(!run.status_success, "a malformed verdict must fail loud");
     assert!(
-        run.stderr.contains("unparseable verdict"),
+        run.stderr.contains("unparsable verdict"),
         "stderr must name the protocol fault, got: {}",
         run.stderr
     );

--- a/rust_scorer/tests/racing_stdio_cli.rs
+++ b/rust_scorer/tests/racing_stdio_cli.rs
@@ -1,0 +1,361 @@
+//! End-to-end tests for `--race-stdio` (NEAT-AI#3928).
+//!
+//! Issue #308 put the early-exit hook behind a **library** entrypoint, so a
+//! caller that drives `rust_scorer` as a subprocess — every NEAT-AI deployment
+//! does — could not reach it. These tests drive the compiled binary over the
+//! stdio protocol that closes that gap, and assert the three contracts a
+//! consumer depends on:
+//!
+//! * always answering `continue` reproduces plain directory-mode scores exactly;
+//! * an `abort` verdict freezes that creature at its partial `recordCount`,
+//!   leaving every other creature's full-corpus score untouched;
+//! * a protocol fault (closed stdin, malformed verdict) exits non-zero instead
+//!   of silently completing the full sweep.
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const INPUTS: usize = 2;
+const OUTPUTS: usize = 1;
+const RECORD_BYTES: usize = (INPUTS + OUTPUTS) * 4;
+const RECORDS: usize = 256;
+
+/// Forward-only creature computing `w0*x0 + w1*x1` into one IDENTITY output.
+fn linear_creature(w0: f32, w1: f32) -> String {
+    format!(
+        r#"{{"input":{INPUTS},"output":{OUTPUTS},"forwardOnly":true,"neurons":[{{"type":"output","uuid":"output-0","bias":0.0,"squash":"IDENTITY"}}],"synapses":[{{"fromUUID":"input-0","toUUID":"output-0","weight":{w0}}},{{"fromUUID":"input-1","toUUID":"output-0","weight":{w1}}}]}}"#
+    )
+}
+
+/// Build a `creatures/` + `data/` fixture pair under a fresh temp root.
+fn fixture(tag: &str, n_creatures: usize) -> (PathBuf, PathBuf, tempfile::TempDir) {
+    let root = tempfile::Builder::new()
+        .prefix(&format!("racing_stdio_{tag}_"))
+        .tempdir()
+        .expect("create temp root");
+    let creatures = root.path().join("creatures");
+    let data = root.path().join("data");
+    std::fs::create_dir_all(&creatures).expect("create creatures dir");
+    std::fs::create_dir_all(&data).expect("create data dir");
+    for i in 0..n_creatures {
+        std::fs::write(
+            creatures.join(format!("creature-{i:03}.json")),
+            // Creature 0 is closest to the ground truth below, so the racing
+            // policy in these tests has a stable best and stable losers.
+            linear_creature(0.4 + 0.4 * i as f32, 0.5),
+        )
+        .expect("write creature");
+    }
+    let mut file = std::fs::File::create(data.join("0.bin")).expect("create data file");
+    for r in 0..RECORDS {
+        let x0 = (r as f32 * 0.01).sin();
+        let x1 = (r as f32 * 0.017).cos();
+        let target = 0.4 * x0 + 0.5 * x1;
+        for v in [x0, x1, target] {
+            file.write_all(&v.to_le_bytes()).expect("write f32");
+        }
+    }
+    (creatures, data, root)
+}
+
+/// Score the directory without racing — the parity baseline.
+fn score_plain(creatures: &Path, data: &Path) -> BTreeMap<String, serde_json::Value> {
+    let out = Command::new(env!("CARGO_BIN_EXE_rust_scorer"))
+        .arg("--gpu")
+        .arg("off")
+        .arg(creatures)
+        .arg(data)
+        .env("NEAT_SCORER_READ_BYTES", RECORD_BYTES.to_string())
+        .output()
+        .expect("run plain directory scorer");
+    assert!(
+        out.status.success(),
+        "plain scorer failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("plain scorer emits a JSON map")
+}
+
+/// Outcome of one racing run.
+struct RaceRun {
+    status_success: bool,
+    stderr: String,
+    /// Parsed result map, when the run produced one.
+    results: Option<BTreeMap<String, serde_json::Value>>,
+    /// Chunk events observed on stdout.
+    events: Vec<serde_json::Value>,
+}
+
+/// Drive `--race-stdio`, answering each chunk event with `decide(event)`.
+///
+/// `decide` returns the verdict line to write, or `None` to close stdin (the
+/// protocol-fault case).
+fn race<F>(creatures: &Path, data: &Path, mut decide: F) -> RaceRun
+where
+    F: FnMut(&serde_json::Value) -> Option<String>,
+{
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rust_scorer"))
+        .arg("--gpu")
+        .arg("off")
+        .arg("--race-stdio")
+        .arg(creatures)
+        .arg(data)
+        .env("NEAT_SCORER_READ_BYTES", RECORD_BYTES.to_string())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn racing scorer");
+
+    let mut stdin = Some(child.stdin.take().expect("racing stdin"));
+    let stdout = BufReader::new(child.stdout.take().expect("racing stdout"));
+
+    let mut events = Vec::new();
+    let mut tail = String::new();
+    for line in stdout.lines() {
+        let line = line.expect("read racing stdout line");
+        if line.starts_with("{\"racing\"") {
+            let event: serde_json::Value =
+                serde_json::from_str(&line).expect("chunk event is one JSON object");
+            let verdict = decide(&event);
+            events.push(event);
+            match verdict {
+                // `None` closes the verdict stream — the protocol-fault case.
+                None => stdin = None,
+                Some(reply) => {
+                    if let Some(pipe) = stdin.as_mut() {
+                        // A scorer that has already stopped reading makes this
+                        // write fail; that is the run ending, not a test fault.
+                        if writeln!(pipe, "{reply}").is_err() || pipe.flush().is_err() {
+                            stdin = None;
+                        }
+                    }
+                }
+            }
+        } else {
+            tail.push_str(&line);
+            tail.push('\n');
+        }
+    }
+    drop(stdin);
+    let out = child.wait_with_output().expect("await racing scorer");
+    RaceRun {
+        status_success: out.status.success(),
+        stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        results: serde_json::from_str(tail.trim()).ok(),
+        events,
+    }
+}
+
+fn error_of(results: &BTreeMap<String, serde_json::Value>, key: &str) -> f64 {
+    results[key]["error"].as_f64().expect("error is a number")
+}
+
+fn record_count_of(results: &BTreeMap<String, serde_json::Value>, key: &str) -> u64 {
+    results[key]["recordCount"]
+        .as_u64()
+        .expect("recordCount is an integer")
+}
+
+#[test]
+fn continue_every_chunk_reproduces_plain_directory_scores() {
+    let (creatures, data, _root) = fixture("parity", 3);
+    let baseline = score_plain(&creatures, &data);
+    let run = race(&creatures, &data, |_| {
+        Some("{\"verdict\":\"continue\"}".to_string())
+    });
+    assert!(run.status_success, "racing run failed: {}", run.stderr);
+    assert!(!run.events.is_empty(), "no chunk events were published");
+    let raced = run.results.expect("racing run emits a result map");
+    assert_eq!(raced.len(), baseline.len());
+    for (key, value) in &baseline {
+        assert_eq!(
+            raced[key]["error"], value["error"],
+            "error for {key} must be bit-identical to the non-racing sweep"
+        );
+        assert_eq!(
+            raced[key]["score"], value["score"],
+            "score for {key} must be bit-identical to the non-racing sweep"
+        );
+        assert_eq!(raced[key]["recordCount"], value["recordCount"]);
+    }
+}
+
+#[test]
+fn chunk_events_carry_the_running_partials_for_active_creatures() {
+    let (creatures, data, _root) = fixture("events", 2);
+    let run = race(&creatures, &data, |_| {
+        Some("{\"verdict\":\"continue\"}".to_string())
+    });
+    assert!(run.status_success, "racing run failed: {}", run.stderr);
+    let first = &run.events[0];
+    assert_eq!(first["racing"], "chunk");
+    assert_eq!(first["chunk"], 1);
+    let partials = first["partials"].as_array().expect("partials array");
+    assert_eq!(partials.len(), 2, "both creatures are active on chunk 1");
+    for p in partials {
+        assert!(p["key"].as_str().expect("key").starts_with("creature-"));
+        assert!(p["partialError"].as_f64().expect("partialError") >= 0.0);
+        assert!(p["recordsScored"].as_u64().expect("recordsScored") >= 1);
+    }
+    // Records scored must grow monotonically as the sweep advances.
+    let last = run.events.last().expect("at least one event");
+    let first_records = partials[0]["recordsScored"].as_u64().unwrap();
+    let last_records = last["partials"][0]["recordsScored"].as_u64().unwrap();
+    assert!(
+        last_records > first_records,
+        "recordsScored must advance across chunks ({first_records} -> {last_records})"
+    );
+}
+
+#[test]
+fn aborting_a_creature_freezes_it_at_its_partial_record_count() {
+    let (creatures, data, _root) = fixture("abort", 3);
+    let baseline = score_plain(&creatures, &data);
+    let mut aborted_at: Option<u64> = None;
+    let run = race(&creatures, &data, |event| {
+        let partials = event["partials"].as_array().expect("partials");
+        // Abandon the worst creature ("creature-002") on the first chunk only.
+        if aborted_at.is_none() {
+            let victim = partials
+                .iter()
+                .find(|p| p["key"] == "creature-002")
+                .expect("victim present on chunk 1");
+            aborted_at = Some(victim["recordsScored"].as_u64().unwrap());
+            let index = victim["index"].as_u64().unwrap();
+            return Some(format!("{{\"verdict\":\"abort\",\"creatures\":[{index}]}}"));
+        }
+        assert!(
+            partials.iter().all(|p| p["key"] != "creature-002"),
+            "an abandoned creature must not appear in later chunk events"
+        );
+        Some("{\"verdict\":\"continue\"}".to_string())
+    });
+    assert!(run.status_success, "racing run failed: {}", run.stderr);
+    let raced = run.results.expect("racing run emits a result map");
+    let frozen_at = aborted_at.expect("the victim was abandoned");
+
+    assert_eq!(
+        record_count_of(&raced, "creature-002"),
+        frozen_at,
+        "the abandoned creature freezes at the records it had scored"
+    );
+    assert!(
+        record_count_of(&raced, "creature-002") < record_count_of(&baseline, "creature-002"),
+        "the abandoned creature must not be scored over the whole corpus"
+    );
+    for survivor in ["creature-000", "creature-001"] {
+        assert_eq!(
+            error_of(&raced, survivor),
+            error_of(&baseline, survivor),
+            "{survivor} was never abandoned and keeps its exact full-corpus error"
+        );
+        assert_eq!(
+            record_count_of(&raced, survivor),
+            record_count_of(&baseline, survivor)
+        );
+    }
+}
+
+#[test]
+fn abort_all_stops_the_sweep_for_every_creature() {
+    let (creatures, data, _root) = fixture("abortall", 2);
+    let baseline = score_plain(&creatures, &data);
+    let run = race(&creatures, &data, |_| {
+        Some("{\"verdict\":\"abortAll\"}".to_string())
+    });
+    assert!(run.status_success, "racing run failed: {}", run.stderr);
+    assert_eq!(run.events.len(), 1, "abortAll stops after the first chunk");
+    let raced = run.results.expect("racing run emits a result map");
+    for key in raced.keys() {
+        assert!(
+            record_count_of(&raced, key) < record_count_of(&baseline, key),
+            "{key} must freeze mid-corpus under abortAll"
+        );
+    }
+}
+
+#[test]
+fn a_closed_verdict_stream_exits_non_zero() {
+    let (creatures, data, _root) = fixture("closed", 2);
+    let run = race(&creatures, &data, |_| None);
+    assert!(
+        !run.status_success,
+        "a closed verdict stream must fail loud, not silently full-score"
+    );
+    assert!(
+        run.stderr.contains("verdict stream closed"),
+        "stderr must name the protocol fault, got: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a_malformed_verdict_exits_non_zero() {
+    let (creatures, data, _root) = fixture("malformed", 2);
+    let run = race(&creatures, &data, |_| Some("{\"verdict\":42}".to_string()));
+    assert!(!run.status_success, "a malformed verdict must fail loud");
+    assert!(
+        run.stderr.contains("unparseable verdict"),
+        "stderr must name the protocol fault, got: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn race_stdio_rejects_a_single_creature_file() {
+    let (creatures, data, _root) = fixture("single", 1);
+    let creature_file = creatures.join("creature-000.json");
+    let out = Command::new(env!("CARGO_BIN_EXE_rust_scorer"))
+        .arg("--gpu")
+        .arg("off")
+        .arg("--race-stdio")
+        .arg(&creature_file)
+        .arg(&data)
+        .output()
+        .expect("run scorer");
+    assert!(!out.status.success(), "a file target must be rejected");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--race-stdio requires a creatures directory"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn race_stdio_rejects_gpu_on() {
+    let (creatures, data, _root) = fixture("gpuon", 2);
+    let out = Command::new(env!("CARGO_BIN_EXE_rust_scorer"))
+        .arg("--gpu")
+        .arg("on")
+        .arg("--race-stdio")
+        .arg(&creatures)
+        .arg(&data)
+        .output()
+        .expect("run scorer");
+    assert!(!out.status.success(), "--gpu on must be rejected");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--race-stdio has no GPU kernel"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn help_advertises_race_stdio_so_callers_can_probe_for_it() {
+    let out = Command::new(env!("CARGO_BIN_EXE_rust_scorer"))
+        .arg("--help")
+        .output()
+        .expect("run scorer --help");
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        help.contains("--race-stdio"),
+        "--help must advertise --race-stdio for capability probing, got:\n{help}"
+    );
+}


### PR DESCRIPTION
Fixes the root cause of stSoftwareAU/NEAT-AI#3928 here, in the dependency's own repo.

The early-exit hook is a library entrypoint, so subprocess callers (every NEAT-AI deployment) could never register a callback; --race-stdio exposes it over a line protocol with bit-identical full-score parity, consumed by NEAT-AI#3928.

**Head:** `issue-308-race-stdio-cli` → **base:** `Develop`

Raised by the Vibe Coder worker on behalf of the run working stSoftwareAU/NEAT-AI#3928: the agent pushed the branch, and the worker opened this PR after validating the target as an internal, reachable `stSoftwareAU/*` repository (Issue #182).

**Do not auto-merge on the worker's behalf** — releasing this dependency is a human decision.