### PR TITLE
Build against neat-core 0.13.0: read CompiledNetwork through its accessors (Issue #605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ section to the released version with its date.
 
 ### Fixed
 
+- **Builds against neat-core 0.13.0 — `CompiledNetwork`'s fields went private
+  (neat-core #625 / #633; GRQ #4724).** neat-core 0.12.0 made every
+  `CompiledNetwork` field private behind borrow-only accessors (neat-core #625 /
+  #633) and 0.13.0 followed the same day. Every GRQ host builds the Rust
+  consumers from the sibling neat-core at head, so `rust_scorer` failed to
+  compile fleet-wide within minutes and, with no fallback engine, the fleet
+  stopped scoring ([GRQ
+  #4724](https://github.com/stSoftwareAU/GRQ/issues/4724)). `cargo build -p
+  rust_scorer` failed with 11 × `E0616` at `gpu/forward_mse_batched.rs`. The GPU
+  upload path and the fixtures/tests now read `num_inputs()` / `num_neurons()` /
+  `neurons()` / `synapses()` through the accessors; the tests that used to write
+  into a compiled fixture rebuild it through `CompiledNetwork::from_parts`, the
+  above-the-cap case is a real 257-neuron creature, and the now-unconstructible
+  "absurd neuron count" test is replaced by a pin that neat-core's
+  `MAX_NODE_COUNT` sits below `MAX_NEURONS_ABSOLUTE`.
+  `neat-core.expected-version` acknowledges 0.13.0.
+
 - **External termination names itself instead of dying silently (Issue #591).**
   A production sampler run hit its 3-hour per-task wall-clock cap mid-batch; the
   fleet supervisor signalled the process group, `rust_scorer` died on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,21 +18,18 @@ section to the released version with its date.
 ### Fixed
 
 - **Builds against neat-core 0.13.0 — `CompiledNetwork`'s fields went private
-  (neat-core #625 / #633; GRQ #4724).** neat-core 0.12.0 made every
-  `CompiledNetwork` field private behind borrow-only accessors (neat-core #625 /
-  #633) and 0.13.0 followed the same day. Every GRQ host builds the Rust
-  consumers from the sibling neat-core at head, so `rust_scorer` failed to
-  compile fleet-wide within minutes and, with no fallback engine, the fleet
-  stopped scoring ([GRQ
-  #4724](https://github.com/stSoftwareAU/GRQ/issues/4724)). `cargo build -p
-  rust_scorer` failed with 11 × `E0616` at `gpu/forward_mse_batched.rs`. The GPU
-  upload path and the fixtures/tests now read `num_inputs()` / `num_neurons()` /
-  `neurons()` / `synapses()` through the accessors; the tests that used to write
-  into a compiled fixture rebuild it through `CompiledNetwork::from_parts`, the
-  above-the-cap case is a real 257-neuron creature, and the now-unconstructible
-  "absurd neuron count" test is replaced by a pin that neat-core's
-  `MAX_NODE_COUNT` sits below `MAX_NEURONS_ABSOLUTE`.
-  `neat-core.expected-version` acknowledges 0.13.0.
+  (neat-core #625 / #633).** neat-core 0.12.0 made every `CompiledNetwork`
+  field private behind borrow-only accessors and 0.13.0 followed the same day.
+  Every production host builds `rust_scorer` from the sibling neat-core at
+  head, so the build failed fleet-wide with 11 × `E0616` at
+  `gpu/forward_mse_batched.rs` within minutes and, with no fallback engine,
+  the fleet stopped scoring. The GPU upload path and the fixtures/tests now
+  read `num_inputs()` / `num_neurons()` / `neurons()` / `synapses()` through
+  the accessors; the tests that used to write into a compiled fixture rebuild
+  it through `CompiledNetwork::from_parts`, the above-the-cap case is a real
+  257-neuron creature, and the now-unconstructible "absurd neuron count" test
+  is replaced by a pin that neat-core's `MAX_NODE_COUNT` sits below
+  `MAX_NEURONS_ABSOLUTE`. `neat-core.expected-version` acknowledges 0.13.0.
 
 - **External termination names itself instead of dying silently (Issue #591).**
   A production sampler run hit its 3-hour per-task wall-clock cap mid-batch; the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.6"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.74"
+version = "1.1.75"
 dependencies = [
  "bytemuck",
  "clap",

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -87,4 +87,18 @@
 # loads with every synapse intact, scores identically to the pre-#577 relay
 # workaround, and scores *differently* from the creature a `(from, to)`-keyed
 # loader is left holding.
-0.10.0
+#
+# 0.10.0 -> 0.13.0: acknowledge neat-core #633 (Issue #625, 0.12.0), which made
+# every `CompiledNetwork` field private behind borrow-only accessors so safe
+# code can no longer edit a validated network into an out-of-bounds SIMD read,
+# and 0.13.0 (#637, the security-scan milestone roll-up, no further API change
+# scorer names). rust_scorer read `num_inputs` / `num_neurons` / `neurons` /
+# `synapses` directly on its GPU upload path (`gpu/forward_mse_batched.rs`) and
+# in fixtures/tests; every read now goes through the `()` accessor, and the
+# tests that used to write into a compiled fixture rebuild it through
+# `CompiledNetwork::from_parts` instead. Unhandled, this bump took the whole
+# GRQ fleet down (GRQ#4724): every host builds rust_scorer from the sibling
+# neat-core at head, so the break was fleet-wide within minutes of merging.
+# Verified by `cargo clippy --all-targets -- -D warnings` and the full scorer
+# test suite against the sibling clone at 0.13.0 (59eb6e6).
+0.13.0

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.74"
+version = "1.1.75"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/dual_role_fixture.rs
+++ b/rust_scorer/src/dual_role_fixture.rs
@@ -401,7 +401,7 @@ mod tests {
         assert_eq!(creature.synapses.len(), 7);
         let net = compile_creature(&creature).expect("compile");
         assert_eq!(
-            net.synapses.len(),
+            net.synapses().len(),
             7,
             "compiling must drop no synapse — a (from, to)-keyed loader keeps only 5"
         );
@@ -412,12 +412,12 @@ mod tests {
         let creature = parse_creature_json(&dual_role_if_creature_json(&SPEC)).expect("parse");
         let net = compile_creature(&creature).expect("compile");
         let node = net
-            .neurons
+            .neurons()
             .iter()
             .find(|n| !n.is_constant && n.num_synapses == 6)
             .expect("the IF node reads six synapses");
         let start = node.start_synapse as usize;
-        let roles: Vec<SynapseType> = net.synapses[start..start + 6]
+        let roles: Vec<SynapseType> = net.synapses()[start..start + 6]
             .iter()
             .map(|s| SynapseType::from(s.synapse_type))
             .collect();

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -256,23 +256,23 @@ pub(crate) fn build_batched_network_data(
     let mut creatures = Vec::with_capacity(networks.len());
 
     for (creature_idx, net) in networks.iter().enumerate() {
-        if net.num_inputs != num_inputs {
+        if net.num_inputs() != num_inputs {
             return Err(GpuPrepareError::MismatchedShape);
         }
         // Issue #182: creatures above the 256 private-array cap are no longer
         // rejected — they run on the `forward_mse_scratch` kernel. Only an
         // absurd, almost-certainly-corrupt neuron count is refused.
-        if net.num_neurons > MAX_NEURONS_ABSOLUTE as usize {
+        if net.num_neurons() > MAX_NEURONS_ABSOLUTE as usize {
             return Err(GpuPrepareError::TooManyNeurons {
                 creature_idx,
-                num_neurons: net.num_neurons,
+                num_neurons: net.num_neurons(),
             });
         }
         let neuron_offset = neurons.len() as u32;
         let synapse_offset = synapses.len() as u32;
-        let num_non_inputs = net.neurons.len() as u32;
+        let num_non_inputs = net.neurons().len() as u32;
 
-        for n in &net.neurons {
+        for n in net.neurons() {
             // Constant neurons are hosted since Issue #312 (clamped bias,
             // synapses ignored), so they no longer force a CPU fallback. A
             // constant neuron's squash discriminant is irrelevant on the GPU —
@@ -289,7 +289,7 @@ pub(crate) fn build_batched_network_data(
                 is_constant: u32::from(n.is_constant),
             });
         }
-        for s in &net.synapses {
+        for s in net.synapses() {
             synapses.push(SynapseGpu {
                 weight: s.weight,
                 // neat-core #177 narrowed `SynapseData::from_index` to `u16`;
@@ -305,7 +305,7 @@ pub(crate) fn build_batched_network_data(
             neuron_offset,
             num_non_inputs,
             synapse_offset,
-            num_neurons: net.num_neurons as u32,
+            num_neurons: net.num_neurons() as u32,
         });
     }
 
@@ -996,7 +996,7 @@ pub(crate) fn directory_gpu_topology(networks: &[CompiledNetwork]) -> DirectoryG
     let mut has_private = false;
     let mut has_scratch = false;
     for net in networks {
-        if u32::try_from(net.num_neurons).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
+        if u32::try_from(net.num_neurons()).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
             has_scratch = true;
         } else {
             has_private = true;
@@ -1022,7 +1022,7 @@ pub(crate) fn directory_gpu_topology(networks: &[CompiledNetwork]) -> DirectoryG
 pub(crate) fn directory_pool_is_shallow(networks: &[CompiledNetwork]) -> bool {
     !networks.is_empty()
         && networks.iter().all(|net| {
-            let non_input = net.num_neurons.saturating_sub(net.num_inputs);
+            let non_input = net.num_neurons().saturating_sub(net.num_inputs());
             u32::try_from(non_input).unwrap_or(u32::MAX) <= MAX_SHALLOW_NON_INPUT_NEURONS
         })
 }
@@ -1053,7 +1053,7 @@ impl DirectoryGpuRunners {
         let mut scratch_orig: Vec<usize> = Vec::new();
 
         for (i, net) in networks.iter().enumerate() {
-            if u32::try_from(net.num_neurons).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
+            if u32::try_from(net.num_neurons()).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
                 scratch_orig.push(i);
                 scratch_nets.push(net.clone());
             } else {
@@ -1241,6 +1241,21 @@ mod tests {
     };
     use neat_core::creature::compile_creature;
     use neat_core::creature::parse_creature_json;
+    use neat_core::network::{NeuronData, SynapseData};
+
+    /// Issue #625 (neat-core 0.12.0): `CompiledNetwork`'s fields are private,
+    /// so a fixture is edited by rebuilding it from its parts through the one
+    /// validated constructor, not by writing into a compiled value.
+    fn rebuilt_with(
+        net: &CompiledNetwork,
+        edit: impl FnOnce(&mut Vec<NeuronData>, &mut Vec<SynapseData>),
+    ) -> CompiledNetwork {
+        let mut neurons = net.neurons().to_vec();
+        let mut synapses = net.synapses().to_vec();
+        edit(&mut neurons, &mut synapses);
+        CompiledNetwork::from_parts(net.num_inputs(), neurons, synapses)
+            .expect("edited fixture must still satisfy the index invariant")
+    }
 
     fn synthetic_creature(num_inputs: usize, num_outputs: usize, hidden: usize) -> CompiledNetwork {
         let json = dense_mlp_creature_json(num_inputs, num_outputs, hidden, "TANH");
@@ -1284,7 +1299,7 @@ mod tests {
         // of the source network's `u16` `from_index`.
         let net = synthetic_creature(2, 1, 2);
         let expected: Vec<u32> = net
-            .synapses
+            .synapses()
             .iter()
             .map(|s| u32::from(s.from_index))
             .collect();
@@ -1303,10 +1318,9 @@ mod tests {
         // Build a creature with a still-unhosted aggregate squash (MEAN = 37).
         // MINIMUM/MAXIMUM/IF (32..=34) are hosted since Issue #312, so pick one
         // of the remaining aggregates to exercise the rejection path.
-        let mut net = synthetic_creature(1, 1, 1);
-        if let Some(n) = net.neurons.first_mut() {
-            n.squash_type = 37; // MEAN — not yet hosted by the shader.
-        }
+        let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+            neurons[0].squash_type = 37; // MEAN — not yet hosted by the shader.
+        });
         let err =
             build_batched_network_data(&[net], 1, 1).expect_err("unsupported squash rejected");
         match err {
@@ -1321,11 +1335,10 @@ mod tests {
     #[test]
     fn build_batched_network_data_accepts_all_pointwise_squashes() {
         for t in 0u8..=MAX_POINTWISE_SQUASH {
-            let mut net = synthetic_creature(1, 1, 1);
-            // Set the hidden neuron's squash to the discriminant under test.
-            if let Some(n) = net.neurons.first_mut() {
-                n.squash_type = t;
-            }
+            let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+                // Set the hidden neuron's squash to the discriminant under test.
+                neurons[0].squash_type = t;
+            });
             build_batched_network_data(&[net], 1, 1)
                 .unwrap_or_else(|e| panic!("point-wise squash {t} must be GPU-supported: {e:?}"));
         }
@@ -1337,10 +1350,9 @@ mod tests {
     #[test]
     fn build_batched_network_data_accepts_min_max_if_aggregates() {
         for t in 32u8..=34u8 {
-            let mut net = synthetic_creature(1, 1, 1);
-            if let Some(n) = net.neurons.first_mut() {
-                n.squash_type = t;
-            }
+            let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+                neurons[0].squash_type = t;
+            });
             let data = build_batched_network_data(&[net], 1, 1)
                 .unwrap_or_else(|e| panic!("aggregate squash {t} must be GPU-supported: {e:?}"));
             assert_eq!(
@@ -1356,10 +1368,9 @@ mod tests {
     #[test]
     fn build_batched_network_data_rejects_remaining_aggregate_squashes() {
         for t in 35u8..=37u8 {
-            let mut net = synthetic_creature(1, 1, 1);
-            if let Some(n) = net.neurons.first_mut() {
-                n.squash_type = t;
-            }
+            let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+                neurons[0].squash_type = t;
+            });
             let err = build_batched_network_data(&[net], 1, 1)
                 .expect_err("remaining aggregate squash must be rejected");
             match err {
@@ -1377,11 +1388,10 @@ mod tests {
     /// aggregate discriminant on a constant neuron must not force a fallback.
     #[test]
     fn build_batched_network_data_accepts_constant_neuron() {
-        let mut net = synthetic_creature(1, 1, 1);
-        if let Some(n) = net.neurons.first_mut() {
-            n.is_constant = true;
-            n.squash_type = 37; // MEAN — unhosted, but ignored for constants.
-        }
+        let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+            neurons[0].is_constant = true;
+            neurons[0].squash_type = 37; // MEAN — unhosted, but ignored for constants.
+        });
         let data = build_batched_network_data(&[net], 1, 1)
             .expect("a constant neuron is GPU-hostable since Issue #312");
         assert_eq!(
@@ -1394,14 +1404,15 @@ mod tests {
     /// `SynapseType` discriminant must be widened losslessly into `SynapseGpu`.
     #[test]
     fn build_batched_network_data_populates_synapse_type() {
-        let mut net = synthetic_creature(1, 1, 1);
         // Tag the compiled synapses with distinct types and assert they survive
         // the u8 -> u32 widening at the upload boundary.
-        for (i, s) in net.synapses.iter_mut().enumerate() {
-            s.synapse_type = (i % 4) as u8;
-        }
+        let net = rebuilt_with(&synthetic_creature(1, 1, 1), |_, synapses| {
+            for (i, s) in synapses.iter_mut().enumerate() {
+                s.synapse_type = (i % 4) as u8;
+            }
+        });
         let expected: Vec<u32> = net
-            .synapses
+            .synapses()
             .iter()
             .map(|s| u32::from(s.synapse_type))
             .collect();
@@ -1429,7 +1440,7 @@ mod tests {
         let spec = TreeSpec::new(4, 2, 7);
         let creature = parse_creature_json(&tree_creature_json(&spec)).expect("parse fixture");
         let net = compile_creature(&creature).expect("compile fixture");
-        let num_inputs = net.num_inputs;
+        let num_inputs = net.num_inputs();
         // The constant neuron is the first non-input neuron the fixture emits.
         let constant_index = num_inputs as u32;
         // Fixture node ids are emitted deepest-first, so the compiled IF neurons
@@ -1440,7 +1451,7 @@ mod tests {
             .expect("IF trees are GPU-hostable");
 
         let mut seen_if = 0usize;
-        for (i, neuron) in net.neurons.iter().enumerate() {
+        for (i, neuron) in net.neurons().iter().enumerate() {
             if neuron.is_constant || SquashType::from(neuron.squash_type) != SquashType::If {
                 continue;
             }
@@ -1486,8 +1497,9 @@ mod tests {
     /// the cap; only an absurd count beyond [`MAX_NEURONS_ABSOLUTE`] is refused.
     #[test]
     fn build_batched_network_data_accepts_above_private_cap() {
-        let mut net = synthetic_creature(1, 1, 1);
-        net.num_neurons = (MAX_NEURONS_PER_CREATURE as usize) + 1;
+        // 1 input + 255 hidden + 1 output = 257 neurons: one past the cap.
+        let net = synthetic_creature(1, 1, 255);
+        assert_eq!(net.num_neurons(), MAX_NEURONS_PER_CREATURE as usize + 1);
         let data = build_batched_network_data(&[net], 1, 1)
             .expect("creatures above the 256 cap now route to the scratch kernel");
         assert_eq!(data.creatures.len(), 1);
@@ -1498,13 +1510,22 @@ mod tests {
         );
     }
 
+    /// neat-core 0.12.0 (#625) builds every `CompiledNetwork` through one
+    /// validated constructor, so a compiled value can no longer be edited into
+    /// an absurd neuron count, and neat-core's own node ceiling sits far below
+    /// [`MAX_NEURONS_ABSOLUTE`]. The `TooManyNeurons` guard in
+    /// `build_batched_network_data` stays as belt and braces; this pins the
+    /// ordering that makes it unreachable for any network neat-core will hand us.
     #[test]
-    fn build_batched_network_data_rejects_absurd_neuron_count() {
-        let mut net = synthetic_creature(1, 1, 1);
-        net.num_neurons = (MAX_NEURONS_ABSOLUTE as usize) + 1;
-        let err = build_batched_network_data(&[net], 1, 1)
-            .expect_err("an absurd neuron count is rejected");
-        assert!(matches!(err, GpuPrepareError::TooManyNeurons { .. }));
+    fn absurd_neuron_count_is_unreachable_for_a_valid_network() {
+        use neat_core::network::{MAX_NODE_COUNT, NetworkError};
+        assert!(MAX_NODE_COUNT <= MAX_NEURONS_ABSOLUTE as usize);
+        let refused =
+            CompiledNetwork::from_parts(MAX_NEURONS_ABSOLUTE as usize + 1, Vec::new(), Vec::new());
+        assert!(
+            matches!(refused, Err(NetworkError::TooManyNodes { .. })),
+            "neat-core must refuse a node count past MAX_NODE_COUNT"
+        );
     }
 
     #[test]
@@ -1557,7 +1578,7 @@ mod tests {
     fn directory_pool_is_shallow_accepts_enceladus_shape() {
         let net = sparse_creature(2461, 19);
         assert!(
-            net.num_neurons > MAX_NEURONS_PER_CREATURE as usize,
+            net.num_neurons() > MAX_NEURONS_PER_CREATURE as usize,
             "the Enceladus shape must still route to the scratch kernel"
         );
         assert!(directory_pool_is_shallow(std::slice::from_ref(&net)));
@@ -1582,7 +1603,7 @@ mod tests {
         let hidden = MAX_SHALLOW_NON_INPUT_NEURONS as usize - 1;
         let at_cap = sparse_creature(2461, hidden);
         assert_eq!(
-            at_cap.num_neurons - at_cap.num_inputs,
+            at_cap.num_neurons() - at_cap.num_inputs(),
             MAX_SHALLOW_NON_INPUT_NEURONS as usize
         );
         assert!(directory_pool_is_shallow(&[at_cap]));

--- a/rust_scorer/src/if_tree_fixture.rs
+++ b/rust_scorer/src/if_tree_fixture.rs
@@ -514,7 +514,7 @@ mod tests {
         let net = compile_creature(&creature).expect("compile");
 
         let if_neurons = net
-            .neurons
+            .neurons()
             .iter()
             .filter(|n| !n.is_constant && SquashType::from(n.squash_type) == SquashType::If)
             .count();
@@ -522,13 +522,13 @@ mod tests {
 
         // Every IF neuron carries two condition edges plus one positive and one
         // negative branch edge.
-        for neuron in &net.neurons {
+        for neuron in net.neurons() {
             if neuron.is_constant || SquashType::from(neuron.squash_type) != SquashType::If {
                 continue;
             }
             let start = neuron.start_synapse as usize;
             let end = start + neuron.num_synapses as usize;
-            let roles: Vec<SynapseType> = net.synapses[start..end]
+            let roles: Vec<SynapseType> = net.synapses()[start..end]
                 .iter()
                 .map(|s| SynapseType::from(s.synapse_type))
                 .collect();
@@ -637,7 +637,7 @@ mod tests {
             let creature = parse_creature_json(&json).expect("parse");
             let net = compile_creature(&creature).expect("a deep spec must still graft cleanly");
             let if_neurons = net
-                .neurons
+                .neurons()
                 .iter()
                 .filter(|n| !n.is_constant && SquashType::from(n.squash_type) == SquashType::If)
                 .count();

--- a/rust_scorer/tests/dual_role_parity.rs
+++ b/rust_scorer/tests/dual_role_parity.rs
@@ -146,10 +146,10 @@ fn every_declared_synapse_survives_the_load() {
             declared - creature.synapses.len()
         );
         assert_eq!(
-            net.synapses.len(),
+            net.synapses().len(),
             declared,
             "{label}: compiling dropped {} of {declared} synapses",
-            declared - net.synapses.len()
+            declared - net.synapses().len()
         );
     }
 }
@@ -423,7 +423,7 @@ fn assert_gpu_parity(label: &str, json: &str, records: &[f32]) {
         return;
     };
     let template = compile(json);
-    let num_inputs = template.num_inputs;
+    let num_inputs = template.num_inputs();
     let n_records = records.len() / (num_inputs + 1);
     let mut nets: Vec<CompiledNetwork> = (0..4).map(|_| template.clone()).collect();
 

--- a/rust_scorer/tests/gpu_multi_score_parity.rs
+++ b/rust_scorer/tests/gpu_multi_score_parity.rs
@@ -338,7 +338,7 @@ fn run_parity_json(label: &str, json: &str, num_creatures: usize, n_records: usi
 
     let creature = parse_creature_json(json).expect("parse creature");
     let template = compile_creature(&creature).expect("compile");
-    let num_inputs = template.num_inputs;
+    let num_inputs = template.num_inputs();
     let num_outputs = creature.output;
     let mut nets: Vec<_> = (0..num_creatures).map(|_| template.clone()).collect();
 

--- a/rust_scorer/tests/if_tree_parity.rs
+++ b/rust_scorer/tests/if_tree_parity.rs
@@ -340,7 +340,7 @@ fn assert_kernel_parity(
         return;
     };
     let template = compile(json);
-    let num_inputs = template.num_inputs;
+    let num_inputs = template.num_inputs();
     let n_records = records.len() / (num_inputs + 1);
     let mut nets: Vec<CompiledNetwork> = (0..num_creatures).map(|_| template.clone()).collect();
 


### PR DESCRIPTION
Closes #605.

## Why

neat-core #633 (Issue #625, `0.11.4 → 0.12.0`, merged 2026-09-09T03:00Z) made every `CompiledNetwork` field private behind borrow-only accessors; `0.13.0` (#637) followed the same day. This crate read the fields directly, so it stopped compiling against the sibling `NEAT-AI-core` at head and the `neat-core.expected-version` breaking-bump gate went red.

Every GRQ host builds the Rust consumers from the sibling checkout at `origin/Develop` HEAD, so the unhandled bump took the whole fleet down through `rust_scorer` within minutes — see [GRQ #4724](https://github.com/stSoftwareAU/GRQ/issues/4724). This PR is one of five (scorer, Lamarck, Forests, Ockham, Backpropagation).

## What

- Field reads → accessors: `rust_scorer/src/gpu/forward_mse_batched.rs` (GPU upload path + tests), `dual_role_fixture.rs`, `if_tree_fixture.rs`, `tests/{dual_role_parity,if_tree_parity,gpu_multi_score_parity}.rs`. Tests that used to write into a compiled fixture now rebuild it through `CompiledNetwork::from_parts` (`rebuilt_with` helper); the above-the-cap case is a real 257-neuron creature; the now-unconstructible "absurd neuron count" test is replaced by a pin that `MAX_NODE_COUNT <= MAX_NEURONS_ABSOLUTE`.
- `neat-core.expected-version` → `0.13.0`, with the acknowledgement paragraph the gate asks for.
- Crate patch version bumped so the fleet's version marker triggers a rebuild.
- `Cargo.lock`: `neat-core 0.10.x → 0.13.0`.

## Verification

Against the sibling `NEAT-AI-core` at `59eb6e6` (0.13.0): `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean, `cargo test` green (556 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXkD5hNp6n5t2U7XpRbyLy