### PR TITLE
Guard one PR-time cargo audit across workflows (Issue #603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,25 @@ section to the released version with its date.
 
 ### Added
 
+- **The PR-time `cargo audit` must live in exactly one workflow (Issue #603).**
+  `cargo-audit.yml`'s `pull_request` trigger and `security.yml`'s
+  `rustsec/audit-check` step (reached from `ci.yml`) read the identical
+  `Cargo.lock` against the identical RustSec advisory database on the identical
+  `pull_request` event, so every PR into `Develop`/`milestone/**` pays for two
+  audits that can only ever agree. `scripts/check-cargo-audit-workflow.sh` now
+  enforces the dedup invariant `check-shellcheck-dedup.sh` enforces for
+  ShellCheck (Issue #157): it resolves which workflows audit on a pull request
+  — following local `uses: ./.github/workflows/…` calls so a reusable
+  workflow's audit is attributed to the PR event that reaches it — and reports
+  a duplicate as a loud `WARN` naming both files. Its `pull_request` trigger is
+  no longer *required*: the weekly cron is the standalone workflow's
+  non-redundant value, and the milestone branch-filter rule (Issue #391) now
+  applies only when a `pull_request` trigger is present, so the validator
+  passes cleanly once the trigger is dropped. Losing PR-time coverage
+  altogether stays a hard `FAIL`. The `.github/workflows/` edit itself needs a
+  maintainer: the automation worker's credentials carry no `workflow` OAuth
+  scope ([CONTRIBUTING → Human escalation](./CONTRIBUTING.md#human-escalation)),
+  so the `WARN` stays until those three trigger lines are removed.
 - **The Semgrep container pin is checked for bump-ability, not just
   immutability (Issue #602).** `.github/workflows/semgrep.yml` pins the scanner
   by bare `@sha256:` digest with no tag beside it. The digest is immutable, but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ section to the released version with its date.
 
 ### Fixed
 
+- **Builds against neat-core 0.14.2 — the declared observation width is now
+  bounded (neat-core #622 / #640).** neat-core 0.14.0 added a `MAX_NODE_COUNT`
+  ceiling to its own `validate_creature_width`, so creature JSON declaring an
+  `input` past the u16 index space is `CreatureError::TooManyNodes` rather than
+  a hundred-million-entry allocation. It is a BREAKING tightening — JSON that
+  used to parse is now refused — but `rust_scorer` needs no code change: every
+  load path calls `parse_creature_json` first, so the ceiling arrives ahead of
+  the scorer's own lower-bound guard (Issue #571), which keeps owning the `< 1`
+  wording. New `rust_scorer/tests/creature_width_ceiling.rs` pins the refusal
+  from the binary's side, and `neat-core.expected-version` acknowledges 0.14.2.
+
 - **Builds against neat-core 0.13.0 — `CompiledNetwork`'s fields went private
   (neat-core #625 / #633).** neat-core 0.12.0 made every `CompiledNetwork`
   field private behind borrow-only accessors and 0.13.0 followed the same day.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ section to the released version with its date.
 
 ### Fixed
 
+- **Builds against neat-core 0.13.0 — `CompiledNetwork`'s fields went private
+  (neat-core #625 / #633).** neat-core 0.12.0 made every `CompiledNetwork`
+  field private behind borrow-only accessors and 0.13.0 followed the same day.
+  Every production host builds `rust_scorer` from the sibling neat-core at
+  head, so the build failed fleet-wide with 11 × `E0616` at
+  `gpu/forward_mse_batched.rs` within minutes and, with no fallback engine,
+  the fleet stopped scoring. The GPU upload path and the fixtures/tests now
+  read `num_inputs()` / `num_neurons()` / `neurons()` / `synapses()` through
+  the accessors; the tests that used to write into a compiled fixture rebuild
+  it through `CompiledNetwork::from_parts`, the above-the-cap case is a real
+  257-neuron creature, and the now-unconstructible "absurd neuron count" test
+  is replaced by a pin that neat-core's `MAX_NODE_COUNT` sits below
+  `MAX_NEURONS_ABSOLUTE`. `neat-core.expected-version` acknowledges 0.13.0.
+
 - **External termination names itself instead of dying silently (Issue #591).**
   A production sampler run hit its 3-hour per-task wall-clock cap mid-batch; the
   fleet supervisor signalled the process group, `rust_scorer` died on the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.8"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.75"
+version = "1.1.76"
 dependencies = [
  "bytemuck",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.14.2"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.10.6"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.74"
+version = "1.1.75"
 dependencies = [
  "bytemuck",
  "clap",

--- a/README.md
+++ b/README.md
@@ -1645,9 +1645,38 @@ reusable `security.yml` scans the same `Cargo.lock` via the `rustsec/audit-check
 action (which annotates the PR check run). A second, direct `cargo audit` run
 in `security.yml` was removed as pure duplication (Issue #399): the action
 already fails the check on any advisory, so a follow-up run in the same job
-could not catch anything it missed. The workflow is validated by
-`scripts/check-cargo-audit-workflow.sh` (invoked from `quality.sh`) and covered
-end-to-end by `tests/scripts/cargo_audit_workflow.bats`.
+could not catch anything it missed.
+
+**One PR-time audit, one home (Issue #603).** The same reasoning applies across
+workflow files: `cargo-audit.yml`'s `pull_request` trigger and `security.yml`'s
+`rustsec/audit-check` read the identical `Cargo.lock` against the identical
+advisory database on the identical `pull_request` event, so on a PR into
+`Develop` or `milestone/**` the second run can only repeat the first verdict at
+double the runner minutes. `check-cargo-audit-workflow.sh` now enforces the
+dedup invariant that `check-shellcheck-dedup.sh` enforces for ShellCheck
+(Issue #157) — exactly one workflow may audit on a pull request, counting an
+audit reached indirectly (`ci.yml` fires on `pull_request` and calls the
+reusable `security.yml`). Missing PR-time coverage is a hard FAIL; a duplicate
+is a loud `WARN`, because removing it means editing `.github/workflows/`, which
+the automation worker has no `workflow` OAuth scope to push
+([CONTRIBUTING → Human escalation](./CONTRIBUTING.md#human-escalation)). The
+`pull_request` trigger is optional here — the weekly cron is the standalone
+workflow's non-redundant value — so once a maintainer drops the three trigger
+lines the validator passes with no WARN.
+
+```mermaid
+flowchart LR
+    PR[pull_request] --> CA["cargo-audit.yml<br/>prebuilt cargo audit"]
+    PR --> CI["ci.yml → security.yml<br/>rustsec/audit-check"]
+    CA --> LOCK[(Cargo.lock<br/>+ RustSec DB)]
+    CI --> LOCK
+    LOCK --> V["one verdict,<br/>paid for twice"]
+    CRON["schedule: 0 6 * * 1"] --> CA
+```
+
+The workflow is validated by `scripts/check-cargo-audit-workflow.sh` (invoked
+from `quality.sh`) and covered end-to-end by
+`tests/scripts/cargo_audit_workflow.bats`.
 
 A standalone SBOM workflow (`.github/workflows/sbom.yml`, Issue #172) exports
 the dependency inventory as a CycloneDX Software Bill of Materials and uploads

--- a/docs/archive/pr-summaries/pr-summary-603.md
+++ b/docs/archive/pr-summaries/pr-summary-603.md
@@ -1,0 +1,150 @@
+# PR Summary — Issue #603
+
+## Summary
+
+`cargo-audit.yml`'s `pull_request` trigger and `security.yml`'s
+`rustsec/audit-check` step (reached from `ci.yml`) read the identical
+`Cargo.lock` against the identical RustSec advisory database on the identical
+`pull_request` event, so every PR into `Develop`/`milestone/**` pays for two
+audits that can only ever agree.
+
+`scripts/check-cargo-audit-workflow.sh` now enforces the dedup invariant that
+`check-shellcheck-dedup.sh` enforces for ShellCheck (Issue #157): **exactly one
+workflow may run a `cargo audit` on a pull request**, counting an audit reached
+indirectly — the validator follows local `uses: ./.github/workflows/…` calls to
+a fixed point, so `security.yml`'s audit is attributed to the `pull_request`
+event that `ci.yml` brings it. A duplicate is a loud `WARN` naming both files;
+losing PR-time coverage altogether is a hard `FAIL`.
+
+Two supporting rule changes make the validator pass cleanly *after* the fix
+rather than swapping one failure for another: the `pull_request` trigger is no
+longer required (the weekly cron is the standalone workflow's non-redundant
+value), and the `milestone/*` branch-filter rule (Issue #391) now applies only
+when a `pull_request` trigger is present.
+
+The `.github/workflows/` edit itself is **not** in this PR: the automation
+worker's credentials carry no `workflow` OAuth scope, so per
+[CONTRIBUTING → Human escalation](../../../CONTRIBUTING.md#human-escalation) the
+issue is labelled `needs-human` with a comment spelling out the exact edit. The
+`WARN` stays visible on every gate run until a maintainer lands it — the
+deficiency never disappears into a silent pass.
+
+Closes #603.
+
+## Evidence
+
+Backend/CI tooling change — no web interface to screenshot. Evidence is the
+validator's own output against the real repository, which detects the
+duplication through the reusable-workflow hop:
+
+```text
+$ ./scripts/check-cargo-audit-workflow.sh
+OK   .github/workflows/cargo-audit.yml: triggers on schedule (cron)
+OK   .github/workflows/cargo-audit.yml: permissions block grants only contents: read
+OK   .github/workflows/cargo-audit.yml: actions/checkout pinned to a numeric major or 40-char SHA
+OK   .github/workflows/cargo-audit.yml: dtolnay/rust-toolchain present
+OK   .github/workflows/cargo-audit.yml: cargo audit invoked directly
+OK   .github/workflows/cargo-audit.yml: triggers on pull_request
+OK   .github/workflows/cargo-audit.yml: pull_request branch filter covers milestone/* branches
+WARN .github/workflows/cargo-audit.yml: PR-time cargo audit duplicated across 2
+     workflows — both read the same Cargo.lock against the same advisory database
+     on the same pull_request event, so the second run can only repeat the first
+     verdict at double the runner minutes (Issue #603):
+     .github/workflows/cargo-audit.yml .github/workflows/security.yml. Drop the
+     standalone workflow's pull_request trigger (keeping its weekly cron) or the
+     reusable workflow's audit step — the edit is under .github/workflows/ and
+     needs a maintainer (CONTRIBUTING "Human escalation")
+exit=0
+```
+
+Today's duplicated graph, and the shape the maintainer edit leaves behind:
+
+```mermaid
+flowchart LR
+    PR[pull_request] --> CA["cargo-audit.yml<br/>prebuilt cargo audit"]
+    PR --> CI["ci.yml → security.yml<br/>rustsec/audit-check"]
+    CA --> LOCK[(Cargo.lock<br/>+ RustSec DB)]
+    CI --> LOCK
+    LOCK --> V["one verdict,<br/>paid for twice"]
+    CRON["schedule: 0 6 * * 1"] --> CA
+```
+
+```mermaid
+flowchart LR
+    PR2[pull_request] --> CI2["ci.yml → security.yml<br/>rustsec/audit-check"]
+    CRON2["schedule: 0 6 * * 1"] --> CA2["cargo-audit.yml<br/>weekly + dispatch only"]
+    CI2 --> LOCK2[(Cargo.lock<br/>+ RustSec DB)]
+    CA2 --> LOCK2
+```
+
+### The maintainer edit this PR cannot make
+
+Delete lines 27–28 of `.github/workflows/cargo-audit.yml`, leaving `schedule:`
+and `workflow_dispatch:`, and trim the now-stale `pull_request` bullet from the
+header comment (lines 13–18):
+
+```yaml
+  pull_request:
+    branches: ["*", "milestone/**"]
+```
+
+After that edit the validator reports
+`OK … exactly one PR-time cargo audit across .github/workflows:
+.github/workflows/security.yml` with no `WARN`, and the end state is already
+covered by `cargo_audit_workflow.bats::passes without a pull_request trigger
+once another workflow owns the PR audit`.
+
+The issue's alternative — drop `security.yml`'s audit step instead — is equally
+accepted by the new guard. It is noted on the issue with its trade-off
+(`cargo-audit.yml` uses a *prebuilt* cargo-audit per Issue #208 and covers a
+wider branch filter, but `rustsec/audit-check` annotates the check run and
+removing it would leave `security.yml` with only the dependency-review step its
+sole caller opts out of).
+
+## Test Plan
+
+`tests/scripts/cargo_audit_workflow.bats` — 16 tests, all passing. New and
+changed coverage:
+
+- **new** `warns when a second PR-reachable workflow audits the same lockfile
+  (issue #603)` — fixture pair `ci.yml` (on `pull_request`, `uses:
+  ./.github/workflows/security.yml`) + `security.yml` (`rustsec/audit-check`);
+  asserts exit 0, a `WARN` naming both files, and no `FAIL`. This is the
+  reusable-workflow reachability case.
+- **new** `passes without a pull_request trigger once another workflow owns the
+  PR audit (issue #603)` — the post-fix end state: exit 0, no `WARN`, and the
+  milestone branch-filter rule not evaluated.
+- **new** `fails when no workflow provides a PR-time cargo audit (issue #603)` —
+  schedule-only with no sibling audit is a hard failure, so the duplication
+  cannot be "resolved" by deleting both.
+- **new** `prose mentioning cargo audit does not count as a second invocation
+  (issue #603)` — the invocation patterns anchor to `uses:`/`run:`, so the
+  several `cargo audit` mentions in `security.yml`'s comments are not miscounted.
+- **new** `reports an error when the workflows directory does not exist` — the
+  shared not-found contract for the new `--workflows DIR` flag.
+- **changed** `passes on the canonical fixture` — now asserts 8 `OK` lines (was
+  7; the dedup rule adds one) and no `WARN`.
+- **removed** `fails when the workflow is not triggered on pull_request` — the
+  business logic changed deliberately: a `pull_request` trigger on this workflow
+  is now optional, which is the whole point of Issue #603. Its replacement is
+  the pair of new tests above, which pin that dropping the trigger is a pass
+  *only* while another workflow provides PR-time coverage.
+- **unchanged** the schedule, permissions, checkout-pin, toolchain,
+  audit-invoked, milestone-filter and real-repository tests.
+
+### Quality gate
+
+`./quality.sh` fails at a **pre-existing, unrelated** stage on this container:
+`check-neat-core-version.sh` reports `breaking neat-core bump: 0.11.4 exceeds
+handled baseline 0.10.0`, which needs its own deliberate upgrade PR (the sibling
+clone has moved ahead of `neat-core.expected-version`). Verified pre-existing by
+running the same suites against a pristine `HEAD` worktree.
+
+Every stage that this diff can affect was run and passed: `bash -n` and
+`shellcheck -x` over all scripts, all 37 other `scripts/check-*.sh` guards,
+`codespell`, `cargo fmt --all --check`, and the full `bats tests/scripts` suite
+(634 tests; the only two failures — the neat-core baseline above and `living
+docs contain no box-drawing ASCII diagrams` — reproduce identically on pristine
+`HEAD`, the latter because this container has no `en_US.UTF-8` locale, so the
+test's `grep` character class degrades to byte matching on em dashes).
+No Rust source changed in this PR.

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -87,4 +87,18 @@
 # loads with every synapse intact, scores identically to the pre-#577 relay
 # workaround, and scores *differently* from the creature a `(from, to)`-keyed
 # loader is left holding.
-0.10.0
+#
+# 0.10.0 -> 0.13.0: acknowledge neat-core #633 (Issue #625, 0.12.0), which made
+# every `CompiledNetwork` field private behind borrow-only accessors so safe
+# code can no longer edit a validated network into an out-of-bounds SIMD read,
+# and 0.13.0 (#637, the security-scan milestone roll-up, no further API change
+# scorer names). rust_scorer read `num_inputs` / `num_neurons` / `neurons` /
+# `synapses` directly on its GPU upload path (`gpu/forward_mse_batched.rs`) and
+# in fixtures/tests; every read now goes through the `()` accessor, and the
+# tests that used to write into a compiled fixture rebuild it through
+# `CompiledNetwork::from_parts` instead. Unhandled, this bump took the whole
+# GRQ fleet down (GRQ#4724): every host builds rust_scorer from the sibling
+# neat-core at head, so the break was fleet-wide within minutes of merging.
+# Verified by `cargo clippy --all-targets -- -D warnings` and the full scorer
+# test suite against the sibling clone at 0.13.0 (59eb6e6).
+0.13.0

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -101,4 +101,27 @@
 # neat-core at head, so the break was fleet-wide within minutes of merging.
 # Verified by `cargo clippy --all-targets -- -D warnings` and the full scorer
 # test suite against the sibling clone at 0.13.0 (59eb6e6).
-0.13.0
+#
+# 0.13.0 -> 0.14.2: acknowledge neat-core #640 (Issue #622, 0.14.0), which bounds
+# the DECLARED observation width. `CreatureExport::input` is a count with no
+# backing data, so `parse_creature_json` / `compile_creature` /
+# `validate_creature_topology` / `cleanup_creature_with` each built one owned
+# String UUID per declared input before anything bounded it — a 40-byte creature
+# saying `"input": 100000000` sized a hundred-million-entry map. The ceiling now
+# lives in neat-core's own `validate_creature_width`: a declared input above
+# MAX_NODE_COUNT is `CreatureError::TooManyNodes`. BREAKING because creature JSON
+# that used to be accepted is now refused; it is a **tightening**, and every
+# creature the fleet actually scores is far below the u16 ceiling. No rust_scorer
+# code change is required — every scorer load path calls `parse_creature_json`
+# first, so the new ceiling arrives ahead of the scorer's own lower-bound guard
+# (`rust_scorer::creature_width`, Issue #571), which keeps owning the `< 1`
+# wording. 0.14.1 (#641) and 0.14.2 are bump-deps.sh / release-tooling changes
+# with no API surface. Verified by `cargo clippy --all-targets -- -D warnings`
+# and the full scorer test suite (560 tests) against the sibling clone at 0.14.2,
+# plus the new `rust_scorer/tests/creature_width_ceiling.rs`, which pins the
+# refusal from the binary's side (CLI exits non-zero before the data directory is
+# touched) and that the ceiling is inclusive at MAX_NODE_COUNT — the oversized
+# case parsed cleanly against 0.13.0, where the only MAX_NODE_COUNT check was on
+# the listed neuron count.
+
+0.14.2

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.75"
+version = "1.1.76"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.74"
+version = "1.1.75"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/src/dual_role_fixture.rs
+++ b/rust_scorer/src/dual_role_fixture.rs
@@ -401,7 +401,7 @@ mod tests {
         assert_eq!(creature.synapses.len(), 7);
         let net = compile_creature(&creature).expect("compile");
         assert_eq!(
-            net.synapses.len(),
+            net.synapses().len(),
             7,
             "compiling must drop no synapse — a (from, to)-keyed loader keeps only 5"
         );
@@ -412,12 +412,12 @@ mod tests {
         let creature = parse_creature_json(&dual_role_if_creature_json(&SPEC)).expect("parse");
         let net = compile_creature(&creature).expect("compile");
         let node = net
-            .neurons
+            .neurons()
             .iter()
             .find(|n| !n.is_constant && n.num_synapses == 6)
             .expect("the IF node reads six synapses");
         let start = node.start_synapse as usize;
-        let roles: Vec<SynapseType> = net.synapses[start..start + 6]
+        let roles: Vec<SynapseType> = net.synapses()[start..start + 6]
             .iter()
             .map(|s| SynapseType::from(s.synapse_type))
             .collect();

--- a/rust_scorer/src/gpu/forward_mse_batched.rs
+++ b/rust_scorer/src/gpu/forward_mse_batched.rs
@@ -256,23 +256,23 @@ pub(crate) fn build_batched_network_data(
     let mut creatures = Vec::with_capacity(networks.len());
 
     for (creature_idx, net) in networks.iter().enumerate() {
-        if net.num_inputs != num_inputs {
+        if net.num_inputs() != num_inputs {
             return Err(GpuPrepareError::MismatchedShape);
         }
         // Issue #182: creatures above the 256 private-array cap are no longer
         // rejected — they run on the `forward_mse_scratch` kernel. Only an
         // absurd, almost-certainly-corrupt neuron count is refused.
-        if net.num_neurons > MAX_NEURONS_ABSOLUTE as usize {
+        if net.num_neurons() > MAX_NEURONS_ABSOLUTE as usize {
             return Err(GpuPrepareError::TooManyNeurons {
                 creature_idx,
-                num_neurons: net.num_neurons,
+                num_neurons: net.num_neurons(),
             });
         }
         let neuron_offset = neurons.len() as u32;
         let synapse_offset = synapses.len() as u32;
-        let num_non_inputs = net.neurons.len() as u32;
+        let num_non_inputs = net.neurons().len() as u32;
 
-        for n in &net.neurons {
+        for n in net.neurons() {
             // Constant neurons are hosted since Issue #312 (clamped bias,
             // synapses ignored), so they no longer force a CPU fallback. A
             // constant neuron's squash discriminant is irrelevant on the GPU —
@@ -289,7 +289,7 @@ pub(crate) fn build_batched_network_data(
                 is_constant: u32::from(n.is_constant),
             });
         }
-        for s in &net.synapses {
+        for s in net.synapses() {
             synapses.push(SynapseGpu {
                 weight: s.weight,
                 // neat-core #177 narrowed `SynapseData::from_index` to `u16`;
@@ -305,7 +305,7 @@ pub(crate) fn build_batched_network_data(
             neuron_offset,
             num_non_inputs,
             synapse_offset,
-            num_neurons: net.num_neurons as u32,
+            num_neurons: net.num_neurons() as u32,
         });
     }
 
@@ -996,7 +996,7 @@ pub(crate) fn directory_gpu_topology(networks: &[CompiledNetwork]) -> DirectoryG
     let mut has_private = false;
     let mut has_scratch = false;
     for net in networks {
-        if u32::try_from(net.num_neurons).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
+        if u32::try_from(net.num_neurons()).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
             has_scratch = true;
         } else {
             has_private = true;
@@ -1022,7 +1022,7 @@ pub(crate) fn directory_gpu_topology(networks: &[CompiledNetwork]) -> DirectoryG
 pub(crate) fn directory_pool_is_shallow(networks: &[CompiledNetwork]) -> bool {
     !networks.is_empty()
         && networks.iter().all(|net| {
-            let non_input = net.num_neurons.saturating_sub(net.num_inputs);
+            let non_input = net.num_neurons().saturating_sub(net.num_inputs());
             u32::try_from(non_input).unwrap_or(u32::MAX) <= MAX_SHALLOW_NON_INPUT_NEURONS
         })
 }
@@ -1053,7 +1053,7 @@ impl DirectoryGpuRunners {
         let mut scratch_orig: Vec<usize> = Vec::new();
 
         for (i, net) in networks.iter().enumerate() {
-            if u32::try_from(net.num_neurons).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
+            if u32::try_from(net.num_neurons()).unwrap_or(u32::MAX) > MAX_NEURONS_PER_CREATURE {
                 scratch_orig.push(i);
                 scratch_nets.push(net.clone());
             } else {
@@ -1241,6 +1241,21 @@ mod tests {
     };
     use neat_core::creature::compile_creature;
     use neat_core::creature::parse_creature_json;
+    use neat_core::network::{NeuronData, SynapseData};
+
+    /// Issue #625 (neat-core 0.12.0): `CompiledNetwork`'s fields are private,
+    /// so a fixture is edited by rebuilding it from its parts through the one
+    /// validated constructor, not by writing into a compiled value.
+    fn rebuilt_with(
+        net: &CompiledNetwork,
+        edit: impl FnOnce(&mut Vec<NeuronData>, &mut Vec<SynapseData>),
+    ) -> CompiledNetwork {
+        let mut neurons = net.neurons().to_vec();
+        let mut synapses = net.synapses().to_vec();
+        edit(&mut neurons, &mut synapses);
+        CompiledNetwork::from_parts(net.num_inputs(), neurons, synapses)
+            .expect("edited fixture must still satisfy the index invariant")
+    }
 
     fn synthetic_creature(num_inputs: usize, num_outputs: usize, hidden: usize) -> CompiledNetwork {
         let json = dense_mlp_creature_json(num_inputs, num_outputs, hidden, "TANH");
@@ -1284,7 +1299,7 @@ mod tests {
         // of the source network's `u16` `from_index`.
         let net = synthetic_creature(2, 1, 2);
         let expected: Vec<u32> = net
-            .synapses
+            .synapses()
             .iter()
             .map(|s| u32::from(s.from_index))
             .collect();
@@ -1303,10 +1318,9 @@ mod tests {
         // Build a creature with a still-unhosted aggregate squash (MEAN = 37).
         // MINIMUM/MAXIMUM/IF (32..=34) are hosted since Issue #312, so pick one
         // of the remaining aggregates to exercise the rejection path.
-        let mut net = synthetic_creature(1, 1, 1);
-        if let Some(n) = net.neurons.first_mut() {
-            n.squash_type = 37; // MEAN — not yet hosted by the shader.
-        }
+        let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+            neurons[0].squash_type = 37; // MEAN — not yet hosted by the shader.
+        });
         let err =
             build_batched_network_data(&[net], 1, 1).expect_err("unsupported squash rejected");
         match err {
@@ -1321,11 +1335,10 @@ mod tests {
     #[test]
     fn build_batched_network_data_accepts_all_pointwise_squashes() {
         for t in 0u8..=MAX_POINTWISE_SQUASH {
-            let mut net = synthetic_creature(1, 1, 1);
-            // Set the hidden neuron's squash to the discriminant under test.
-            if let Some(n) = net.neurons.first_mut() {
-                n.squash_type = t;
-            }
+            let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+                // Set the hidden neuron's squash to the discriminant under test.
+                neurons[0].squash_type = t;
+            });
             build_batched_network_data(&[net], 1, 1)
                 .unwrap_or_else(|e| panic!("point-wise squash {t} must be GPU-supported: {e:?}"));
         }
@@ -1337,10 +1350,9 @@ mod tests {
     #[test]
     fn build_batched_network_data_accepts_min_max_if_aggregates() {
         for t in 32u8..=34u8 {
-            let mut net = synthetic_creature(1, 1, 1);
-            if let Some(n) = net.neurons.first_mut() {
-                n.squash_type = t;
-            }
+            let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+                neurons[0].squash_type = t;
+            });
             let data = build_batched_network_data(&[net], 1, 1)
                 .unwrap_or_else(|e| panic!("aggregate squash {t} must be GPU-supported: {e:?}"));
             assert_eq!(
@@ -1356,10 +1368,9 @@ mod tests {
     #[test]
     fn build_batched_network_data_rejects_remaining_aggregate_squashes() {
         for t in 35u8..=37u8 {
-            let mut net = synthetic_creature(1, 1, 1);
-            if let Some(n) = net.neurons.first_mut() {
-                n.squash_type = t;
-            }
+            let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+                neurons[0].squash_type = t;
+            });
             let err = build_batched_network_data(&[net], 1, 1)
                 .expect_err("remaining aggregate squash must be rejected");
             match err {
@@ -1377,11 +1388,10 @@ mod tests {
     /// aggregate discriminant on a constant neuron must not force a fallback.
     #[test]
     fn build_batched_network_data_accepts_constant_neuron() {
-        let mut net = synthetic_creature(1, 1, 1);
-        if let Some(n) = net.neurons.first_mut() {
-            n.is_constant = true;
-            n.squash_type = 37; // MEAN — unhosted, but ignored for constants.
-        }
+        let net = rebuilt_with(&synthetic_creature(1, 1, 1), |neurons, _| {
+            neurons[0].is_constant = true;
+            neurons[0].squash_type = 37; // MEAN — unhosted, but ignored for constants.
+        });
         let data = build_batched_network_data(&[net], 1, 1)
             .expect("a constant neuron is GPU-hostable since Issue #312");
         assert_eq!(
@@ -1394,14 +1404,15 @@ mod tests {
     /// `SynapseType` discriminant must be widened losslessly into `SynapseGpu`.
     #[test]
     fn build_batched_network_data_populates_synapse_type() {
-        let mut net = synthetic_creature(1, 1, 1);
         // Tag the compiled synapses with distinct types and assert they survive
         // the u8 -> u32 widening at the upload boundary.
-        for (i, s) in net.synapses.iter_mut().enumerate() {
-            s.synapse_type = (i % 4) as u8;
-        }
+        let net = rebuilt_with(&synthetic_creature(1, 1, 1), |_, synapses| {
+            for (i, s) in synapses.iter_mut().enumerate() {
+                s.synapse_type = (i % 4) as u8;
+            }
+        });
         let expected: Vec<u32> = net
-            .synapses
+            .synapses()
             .iter()
             .map(|s| u32::from(s.synapse_type))
             .collect();
@@ -1429,7 +1440,7 @@ mod tests {
         let spec = TreeSpec::new(4, 2, 7);
         let creature = parse_creature_json(&tree_creature_json(&spec)).expect("parse fixture");
         let net = compile_creature(&creature).expect("compile fixture");
-        let num_inputs = net.num_inputs;
+        let num_inputs = net.num_inputs();
         // The constant neuron is the first non-input neuron the fixture emits.
         let constant_index = num_inputs as u32;
         // Fixture node ids are emitted deepest-first, so the compiled IF neurons
@@ -1440,7 +1451,7 @@ mod tests {
             .expect("IF trees are GPU-hostable");
 
         let mut seen_if = 0usize;
-        for (i, neuron) in net.neurons.iter().enumerate() {
+        for (i, neuron) in net.neurons().iter().enumerate() {
             if neuron.is_constant || SquashType::from(neuron.squash_type) != SquashType::If {
                 continue;
             }
@@ -1486,8 +1497,9 @@ mod tests {
     /// the cap; only an absurd count beyond [`MAX_NEURONS_ABSOLUTE`] is refused.
     #[test]
     fn build_batched_network_data_accepts_above_private_cap() {
-        let mut net = synthetic_creature(1, 1, 1);
-        net.num_neurons = (MAX_NEURONS_PER_CREATURE as usize) + 1;
+        // 1 input + 255 hidden + 1 output = 257 neurons: one past the cap.
+        let net = synthetic_creature(1, 1, 255);
+        assert_eq!(net.num_neurons(), MAX_NEURONS_PER_CREATURE as usize + 1);
         let data = build_batched_network_data(&[net], 1, 1)
             .expect("creatures above the 256 cap now route to the scratch kernel");
         assert_eq!(data.creatures.len(), 1);
@@ -1498,13 +1510,22 @@ mod tests {
         );
     }
 
+    /// neat-core 0.12.0 (#625) builds every `CompiledNetwork` through one
+    /// validated constructor, so a compiled value can no longer be edited into
+    /// an absurd neuron count, and neat-core's own node ceiling sits far below
+    /// [`MAX_NEURONS_ABSOLUTE`]. The `TooManyNeurons` guard in
+    /// `build_batched_network_data` stays as belt and braces; this pins the
+    /// ordering that makes it unreachable for any network neat-core will hand us.
     #[test]
-    fn build_batched_network_data_rejects_absurd_neuron_count() {
-        let mut net = synthetic_creature(1, 1, 1);
-        net.num_neurons = (MAX_NEURONS_ABSOLUTE as usize) + 1;
-        let err = build_batched_network_data(&[net], 1, 1)
-            .expect_err("an absurd neuron count is rejected");
-        assert!(matches!(err, GpuPrepareError::TooManyNeurons { .. }));
+    fn absurd_neuron_count_is_unreachable_for_a_valid_network() {
+        use neat_core::network::{MAX_NODE_COUNT, NetworkError};
+        assert!(MAX_NODE_COUNT <= MAX_NEURONS_ABSOLUTE as usize);
+        let refused =
+            CompiledNetwork::from_parts(MAX_NEURONS_ABSOLUTE as usize + 1, Vec::new(), Vec::new());
+        assert!(
+            matches!(refused, Err(NetworkError::TooManyNodes { .. })),
+            "neat-core must refuse a node count past MAX_NODE_COUNT"
+        );
     }
 
     #[test]
@@ -1557,7 +1578,7 @@ mod tests {
     fn directory_pool_is_shallow_accepts_enceladus_shape() {
         let net = sparse_creature(2461, 19);
         assert!(
-            net.num_neurons > MAX_NEURONS_PER_CREATURE as usize,
+            net.num_neurons() > MAX_NEURONS_PER_CREATURE as usize,
             "the Enceladus shape must still route to the scratch kernel"
         );
         assert!(directory_pool_is_shallow(std::slice::from_ref(&net)));
@@ -1582,7 +1603,7 @@ mod tests {
         let hidden = MAX_SHALLOW_NON_INPUT_NEURONS as usize - 1;
         let at_cap = sparse_creature(2461, hidden);
         assert_eq!(
-            at_cap.num_neurons - at_cap.num_inputs,
+            at_cap.num_neurons() - at_cap.num_inputs(),
             MAX_SHALLOW_NON_INPUT_NEURONS as usize
         );
         assert!(directory_pool_is_shallow(&[at_cap]));

--- a/rust_scorer/src/if_tree_fixture.rs
+++ b/rust_scorer/src/if_tree_fixture.rs
@@ -514,7 +514,7 @@ mod tests {
         let net = compile_creature(&creature).expect("compile");
 
         let if_neurons = net
-            .neurons
+            .neurons()
             .iter()
             .filter(|n| !n.is_constant && SquashType::from(n.squash_type) == SquashType::If)
             .count();
@@ -522,13 +522,13 @@ mod tests {
 
         // Every IF neuron carries two condition edges plus one positive and one
         // negative branch edge.
-        for neuron in &net.neurons {
+        for neuron in net.neurons() {
             if neuron.is_constant || SquashType::from(neuron.squash_type) != SquashType::If {
                 continue;
             }
             let start = neuron.start_synapse as usize;
             let end = start + neuron.num_synapses as usize;
-            let roles: Vec<SynapseType> = net.synapses[start..end]
+            let roles: Vec<SynapseType> = net.synapses()[start..end]
                 .iter()
                 .map(|s| SynapseType::from(s.synapse_type))
                 .collect();
@@ -637,7 +637,7 @@ mod tests {
             let creature = parse_creature_json(&json).expect("parse");
             let net = compile_creature(&creature).expect("a deep spec must still graft cleanly");
             let if_neurons = net
-                .neurons
+                .neurons()
                 .iter()
                 .filter(|n| !n.is_constant && SquashType::from(n.squash_type) == SquashType::If)
                 .count();

--- a/rust_scorer/tests/creature_width_ceiling.rs
+++ b/rust_scorer/tests/creature_width_ceiling.rs
@@ -1,0 +1,108 @@
+//! neat-core 0.14.0 (NEAT-AI-core#640, Issue #622) — a declared observation
+//! width above `MAX_NODE_COUNT` is refused *before* anything is sized by it.
+//!
+//! `CreatureExport::input` is a declared count with no backing data, so a
+//! sub-100-byte creature saying `"input": 100000000` used to make
+//! `parse_creature_json` / `compile_creature` build one owned String UUID per
+//! declared input. neat-core now bounds the width in `validate_creature_width`,
+//! which is the BREAKING half of the 0.13.0 -> 0.14.0 bump this repository
+//! acknowledges in `neat-core.expected-version`.
+//!
+//! rust_scorer needs no code change: every load path calls
+//! `parse_creature_json` first, so the ceiling arrives ahead of the scorer's
+//! own lower-bound guard (`rust_scorer::creature_width`, Issue #571). These
+//! tests pin that from the binary's side, so a neat-core that ever dropped the
+//! ceiling fails here rather than in the fleet.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use neat_core::creature::{CreatureError, parse_creature_json};
+use neat_core::network::MAX_NODE_COUNT;
+use rust_scorer::creature_width::validate_creature_width;
+use rust_scorer::fixture_json::{creature_envelope, neuron_json, synapse_json};
+
+/// A creature whose top-level `input` is set explicitly; `neurons` lists only
+/// the single output, so the declared width is the sole allocation driver.
+fn creature_json(input: usize) -> String {
+    let neurons = vec![neuron_json("output", "output-0", 0.0, "IDENTITY")];
+    let synapses = vec![synapse_json("input-0", "output-0", 1.0)];
+    creature_envelope(input, 1, &neurons, &synapses)
+}
+
+fn scorer_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rust_scorer"))
+}
+
+fn missing_data_dir(tmp: &Path) -> PathBuf {
+    let missing = tmp.join("no-such-data-dir");
+    assert!(!missing.exists());
+    missing
+}
+
+#[test]
+fn a_declared_width_past_the_ceiling_is_refused_by_the_parser() {
+    let err = parse_creature_json(&creature_json(100_000_000)).unwrap_err();
+    // The typed error carries the whole declared node count (input + listed
+    // neurons), not just the input.
+    assert!(
+        matches!(err, CreatureError::TooManyNodes { count } if count == 100_000_001),
+        "expected TooManyNodes carrying the declared node count, got: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("exceeding the maximum of"),
+        "the rendered message must name the ceiling, got: {err}"
+    );
+}
+
+#[test]
+fn the_ceiling_is_inclusive_at_max_node_count() {
+    // MAX_NODE_COUNT is the widest network a u16 source index can address, so
+    // it is accepted; one more is not.
+    assert!(parse_creature_json(&creature_json(MAX_NODE_COUNT)).is_ok());
+    assert!(matches!(
+        parse_creature_json(&creature_json(MAX_NODE_COUNT + 1)),
+        Err(CreatureError::TooManyNodes { .. })
+    ));
+}
+
+#[test]
+fn the_scorer_lower_bound_guard_still_accepts_a_legal_width() {
+    // The scorer's own guard (Issue #571) is unchanged by the bump: it owns the
+    // `< 1` wording, and the ceiling is neat-core's.
+    let creature = parse_creature_json(&creature_json(3)).unwrap();
+    assert!(validate_creature_width(&creature).is_ok());
+}
+
+#[test]
+fn the_cli_refuses_an_oversized_width_before_reading_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let creature = tmp.path().join("creature.json");
+    std::fs::write(&creature, creature_json(100_000_000)).unwrap();
+
+    let output = Command::new(scorer_bin())
+        .arg(&creature)
+        .arg(missing_data_dir(tmp.path()))
+        .output()
+        .expect("spawn scorer");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "scorer must exit non-zero, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        stderr.contains("exceeding the maximum of"),
+        "stderr must carry the ceiling error, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("is not a directory") && !stderr.contains("No .bin files"),
+        "the ceiling must fire before the data directory is touched, got:\n{stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "no score JSON may be emitted for an oversized creature, got:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/rust_scorer/tests/dual_role_parity.rs
+++ b/rust_scorer/tests/dual_role_parity.rs
@@ -146,10 +146,10 @@ fn every_declared_synapse_survives_the_load() {
             declared - creature.synapses.len()
         );
         assert_eq!(
-            net.synapses.len(),
+            net.synapses().len(),
             declared,
             "{label}: compiling dropped {} of {declared} synapses",
-            declared - net.synapses.len()
+            declared - net.synapses().len()
         );
     }
 }
@@ -423,7 +423,7 @@ fn assert_gpu_parity(label: &str, json: &str, records: &[f32]) {
         return;
     };
     let template = compile(json);
-    let num_inputs = template.num_inputs;
+    let num_inputs = template.num_inputs();
     let n_records = records.len() / (num_inputs + 1);
     let mut nets: Vec<CompiledNetwork> = (0..4).map(|_| template.clone()).collect();
 

--- a/rust_scorer/tests/gpu_multi_score_parity.rs
+++ b/rust_scorer/tests/gpu_multi_score_parity.rs
@@ -338,7 +338,7 @@ fn run_parity_json(label: &str, json: &str, num_creatures: usize, n_records: usi
 
     let creature = parse_creature_json(json).expect("parse creature");
     let template = compile_creature(&creature).expect("compile");
-    let num_inputs = template.num_inputs;
+    let num_inputs = template.num_inputs();
     let num_outputs = creature.output;
     let mut nets: Vec<_> = (0..num_creatures).map(|_| template.clone()).collect();
 

--- a/rust_scorer/tests/if_tree_parity.rs
+++ b/rust_scorer/tests/if_tree_parity.rs
@@ -340,7 +340,7 @@ fn assert_kernel_parity(
         return;
     };
     let template = compile(json);
-    let num_inputs = template.num_inputs;
+    let num_inputs = template.num_inputs();
     let n_records = records.len() / (num_inputs + 1);
     let mut nets: Vec<CompiledNetwork> = (0..num_creatures).map(|_| template.clone()).collect();
 

--- a/scripts/check-cargo-audit-workflow.sh
+++ b/scripts/check-cargo-audit-workflow.sh
@@ -1,47 +1,68 @@
 #!/usr/bin/env bash
-# Validate the standalone Cargo Security Audit workflow (Issue #64).
+# Validate the standalone Cargo Security Audit workflow (Issues #64, #603).
 #
 # The cargo-audit workflow must:
-#   1. Trigger on pull_request so every change is audited before merge.
-#   2. Trigger on a cron schedule so freshly published advisories surface
-#      even on quiet branches (the lockfile does not change but the
-#      advisory database does).
-#   3. Declare an explicit `permissions:` block (least privilege).
-#   4. Pin `actions/checkout` to a numeric major version or a 40-char SHA
+#   1. Trigger on a cron schedule so freshly published advisories surface even
+#      on quiet branches (the lockfile does not change but the advisory
+#      database does). This is the standalone workflow's non-redundant value.
+#   2. Declare an explicit `permissions:` block (least privilege).
+#   3. Pin `actions/checkout` to a numeric major version or a 40-char SHA
 #      (Node 24 policy).
-#   5. Install a Rust toolchain via `dtolnay/rust-toolchain` so cargo-audit
+#   4. Install a Rust toolchain via `dtolnay/rust-toolchain` so cargo-audit
 #      can be installed and run.
-#   6. Invoke cargo-audit — either directly (`cargo audit` after a
+#   5. Invoke cargo-audit — either directly (`cargo audit` after a
 #      `cargo install cargo-audit` step) or via the official RustSec
 #      action (`rustsec/audit-check@vN`).
-#   7. Cover milestone/<slug> branches in the pull_request filter so the gate
-#      runs on milestone sub-issue PRs, not only top-level base branches
-#      (Issue #391). A bare "*" glob does not match refs containing a slash.
+#   6. Cover milestone/<slug> branches in the pull_request filter, *when it has
+#      one*, so the gate runs on milestone sub-issue PRs and not only on
+#      top-level base branches (Issue #391). A bare "*" glob does not match
+#      refs containing a slash.
+#   7. Leave exactly ONE PR-time `cargo audit` across `.github/workflows`
+#      (Issue #603). A `pull_request` trigger here is optional: what matters is
+#      that some workflow audits `Cargo.lock` on a pull request, and that no
+#      second one repeats the identical verdict for double the runner minutes.
 #
-# The script takes a single optional `--workflow PATH` argument so BATS tests
-# can exercise it against fixtures. When called with no argument it validates
-# `.github/workflows/cargo-audit.yml` relative to the repo root.
+# Rule 7 mirrors the ShellCheck dedup invariant (Issue #157,
+# `check-shellcheck-dedup.sh`): a logical check belongs in exactly one home.
+# "PR-time" includes an audit reached indirectly — `ci.yml` fires on
+# `pull_request` and calls the reusable `security.yml`, so `security.yml`'s
+# `rustsec/audit-check` step counts.
+#
+# A duplicate is reported with `warn`, not `fail`: removing it means editing
+# `.github/workflows/`, which the automation worker has no `workflow` OAuth
+# scope to push (CONTRIBUTING "Human escalation"). The WARN keeps the
+# deficiency loud on every gate run until a maintainer lands that edit —
+# missing PR-time coverage altogether is a hard FAIL, because that is a real
+# security regression rather than a redundancy.
+#
+# The script takes optional `--workflow PATH` and `--workflows DIR` arguments so
+# BATS tests can exercise it against fixtures. With no argument it validates
+# `.github/workflows/cargo-audit.yml` against the workflows directory beside it.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Shared CLI harness (Issue #512) — the ok/fail/warn reporting primitives and
+# the not-found guards.
+# shellcheck source=scripts/lib/check-harness.sh
+source "$SCRIPT_DIR/lib/check-harness.sh"
 
 # Shared workflow-validation helpers (Issues #511, #514) — the `actions/checkout`
 # pin rule and the least-privilege `permissions:` rule each live in one place
 # instead of inline copies that drift apart.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOW_CHECKS_LIB="$SCRIPT_DIR/lib/workflow-checks.sh"
-if [[ ! -r "$WORKFLOW_CHECKS_LIB" ]]; then
-  echo "Missing shared helper: $WORKFLOW_CHECKS_LIB" >&2
-  exit 2
-fi
+check_require_file "$WORKFLOW_CHECKS_LIB" "Shared helper"
 # shellcheck source=lib/workflow-checks.sh disable=SC1091
 source "$WORKFLOW_CHECKS_LIB"
 
 usage() {
   cat <<'EOF'
-Usage: check-cargo-audit-workflow.sh [--workflow PATH]
+Usage: check-cargo-audit-workflow.sh [--workflow PATH] [--workflows DIR]
 
 Options:
   --workflow PATH   Path to the cargo-audit workflow YAML file (default:
                     .github/workflows/cargo-audit.yml relative to the repo root).
+  --workflows DIR   Directory scanned for other PR-time cargo audits (default:
+                    the directory containing the workflow above).
   -h, --help        Show this message.
 
 Exits 0 when the workflow satisfies every rule listed in the script header.
@@ -50,51 +71,97 @@ EOF
 }
 
 WORKFLOW=""
+WORKFLOWS_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --workflow)
+      check_flag_value "$1" $#
       WORKFLOW="$2"
       shift 2
       ;;
-    -h|--help)
+    --workflows)
+      check_flag_value "$1" $#
+      WORKFLOWS_DIR="$2"
+      shift 2
+      ;;
+    -h | --help)
       usage
       exit 0
       ;;
     *)
-      echo "Unknown argument: $1" >&2
-      usage >&2
-      exit 2
+      check_unknown_arg "$1"
       ;;
   esac
 done
 
 if [[ -z "$WORKFLOW" ]]; then
-  WORKFLOW="$SCRIPT_DIR/../.github/workflows/cargo-audit.yml"
+  WORKFLOW="$(check_repo_path ".github/workflows/cargo-audit.yml")"
 fi
+check_require_file "$WORKFLOW"
 
-if [[ ! -f "$WORKFLOW" ]]; then
-  echo "Workflow file not found: $WORKFLOW" >&2
-  exit 2
+if [[ -z "$WORKFLOWS_DIR" ]]; then
+  WORKFLOWS_DIR="$(dirname "$WORKFLOW")"
 fi
+check_require_dir "$WORKFLOWS_DIR"
 
-EXIT_CODE=0
-fail() {
-  echo "FAIL $WORKFLOW: $*" >&2
-  EXIT_CODE=1
+check_subject "$WORKFLOW"
+
+# triggers_on_pull_request <workflow> — true when the workflow's `on:` map has a
+# `pull_request:` key (block form) or names it in the inline list form. The
+# trailing colon keeps `pull_request_target:` out.
+triggers_on_pull_request() {
+  grep -qE '^[[:space:]]+pull_request:' "$1" \
+    || grep -qE '^on:[[:space:]]*\[?.*pull_request([],[:space:]]|$)' "$1"
 }
-ok() {
-  echo "OK   $WORKFLOW: $*"
+
+# invokes_cargo_audit <workflow> — true when the workflow actually runs an
+# audit: the RustSec action on a `uses:` line, or `cargo audit` inside a `run:`
+# step. Both patterns anchor to the step keyword so prose in a comment — of
+# which `security.yml` has several — never counts as an invocation.
+invokes_cargo_audit() {
+  grep -qE '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*rustsec/audit-check@' "$1" \
+    || grep -qE '^[[:space:]]*(-[[:space:]]*)?run:[[:space:]]*.*\bcargo[[:space:]]+audit\b' "$1"
 }
 
-# 1. Triggered on pull_request events.
-if grep -qE '^[[:space:]]+pull_request:' "$WORKFLOW" \
-  || grep -qE '^on:[[:space:]]*\[?.*pull_request' "$WORKFLOW"; then
-  ok "triggers on pull_request"
-else
-  fail "workflow is not triggered on pull_request"
-fi
+# pr_time_audit_workflows <dir> — print every workflow in DIR that audits
+# `Cargo.lock` on a pull request, one path per line. Reachability starts at the
+# workflows with a `pull_request` trigger and follows local `uses:
+# ./.github/workflows/<file>` calls to a fixed point, so an audit inside a
+# reusable workflow is attributed to the PR event that reaches it.
+pr_time_audit_workflows() {
+  local dir="$1"
+  local -a frontier=() reachable=()
+  local workflow callee name
 
-# 2. Schedule trigger present (cron) — covers advisory-DB updates.
+  while IFS= read -r workflow; do
+    [[ -f "$workflow" ]] || continue
+    if triggers_on_pull_request "$workflow"; then
+      frontier+=("$workflow")
+    fi
+  done < <(find "$dir" -maxdepth 1 \( -name "*.yml" -o -name "*.yaml" \) -type f | sort)
+
+  while [[ ${#frontier[@]} -gt 0 ]]; do
+    workflow="${frontier[0]}"
+    frontier=("${frontier[@]:1}")
+    # Skip anything already seen so a call cycle cannot loop forever.
+    if [[ " ${reachable[*]+"${reachable[*]}"} " == *" $workflow "* ]]; then
+      continue
+    fi
+    reachable+=("$workflow")
+    while IFS= read -r name; do
+      callee="$dir/$name"
+      [[ -f "$callee" ]] && frontier+=("$callee")
+    done < <(sed -nE 's|^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*\./\.github/workflows/([^[:space:]]+).*|\2|p' "$workflow")
+  done
+
+  for workflow in ${reachable[@]+"${reachable[@]}"}; do
+    if invokes_cargo_audit "$workflow"; then
+      echo "$workflow"
+    fi
+  done
+}
+
+# 1. Schedule trigger present (cron) — covers advisory-DB updates.
 if grep -qE '^[[:space:]]+schedule:' "$WORKFLOW" \
   && grep -qE '^[[:space:]]+- cron:' "$WORKFLOW"; then
   ok "triggers on schedule (cron)"
@@ -102,25 +169,25 @@ else
   fail "no schedule (cron) trigger — weekly audit run required"
 fi
 
-# 3. Explicit permissions block (least privilege), via the shared rule in
+# 2. Explicit permissions block (least privilege), via the shared rule in
 #    scripts/lib/workflow-checks.sh (Issue #514).
 require_readonly_permissions "$WORKFLOW"
 
-# 4. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
+# 3. actions/checkout pinned to a numeric major (vN) or a 40-char SHA, via the
 # shared rule in scripts/lib/workflow-checks.sh (Issue #511). Branch refs
 # (e.g. `@main`) disallowed. Issue #136 widened the regex from `v?[0-9]+` so
 # SHAs starting with hex letters a–f are accepted too; keeping that rule in one
 # place is why Issue #511 extracted the helper.
 require_pinned_checkout "$WORKFLOW"
 
-# 5. Rust toolchain provisioned via dtolnay/rust-toolchain.
+# 4. Rust toolchain provisioned via dtolnay/rust-toolchain.
 if grep -qE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$WORKFLOW"; then
   ok "dtolnay/rust-toolchain present"
 else
   fail "dtolnay/rust-toolchain missing — Rust toolchain not provisioned"
 fi
 
-# 6. cargo-audit invoked — either via the rustsec action OR a direct
+# 5. cargo-audit invoked — either via the rustsec action OR a direct
 #    `cargo audit` run (after `cargo install cargo-audit`).
 if grep -qE 'uses:[[:space:]]*rustsec/audit-check@' "$WORKFLOW"; then
   ok "cargo audit invoked via rustsec/audit-check action"
@@ -131,15 +198,36 @@ else
   fail "cargo audit is not invoked — neither rustsec/audit-check nor a 'cargo audit' run step found"
 fi
 
-# 7. pull_request branch filter must include milestone branches so the gate
+# 6. pull_request branch filter must include milestone branches so the gate
 #    runs on milestone/<slug> sub-issue PRs. A bare "*" glob only matches
 #    single-level refs, so milestone/<slug> would otherwise skip the gate and
 #    merge unchecked into the milestone branch (Issue #391). The token
-#    `milestone/*` also matches the wider `milestone/**` glob.
-if grep -qE 'milestone/\*' "$WORKFLOW"; then
-  ok "pull_request branch filter covers milestone/* branches"
+#    `milestone/*` also matches the wider `milestone/**` glob. The rule is
+#    conditional: a workflow that does not gate PRs at all has no filter to
+#    check (Issue #603).
+if triggers_on_pull_request "$WORKFLOW"; then
+  ok "triggers on pull_request"
+  if grep -qE 'milestone/\*' "$WORKFLOW"; then
+    ok "pull_request branch filter covers milestone/* branches"
+  else
+    fail "pull_request branch filter omits milestone/* — milestone PRs skip the gate"
+  fi
 else
-  fail "pull_request branch filter omits milestone/* — milestone PRs skip the gate"
+  ok "no pull_request trigger — schedule/dispatch only, PR-time auditing lives elsewhere (Issue #603)"
 fi
+
+# 7. Exactly one PR-time cargo audit across the workflows directory (Issue #603).
+mapfile -t PR_AUDITS < <(pr_time_audit_workflows "$WORKFLOWS_DIR")
+case "${#PR_AUDITS[@]}" in
+  1)
+    ok "exactly one PR-time cargo audit across $WORKFLOWS_DIR: ${PR_AUDITS[0]}"
+    ;;
+  0)
+    fail "no workflow runs a cargo audit on pull_request — PR-time advisory coverage is missing"
+    ;;
+  *)
+    warn "PR-time cargo audit duplicated across ${#PR_AUDITS[@]} workflows — both read the same Cargo.lock against the same advisory database on the same pull_request event, so the second run can only repeat the first verdict at double the runner minutes (Issue #603): ${PR_AUDITS[*]}. Drop the standalone workflow's pull_request trigger (keeping its weekly cron) or the reusable workflow's audit step — the edit is under .github/workflows/ and needs a maintainer (CONTRIBUTING \"Human escalation\")"
+    ;;
+esac
 
 exit "$EXIT_CODE"

--- a/tests/scripts/cargo_audit_workflow.bats
+++ b/tests/scripts/cargo_audit_workflow.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# Tests for scripts/check-cargo-audit-workflow.sh — Issue #64.
+# Tests for scripts/check-cargo-audit-workflow.sh — Issues #64, #603.
 #
 # Exercises the Cargo Security Audit workflow validator with synthetic
 # workflow YAML in temporary directories so behaviour (exit codes, reported
@@ -51,29 +51,57 @@ jobs:
 EOF
 }
 
+# The Issue #603 end state: the standalone workflow keeps only its weekly cron
+# and the manual trigger, leaving PR-time auditing to a single other workflow.
+write_scheduled_only_audit_workflow() {
+  local file="$1"
+  write_audit_workflow "$file"
+  python3 - "$file" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace('  pull_request:\n    branches: ["*", "milestone/**"]\n', "")
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+}
+
+# A second PR-time cargo audit reached through a reusable workflow: `ci.yml`
+# fires on pull_request and calls `security.yml`, which runs the RustSec action.
+write_pr_reachable_audit_pair() {
+  local dir="$1"
+  cat >"$dir/ci.yml" <<'EOF'
+name: CI
+on:
+  pull_request:
+    branches: [Develop, milestone/*]
+jobs:
+  security:
+    uses: ./.github/workflows/security.yml
+EOF
+  cat >"$dir/security.yml" <<'EOF'
+name: Security Reusable Workflow
+on:
+  workflow_call:
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # Prose mentioning `cargo audit` must not count as an invocation.
+      - uses: rustsec/audit-check@v2
+EOF
+}
+
 @test "passes on the canonical fixture" {
   write_audit_workflow "$TMP_WF/cargo-audit.yml"
   run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
   [ "$status" -eq 0 ]
   # Issue #360: prove every rule was individually evaluated and passed via the
   # machine-checkable "OK   " marker rather than pinning informational wording.
-  [ "$(grep -c '^OK   ' <<<"$output")" -eq 7 ]
-}
-
-@test "fails when the workflow is not triggered on pull_request" {
-  write_audit_workflow "$TMP_WF/cargo-audit.yml"
-  python3 - "$TMP_WF/cargo-audit.yml" <<'PY'
-import sys
-path = sys.argv[1]
-with open(path) as fh:
-    text = fh.read()
-text = text.replace("  pull_request:\n    branches: [\"*\", \"milestone/**\"]\n", "")
-with open(path, "w") as fh:
-    fh.write(text)
-PY
-  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"not triggered on pull_request"* ]]
+  [ "$(grep -c '^OK   ' <<<"$output")" -eq 8 ]
+  [[ "$output" != *"WARN"* ]]
 }
 
 @test "fails when the workflow has no schedule trigger" {
@@ -170,8 +198,65 @@ EOF
   [[ "$output" == *"milestone"* ]]
 }
 
+@test "warns when a second PR-reachable workflow audits the same lockfile (issue #603)" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  write_pr_reachable_audit_pair "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  # A duplicate is a deficiency the validator cannot fail on: fixing it means
+  # editing .github/workflows/, which the automation worker cannot push.
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+  [[ "$output" == *"WARN"* ]]
+  [[ "$output" == *"Issue #603"* ]]
+  [[ "$output" == *"cargo-audit.yml"* ]]
+  [[ "$output" == *"security.yml"* ]]
+}
+
+@test "passes without a pull_request trigger once another workflow owns the PR audit (issue #603)" {
+  write_scheduled_only_audit_workflow "$TMP_WF/cargo-audit.yml"
+  write_pr_reachable_audit_pair "$TMP_WF"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"WARN"* ]]
+  [[ "$output" == *"no pull_request trigger"* ]]
+  # The milestone branch-filter rule is pull_request-only, so it is not
+  # evaluated — and must not fail — on a schedule-only workflow.
+  [[ "$output" != *"milestone/* — milestone PRs skip the gate"* ]]
+}
+
+@test "fails when no workflow provides a PR-time cargo audit (issue #603)" {
+  write_scheduled_only_audit_workflow "$TMP_WF/cargo-audit.yml"
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no workflow runs a cargo audit on pull_request"* ]]
+}
+
+@test "prose mentioning cargo audit does not count as a second invocation (issue #603)" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  cat >"$TMP_WF/lint.yml" <<'EOF'
+name: Lint
+# This workflow does not run `cargo audit` — cargo-audit.yml owns that.
+on:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo fmt --check
+EOF
+  run "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/cargo-audit.yml"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"WARN"* ]]
+}
+
 @test "reports an error when the workflow file does not exist" {
   assert_missing_target_rejected "$SCRIPT_UNDER_TEST" --workflow "$TMP_WF/does-not-exist.yml"
+}
+
+@test "reports an error when the workflows directory does not exist" {
+  write_audit_workflow "$TMP_WF/cargo-audit.yml"
+  assert_missing_target_rejected "$SCRIPT_UNDER_TEST" \
+    --workflow "$TMP_WF/cargo-audit.yml" --workflows "$TMP_WF/no-such-dir"
 }
 
 @test "unknown flag prints usage and exits non-zero" {


### PR DESCRIPTION
# PR Summary — Issue #603

## Summary

`cargo-audit.yml`'s `pull_request` trigger and `security.yml`'s
`rustsec/audit-check` step (reached from `ci.yml`) read the identical
`Cargo.lock` against the identical RustSec advisory database on the identical
`pull_request` event, so every PR into `Develop`/`milestone/**` pays for two
audits that can only ever agree.

`scripts/check-cargo-audit-workflow.sh` now enforces the dedup invariant that
`check-shellcheck-dedup.sh` enforces for ShellCheck (Issue #157): **exactly one
workflow may run a `cargo audit` on a pull request**, counting an audit reached
indirectly — the validator follows local `uses: ./.github/workflows/…` calls to
a fixed point, so `security.yml`'s audit is attributed to the `pull_request`
event that `ci.yml` brings it. A duplicate is a loud `WARN` naming both files;
losing PR-time coverage altogether is a hard `FAIL`.

Two supporting rule changes make the validator pass cleanly *after* the fix
rather than swapping one failure for another: the `pull_request` trigger is no
longer required (the weekly cron is the standalone workflow's non-redundant
value), and the `milestone/*` branch-filter rule (Issue #391) now applies only
when a `pull_request` trigger is present.

The `.github/workflows/` edit itself is **not** in this PR: the automation
worker's credentials carry no `workflow` OAuth scope, so per
[CONTRIBUTING → Human escalation](../../../CONTRIBUTING.md#human-escalation) the
issue is labelled `needs-human` with a comment spelling out the exact edit. The
`WARN` stays visible on every gate run until a maintainer lands it — the
deficiency never disappears into a silent pass.

Closes #603.

## Evidence

Backend/CI tooling change — no web interface to screenshot. Evidence is the
validator's own output against the real repository, which detects the
duplication through the reusable-workflow hop:

```text
$ ./scripts/check-cargo-audit-workflow.sh
OK   .github/workflows/cargo-audit.yml: triggers on schedule (cron)
OK   .github/workflows/cargo-audit.yml: permissions block grants only contents: read
OK   .github/workflows/cargo-audit.yml: actions/checkout pinned to a numeric major or 40-char SHA
OK   .github/workflows/cargo-audit.yml: dtolnay/rust-toolchain present
OK   .github/workflows/cargo-audit.yml: cargo audit invoked directly
OK   .github/workflows/cargo-audit.yml: triggers on pull_request
OK   .github/workflows/cargo-audit.yml: pull_request branch filter covers milestone/* branches
WARN .github/workflows/cargo-audit.yml: PR-time cargo audit duplicated across 2
     workflows — both read the same Cargo.lock against the same advisory database
     on the same pull_request event, so the second run can only repeat the first
     verdict at double the runner minutes (Issue #603):
     .github/workflows/cargo-audit.yml .github/workflows/security.yml. Drop the
     standalone workflow's pull_request trigger (keeping its weekly cron) or the
     reusable workflow's audit step — the edit is under .github/workflows/ and
     needs a maintainer (CONTRIBUTING "Human escalation")
exit=0
```

Today's duplicated graph, and the shape the maintainer edit leaves behind:

```mermaid
flowchart LR
    PR[pull_request] --> CA["cargo-audit.yml<br/>prebuilt cargo audit"]
    PR --> CI["ci.yml → security.yml<br/>rustsec/audit-check"]
    CA --> LOCK[(Cargo.lock<br/>+ RustSec DB)]
    CI --> LOCK
    LOCK --> V["one verdict,<br/>paid for twice"]
    CRON["schedule: 0 6 * * 1"] --> CA
```

```mermaid
flowchart LR
    PR2[pull_request] --> CI2["ci.yml → security.yml<br/>rustsec/audit-check"]
    CRON2["schedule: 0 6 * * 1"] --> CA2["cargo-audit.yml<br/>weekly + dispatch only"]
    CI2 --> LOCK2[(Cargo.lock<br/>+ RustSec DB)]
    CA2 --> LOCK2
```

### The maintainer edit this PR cannot make

Delete lines 27–28 of `.github/workflows/cargo-audit.yml`, leaving `schedule:`
and `workflow_dispatch:`, and trim the now-stale `pull_request` bullet from the
header comment (lines 13–18):

```yaml
  pull_request:
    branches: ["*", "milestone/**"]
```

After that edit the validator reports
`OK … exactly one PR-time cargo audit across .github/workflows:
.github/workflows/security.yml` with no `WARN`, and the end state is already
covered by `cargo_audit_workflow.bats::passes without a pull_request trigger
once another workflow owns the PR audit`.

The issue's alternative — drop `security.yml`'s audit step instead — is equally
accepted by the new guard. It is noted on the issue with its trade-off
(`cargo-audit.yml` uses a *prebuilt* cargo-audit per Issue #208 and covers a
wider branch filter, but `rustsec/audit-check` annotates the check run and
removing it would leave `security.yml` with only the dependency-review step its
sole caller opts out of).

## Test Plan

`tests/scripts/cargo_audit_workflow.bats` — 16 tests, all passing. New and
changed coverage:

- **new** `warns when a second PR-reachable workflow audits the same lockfile
  (issue #603)` — fixture pair `ci.yml` (on `pull_request`, `uses:
  ./.github/workflows/security.yml`) + `security.yml` (`rustsec/audit-check`);
  asserts exit 0, a `WARN` naming both files, and no `FAIL`. This is the
  reusable-workflow reachability case.
- **new** `passes without a pull_request trigger once another workflow owns the
  PR audit (issue #603)` — the post-fix end state: exit 0, no `WARN`, and the
  milestone branch-filter rule not evaluated.
- **new** `fails when no workflow provides a PR-time cargo audit (issue #603)` —
  schedule-only with no sibling audit is a hard failure, so the duplication
  cannot be "resolved" by deleting both.
- **new** `prose mentioning cargo audit does not count as a second invocation
  (issue #603)` — the invocation patterns anchor to `uses:`/`run:`, so the
  several `cargo audit` mentions in `security.yml`'s comments are not miscounted.
- **new** `reports an error when the workflows directory does not exist` — the
  shared not-found contract for the new `--workflows DIR` flag.
- **changed** `passes on the canonical fixture` — now asserts 8 `OK` lines (was
  7; the dedup rule adds one) and no `WARN`.
- **removed** `fails when the workflow is not triggered on pull_request` — the
  business logic changed deliberately: a `pull_request` trigger on this workflow
  is now optional, which is the whole point of Issue #603. Its replacement is
  the pair of new tests above, which pin that dropping the trigger is a pass
  *only* while another workflow provides PR-time coverage.
- **unchanged** the schedule, permissions, checkout-pin, toolchain,
  audit-invoked, milestone-filter and real-repository tests.

### Quality gate

`./quality.sh` fails at a **pre-existing, unrelated** stage on this container:
`check-neat-core-version.sh` reports `breaking neat-core bump: 0.11.4 exceeds
handled baseline 0.10.0`, which needs its own deliberate upgrade PR (the sibling
clone has moved ahead of `neat-core.expected-version`). Verified pre-existing by
running the same suites against a pristine `HEAD` worktree.

Every stage that this diff can affect was run and passed: `bash -n` and
`shellcheck -x` over all scripts, all 37 other `scripts/check-*.sh` guards,
`codespell`, `cargo fmt --all --check`, and the full `bats tests/scripts` suite
(634 tests; the only two failures — the neat-core baseline above and `living
docs contain no box-drawing ASCII diagrams` — reproduce identically on pristine
`HEAD`, the latter because this container has no `en_US.UTF-8` locale, so the
test's `grep` character class degrades to byte matching on em dashes).
No Rust source changed in this PR.



## Milestone
This PR is part of the **Scan 20260907** milestone and targets the `milestone/scan-20260907` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mttogkfz-77ef32`<!-- vibe-worker-issue-603 -->