### PR TITLE
Check the Semgrep container pin for bump-ability (Issue #602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,22 @@ section to the released version with its date.
 
 ### Added
 
+- **The Semgrep container pin is checked for bump-ability, not just
+  immutability (Issue #602).** `.github/workflows/semgrep.yml` pins the scanner
+  by bare `@sha256:` digest with no tag beside it. The digest is immutable, but
+  Renovate's `docker` manager and Dependabot both resolve a container bump from
+  the **tag** component, so a tagless pin can never be bumped automatically — it
+  silently freezes at whatever the workflow comment records.
+  `scripts/check-semgrep-workflow.sh` now accepts the canonical
+  `semgrep/semgrep:<version>@sha256:<digest>` form (which it previously
+  **rejected** as an unpinned tag), names the tag it found, rejects
+  `:latest@sha256:…`, and reports a tagless digest as a `WARN` line on every
+  gate run. The `.github/workflows/` edit itself needs a maintainer — the
+  automation worker's credentials carry no `workflow` OAuth scope (see
+  [Human escalation](./CONTRIBUTING.md#human-escalation)). New shared `warn`
+  primitive in `scripts/lib/check-harness.sh` for exactly this class of
+  deficiency: visible on stderr, never folded into a silent pass.
+
 - **`--race-stdio`: the Issue #308 early-exit hook, reachable from a
   subprocess caller (NEAT-AI#3928).** `score_from_creature_dir_with_early_exit`
   is a library entrypoint, so the callback that decides which creatures to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.6"
+version = "0.10.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.74"
+version = "1.1.75"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -1762,7 +1762,14 @@ scanner. The workflow is validated by `scripts/check-gitleaks-workflow.sh`
 A standalone Semgrep SAST workflow (`.github/workflows/semgrep.yml`,
 Issue #47) runs the official `semgrep/semgrep` container — pinned by
 `sha256:` digest (Issue #102) — on every pull request against any branch.
-The container path is the functional equivalent of the
+The canonical pin is `semgrep/semgrep:<version>@sha256:<digest>`: the
+digest is what makes the image immutable, and the release tag beside it
+is what Renovate's `docker` manager and Dependabot resolve a bump from
+(Issue #602). A bare `@sha256:` digest with no tag is immutable but
+**un-bumpable** — no updater has a version component to compare against —
+so the validator reports it as a `WARN` line rather than a failure, and
+`:latest@sha256:…` is rejected outright because a floating tag resolves
+to nothing useful. The container path is the functional equivalent of the
 `semgrep/semgrep-action` GitHub Action; both consume
 `SEMGREP_APP_TOKEN` from repo secrets and execute
 `semgrep ci --config p/default`. The workflow is validated by

--- a/docs/archive/pr-summaries/pr-summary-602.md
+++ b/docs/archive/pr-summaries/pr-summary-602.md
@@ -1,0 +1,109 @@
+# Check the Semgrep container pin for bump-ability (Issue #602)
+
+## Summary
+
+`.github/workflows/semgrep.yml` pins the scanner container to a bare
+`semgrep/semgrep@sha256:…` digest with no tag beside it. The digest is
+immutable, but Renovate's `docker` manager and Dependabot both resolve a
+container bump from the **tag** component — with no tag there is nothing to
+resolve, so the pin silently freezes at whatever the workflow comment records
+(Semgrep v1.86.0, frozen 2026-05-18) and no later scan flags it as behind.
+
+The one-line YAML edit that fixes it **cannot be made by this worker**: the
+automation credentials carry no `workflow` OAuth scope, so both `git push` and
+the Contents API refuse any change under `.github/workflows/` (evidence below).
+Per [Human escalation](../../../CONTRIBUTING.md#human-escalation) this PR lands
+everything that does *not* need the workflow change, and the maintainer edit is
+spelled out below and on the issue.
+
+What landed:
+
+- **`scripts/check-semgrep-workflow.sh` now accepts the canonical
+  `semgrep/semgrep:<version>@sha256:<digest>` pin.** It previously **rejected**
+  that exact form as "not pinned by digest" (the tag branch matched first), so
+  the repository's own gate blocked the fix the issue asks for. The guard now
+  names the tag it found, rejects `:latest@sha256:…` (a floating tag resolves to
+  nothing an updater can compare), and reports a tagless digest as a `WARN` line
+  on every gate run — visible, never folded into a silent pass.
+- **New shared `warn` primitive in `scripts/lib/check-harness.sh`** — stderr,
+  `EXIT_CODE` untouched — for a deficiency whose fix is blocked outside the
+  repository. The `ok`/`fail` protocol is owned by the harness, so the third
+  reporting level belongs there rather than being open-coded in one validator.
+- README and CHANGELOG record the canonical pin shape and why the tag matters.
+
+**Maintainer action required** — one line in `.github/workflows/semgrep.yml:53`:
+
+```yaml
+      image: semgrep/semgrep:1.86.0@sha256:a9ea2d5621c29d815d90c2a3b2f9571da8972ef4ff855c9e4902681730240e35
+```
+
+The digest is unchanged, so the image stays byte-for-byte identical; only the
+resolvable version tag is added. (Bumping to a newer Semgrep release at the same
+time is fine — update the tag, the digest and the version-label comment in
+lockstep, per the workflow's own bump protocol.) The `WARN` line clears and the
+guard reports `… carries the bump-able version tag ':1.86.0'` the moment that
+edit lands.
+
+Closes #602.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified by the BATS
+suites and by running the validator against the shipped workflow.
+
+Push refusal, reproduced twice on this run (this is why the YAML edit is not in
+the diff):
+
+```text
+! [remote rejected] … (refusing to allow an OAuth App to create or update
+  workflow `.github/workflows/semgrep.yml` without `workflow` scope)
+```
+
+The Contents API refuses the same write (HTTP 404 on
+`PUT …/contents/.github/workflows/semgrep.yml`) while an identical `PUT` to a
+non-workflow path on the same probe branch succeeds — so the refusal is scope-
+specific, not a missing file or a bad request. The probe branch was deleted.
+
+Validator against the shipped workflow today:
+
+```text
+OK   …/semgrep.yml: Semgrep container image is pinned by digest (semgrep/semgrep@sha256:<digest>)
+WARN …/semgrep.yml: Semgrep container image digest carries no version tag — Renovate's
+     docker manager and Dependabot resolve bumps from the tag component, so this pin can
+     never be bumped automatically; use semgrep/semgrep:<version>@sha256:<digest> (Issue #602)
+```
+
+```mermaid
+flowchart LR
+    A["semgrep/semgrep<br/>(bare)"] --> X[FAIL: not pinned]
+    B["semgrep/semgrep:latest"] --> X
+    C["semgrep/semgrep:1.86.0<br/>(tag only, mutable)"] --> X
+    D["semgrep/semgrep:latest@sha256:…"] --> X2["FAIL: floating tag,<br/>nothing to resolve"]
+    E["semgrep/semgrep@sha256:…<br/>(tagless digest — today)"] --> W["OK + WARN:<br/>immutable but un-bumpable"]
+    F["semgrep/semgrep:1.86.0@sha256:…<br/>(canonical)"] --> Y["OK: immutable and<br/>bump-able"]
+```
+
+## Test Plan
+
+- `tests/scripts/semgrep_workflow.bats` — the container fixture now uses the
+  canonical `:<tag>@sha256:<digest>` pin (the old fixture, and every mutation
+  test derived from it, would have failed against the new rule), plus three new
+  cases:
+  - `names the bump-able version tag beside the digest (issue #602)` — passes and
+    reports the tag, with no `WARN`.
+  - `warns but still passes when the digest pin carries no version tag (issue #602)`
+    — exit 0, `WARN`, no `FAIL`.
+  - `fails when the tag beside the digest is :latest (issue #602)` — non-zero.
+  - Existing cases (bare name, `:latest`, tag-only, malformed digest, missing
+    entry point, `--config`, token wiring, rationale comment) all still fail as
+    before; `real repository semgrep workflow satisfies every rule` still passes.
+- `tests/scripts/check_harness.bats` —
+  `warn reports on stderr without flipping the exit code` drives the new
+  primitive through a throwaway validator and asserts the stream and exit code.
+- Full local suite: `bats tests/scripts` — 629 pass. The one failure,
+  `living docs contain no box-drawing ASCII diagrams`, is **pre-existing** and
+  environmental: it fails identically on the unmodified base commit because this
+  container has no `en_US.UTF-8` locale (the test warns
+  `setlocale: LC_ALL: cannot change locale`). CI provides the locale.
+- `shellcheck -x -s bash` clean on both changed scripts; `markdownlint-cli2`
+  clean on the changed Markdown.

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.74"
+version = "1.1.75"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/scripts/check-semgrep-workflow.sh
+++ b/scripts/check-semgrep-workflow.sh
@@ -2,11 +2,17 @@
 # Validate the Semgrep SAST scanning workflow (Issue #47).
 #
 # Two configurations are accepted as functionally equivalent:
-#   1. The official container approach — `container: image: semgrep/semgrep@sha256:<digest>`
-#      with an explicit `semgrep ci|scan --config <ruleset>` invocation. This
-#      is upstream's recommended PR-scan path. Pin by digest, not tag —
-#      Docker tags are mutable; only the `sha256:<64-hex>` digest is immutable
-#      (Issue #102).
+#   1. The official container approach —
+#      `container: image: semgrep/semgrep:<version>@sha256:<digest>` with an
+#      explicit `semgrep ci|scan --config <ruleset>` invocation. This is
+#      upstream's recommended PR-scan path. The `sha256:<64-hex>` digest is
+#      what pins the build — Docker tags are mutable, so a tag alone is not a
+#      pin (Issue #102) — and the release tag sits beside it so Renovate's
+#      `docker` manager and Dependabot have a version component to resolve a
+#      bump from (Issue #602). A bare digest with no tag is immutable but
+#      un-bumpable: it is reported as a WARN, not a FAIL, because only a
+#      maintainer can edit `.github/workflows/` (CONTRIBUTING "Human
+#      escalation").
 #   2. The `semgrep/semgrep-action@vN` GitHub Action — pinned to a numeric
 #      major version so behaviour is reproducible.
 #
@@ -17,8 +23,9 @@
 #     to the Semgrep app dashboard. The token is consumed by both the
 #     container CLI (`semgrep ci`) and `semgrep/semgrep-action`.
 #   * Pin the entry point. Container images MUST use a `@sha256:<64-hex>`
-#     digest; bare names, `:latest`, and version tags are all rejected.
-#     The action ref must NOT be `master`/`main`.
+#     digest; bare names, `:latest`, and version tags on their own are all
+#     rejected, as is `:latest@sha256:<digest>` (a floating tag gives an
+#     updater nothing to resolve). The action ref must NOT be `master`/`main`.
 #   * Carry a comment block documenting the rationale and why the
 #     container path is equivalent to `semgrep/semgrep-action`.
 #
@@ -78,15 +85,26 @@ action_line="$(grep -nE 'uses:[[:space:]]*semgrep/semgrep-action@' "$WORKFLOW" |
 if [[ -n "$container_line" ]]; then
   # Container path. Image MUST be pinned by an immutable sha256 digest —
   # Docker tags are mutable so `:1.86.0` (or any tag) is not a real pin
-  # (Issue #102). Reject bare names, `:latest`, version tags, and malformed
-  # digests; only `semgrep/semgrep@sha256:<64-lowercase-hex>` passes.
-  if echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep@sha256:[0-9a-f]{64}([[:space:]]|$)'; then
+  # (Issue #102) — and SHOULD carry the release tag beside that digest so
+  # automated updaters can resolve a bump (Issue #602). Reject bare names,
+  # `:latest`, tag-only pins and malformed digests.
+  image_tag="$(echo "$container_line" |
+    sed -nE 's|.*image:[[:space:]]*semgrep/semgrep:([A-Za-z0-9._-]+)@sha256:[0-9a-f]{64}([[:space:]].*)?$|\1|p' |
+    head -n 1)"
+  if [[ -n "$image_tag" ]]; then
+    if [[ "$image_tag" == "latest" ]]; then
+      fail "Semgrep container image tag beside the digest is ':latest' — a floating tag gives Renovate/Dependabot nothing to resolve; pin the release version (Issue #602)"
+    else
+      ok "Semgrep container image is pinned by digest and carries the bump-able version tag ':$image_tag' (Issue #602)"
+    fi
+  elif echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep@sha256:[0-9a-f]{64}([[:space:]]|$)'; then
     ok "Semgrep container image is pinned by digest (semgrep/semgrep@sha256:<digest>)"
+    warn "Semgrep container image digest carries no version tag — Renovate's docker manager and Dependabot resolve bumps from the tag component, so this pin can never be bumped automatically; use semgrep/semgrep:<version>@sha256:<digest> (Issue #602)"
   elif echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep:[A-Za-z0-9._-]+' \
     && ! echo "$container_line" | grep -qE 'image:[[:space:]]*semgrep/semgrep:latest'; then
-    fail "Semgrep container image is not pinned by digest — Docker tags are mutable; use semgrep/semgrep@sha256:<64-hex> (Issue #102)"
+    fail "Semgrep container image is not pinned by digest — Docker tags are mutable; use semgrep/semgrep:<version>@sha256:<64-hex> (Issue #102)"
   else
-    fail "Semgrep container image is not pinned by digest — use semgrep/semgrep@sha256:<64-hex>, not bare or :latest"
+    fail "Semgrep container image is not pinned by digest — use semgrep/semgrep:<version>@sha256:<64-hex>, not bare or :latest"
   fi
 elif [[ -n "$action_line" ]]; then
   # Action path. Ref must be a vN-style pin (numeric major component).
@@ -96,7 +114,7 @@ elif [[ -n "$action_line" ]]; then
     fail "semgrep/semgrep-action ref is not a numeric vN pin — branch refs disallowed"
   fi
 else
-  fail "no Semgrep entry point — expect either 'image: semgrep/semgrep:<tag>' or 'uses: semgrep/semgrep-action@vN'"
+  fail "no Semgrep entry point — expect either 'image: semgrep/semgrep:<version>@sha256:<digest>' or 'uses: semgrep/semgrep-action@vN'"
 fi
 
 # 4. semgrep CLI invocation (container path) must include --config.

--- a/scripts/lib/check-harness.sh
+++ b/scripts/lib/check-harness.sh
@@ -15,6 +15,10 @@
 #     it empty when the message names its own subject;
 #   * end with `exit "$EXIT_CODE"`.
 #
+# Reporting primitives: `ok` (satisfied rule, stdout), `fail` (violated rule,
+# stderr, EXIT_CODE=1) and `warn` (deficiency that cannot be failed yet,
+# stderr, EXIT_CODE untouched).
+#
 # Changing the CLI contract — a new flag, machine-readable output, a different
 # exit-code convention — is a single edit here rather than ~30 copy-pasted ones.
 
@@ -111,6 +115,16 @@ ok() {
 fail() {
   echo "FAIL ${CHECK_SUBJECT:+$CHECK_SUBJECT: }$*" >&2
   EXIT_CODE=1
+}
+
+# warn <message...> — record a deficiency the validator cannot fail on yet,
+# on stderr, without touching EXIT_CODE. Reserved for a rule whose fix is
+# blocked outside the repository (e.g. `.github/workflows/` YAML the automation
+# worker has no `workflow` OAuth scope to push, CONTRIBUTING "Human
+# escalation"). The deficiency stays visible on every gate run instead of
+# disappearing into a silent pass.
+warn() {
+  echo "WARN ${CHECK_SUBJECT:+$CHECK_SUBJECT: }$*" >&2
 }
 
 # check_subject <subject> — set the file each subsequent `ok`/`fail` line is

--- a/tests/scripts/check_harness.bats
+++ b/tests/scripts/check_harness.bats
@@ -184,3 +184,23 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"TARGET=[]"* ]]
 }
+
+@test "warn reports on stderr without flipping the exit code" {
+  script="$TMP_DIR/warning.sh"
+  cat >"$script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "$HARNESS"
+usage() { echo "Usage: warning.sh"; }
+CHECK_SUBJECT="subject"
+ok "rule holds"
+warn "deficiency that cannot be failed yet"
+exit "\$EXIT_CODE"
+EOF
+  chmod +x "$script"
+  run --separate-stderr "$script"
+  [ "$status" -eq 0 ]
+  [[ "$stderr" == *"WARN subject: deficiency that cannot be failed yet"* ]]
+  [[ "$output" == *"OK   subject: rule holds"* ]]
+  [[ "$output" != *"WARN"* ]]
+}

--- a/tests/scripts/semgrep_workflow.bats
+++ b/tests/scripts/semgrep_workflow.bats
@@ -22,6 +22,9 @@ teardown() {
 # Placeholder digest used by the synthetic fixtures below. The validator only
 # checks the digest shape (sha256:<64-hex>), so any 64-hex string is fine.
 FIXTURE_DIGEST="sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+# Release tag pinned beside that digest. Renovate's `docker` manager and
+# Dependabot resolve container bumps from the tag component (Issue #602).
+FIXTURE_TAG="1.86.0"
 
 # Canonical hardened workflow using the container path. Failure tests mutate
 # this fixture to drop or break one rule at a time.
@@ -48,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Semgrep v1.86.0, frozen 2026-05-18.
-      image: semgrep/semgrep@${FIXTURE_DIGEST}
+      image: semgrep/semgrep:${FIXTURE_TAG}@${FIXTURE_DIGEST}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -96,6 +99,33 @@ EOF
   [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
 }
 
+@test "names the bump-able version tag beside the digest (issue #602)" {
+  write_container_workflow "$TMP_WF/semgrep.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pinned by digest"* ]]
+  [[ "$output" == *"$FIXTURE_TAG"* ]]
+  [[ "$output" != *"WARN"* ]]
+}
+
+@test "warns but still passes when the digest pin carries no version tag (issue #602)" {
+  write_container_workflow "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep:${FIXTURE_TAG}@${FIXTURE_DIGEST}|semgrep/semgrep@${FIXTURE_DIGEST}|" "$TMP_WF/semgrep.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARN"* ]]
+  [[ "$output" == *"no version tag"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "fails when the tag beside the digest is :latest (issue #602)" {
+  write_container_workflow "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep:${FIXTURE_TAG}@|semgrep/semgrep:latest@|" "$TMP_WF/semgrep.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"':latest'"* ]]
+}
+
 @test "passes on the semgrep/semgrep-action fixture" {
   write_action_workflow "$TMP_WF/semgrep.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
@@ -139,7 +169,7 @@ PY
 
 @test "fails when the container image is unpinned (no digest)" {
   write_container_workflow "$TMP_WF/semgrep.yml"
-  sed -i.bak "s|semgrep/semgrep@${FIXTURE_DIGEST}|semgrep/semgrep|" "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep:${FIXTURE_TAG}@${FIXTURE_DIGEST}|semgrep/semgrep|" "$TMP_WF/semgrep.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"container image is not pinned"* ]]
@@ -147,7 +177,7 @@ PY
 
 @test "fails when the container image is pinned to :latest" {
   write_container_workflow "$TMP_WF/semgrep.yml"
-  sed -i.bak "s|semgrep/semgrep@${FIXTURE_DIGEST}|semgrep/semgrep:latest|" "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep:${FIXTURE_TAG}@${FIXTURE_DIGEST}|semgrep/semgrep:latest|" "$TMP_WF/semgrep.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"container image is not pinned"* ]]
@@ -155,7 +185,7 @@ PY
 
 @test "fails when the container image is pinned to a mutable tag (issue #102)" {
   write_container_workflow "$TMP_WF/semgrep.yml"
-  sed -i.bak "s|semgrep/semgrep@${FIXTURE_DIGEST}|semgrep/semgrep:1.86.0|" "$TMP_WF/semgrep.yml"
+  sed -i.bak "s|semgrep/semgrep:${FIXTURE_TAG}@${FIXTURE_DIGEST}|semgrep/semgrep:1.86.0|" "$TMP_WF/semgrep.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/semgrep.yml"
   [ "$status" -ne 0 ]
   [[ "$output" == *"container image is not pinned by digest"* ]]


### PR DESCRIPTION
# Check the Semgrep container pin for bump-ability (Issue #602)

## Summary

`.github/workflows/semgrep.yml` pins the scanner container to a bare
`semgrep/semgrep@sha256:…` digest with no tag beside it. The digest is
immutable, but Renovate's `docker` manager and Dependabot both resolve a
container bump from the **tag** component — with no tag there is nothing to
resolve, so the pin silently freezes at whatever the workflow comment records
(Semgrep v1.86.0, frozen 2026-05-18) and no later scan flags it as behind.

The one-line YAML edit that fixes it **cannot be made by this worker**: the
automation credentials carry no `workflow` OAuth scope, so both `git push` and
the Contents API refuse any change under `.github/workflows/` (evidence below).
Per [Human escalation](../../../CONTRIBUTING.md#human-escalation) this PR lands
everything that does *not* need the workflow change, and the maintainer edit is
spelled out below and on the issue.

What landed:

- **`scripts/check-semgrep-workflow.sh` now accepts the canonical
  `semgrep/semgrep:<version>@sha256:<digest>` pin.** It previously **rejected**
  that exact form as "not pinned by digest" (the tag branch matched first), so
  the repository's own gate blocked the fix the issue asks for. The guard now
  names the tag it found, rejects `:latest@sha256:…` (a floating tag resolves to
  nothing an updater can compare), and reports a tagless digest as a `WARN` line
  on every gate run — visible, never folded into a silent pass.
- **New shared `warn` primitive in `scripts/lib/check-harness.sh`** — stderr,
  `EXIT_CODE` untouched — for a deficiency whose fix is blocked outside the
  repository. The `ok`/`fail` protocol is owned by the harness, so the third
  reporting level belongs there rather than being open-coded in one validator.
- README and CHANGELOG record the canonical pin shape and why the tag matters.

**Maintainer action required** — one line in `.github/workflows/semgrep.yml:53`:

```yaml
      image: semgrep/semgrep:1.86.0@sha256:a9ea2d5621c29d815d90c2a3b2f9571da8972ef4ff855c9e4902681730240e35
```

The digest is unchanged, so the image stays byte-for-byte identical; only the
resolvable version tag is added. (Bumping to a newer Semgrep release at the same
time is fine — update the tag, the digest and the version-label comment in
lockstep, per the workflow's own bump protocol.) The `WARN` line clears and the
guard reports `… carries the bump-able version tag ':1.86.0'` the moment that
edit lands.

Closes #602.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified by the BATS
suites and by running the validator against the shipped workflow.

Push refusal, reproduced twice on this run (this is why the YAML edit is not in
the diff):

```text
! [remote rejected] … (refusing to allow an OAuth App to create or update
  workflow `.github/workflows/semgrep.yml` without `workflow` scope)
```

The Contents API refuses the same write (HTTP 404 on
`PUT …/contents/.github/workflows/semgrep.yml`) while an identical `PUT` to a
non-workflow path on the same probe branch succeeds — so the refusal is scope-
specific, not a missing file or a bad request. The probe branch was deleted.

Validator against the shipped workflow today:

```text
OK   …/semgrep.yml: Semgrep container image is pinned by digest (semgrep/semgrep@sha256:<digest>)
WARN …/semgrep.yml: Semgrep container image digest carries no version tag — Renovate's
     docker manager and Dependabot resolve bumps from the tag component, so this pin can
     never be bumped automatically; use semgrep/semgrep:<version>@sha256:<digest> (Issue #602)
```

```mermaid
flowchart LR
    A["semgrep/semgrep<br/>(bare)"] --> X[FAIL: not pinned]
    B["semgrep/semgrep:latest"] --> X
    C["semgrep/semgrep:1.86.0<br/>(tag only, mutable)"] --> X
    D["semgrep/semgrep:latest@sha256:…"] --> X2["FAIL: floating tag,<br/>nothing to resolve"]
    E["semgrep/semgrep@sha256:…<br/>(tagless digest — today)"] --> W["OK + WARN:<br/>immutable but un-bumpable"]
    F["semgrep/semgrep:1.86.0@sha256:…<br/>(canonical)"] --> Y["OK: immutable and<br/>bump-able"]
```

## Test Plan

- `tests/scripts/semgrep_workflow.bats` — the container fixture now uses the
  canonical `:<tag>@sha256:<digest>` pin (the old fixture, and every mutation
  test derived from it, would have failed against the new rule), plus three new
  cases:
  - `names the bump-able version tag beside the digest (issue #602)` — passes and
    reports the tag, with no `WARN`.
  - `warns but still passes when the digest pin carries no version tag (issue #602)`
    — exit 0, `WARN`, no `FAIL`.
  - `fails when the tag beside the digest is :latest (issue #602)` — non-zero.
  - Existing cases (bare name, `:latest`, tag-only, malformed digest, missing
    entry point, `--config`, token wiring, rationale comment) all still fail as
    before; `real repository semgrep workflow satisfies every rule` still passes.
- `tests/scripts/check_harness.bats` —
  `warn reports on stderr without flipping the exit code` drives the new
  primitive through a throwaway validator and asserts the stream and exit code.
- Full local suite: `bats tests/scripts` — 629 pass. The one failure,
  `living docs contain no box-drawing ASCII diagrams`, is **pre-existing** and
  environmental: it fails identically on the unmodified base commit because this
  container has no `en_US.UTF-8` locale (the test warns
  `setlocale: LC_ALL: cannot change locale`). CI provides the locale.
- `shellcheck -x -s bash` clean on both changed scripts; `markdownlint-cli2`
  clean on the changed Markdown.



## Milestone
This PR is part of the **Scan 20260907** milestone and targets the `milestone/scan-20260907` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mtqz0nxf-48a61b`<!-- vibe-worker-issue-602 -->