### PR TITLE
Handle the neat-core 0.14.0 breaking bump and move the baseline off 0.13.0 (Issue #609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ section to the released version with its date.
 
 ### Fixed
 
+- **Handles the neat-core 0.14.0 breaking bump — the declared observation width
+  is now bounded before it is walked (neat-core #622 / #640, Issue #609).**
+  `Develop` recorded `0.13.0` in `neat-core.expected-version` while the sibling
+  clone every host builds against had moved to `0.14.x`, so the Issue #252
+  breaking-bump gate failed `Project Validation` on **every** PR and nothing
+  could merge. The bump is a behavioural narrowing, not a signature change:
+  `validate_creature_width` refuses a declared `input` above `MAX_NODE_COUNT`
+  with `CreatureError::TooManyNodes`, so a sub-100-byte creature can no longer
+  cost one owned UUID per declared input. No scorer-reachable creature is
+  affected — `compile_creature` has refused a *total* node count above the same
+  ceiling since neat-core #177, and the total is never below `input`, so the
+  refusal only moves earlier. New `rust_scorer/tests/declared_width_ceiling.rs`
+  pins the typed refusal on the parse, compile and CLI paths, that the ceiling
+  is inclusive, and that the widest creature which has ever compiled still
+  compiles. `neat-core.expected-version` acknowledges 0.14.1.
+
 - **Builds against neat-core 0.13.0 — `CompiledNetwork`'s fields went private
   (neat-core #625 / #633).** neat-core 0.12.0 made every `CompiledNetwork`
   field private behind borrow-only accessors and 0.13.0 followed the same day.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.13.0"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.14.1"
+version = "0.14.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1076,7 +1076,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rust_scorer"
-version = "1.1.75"
+version = "1.1.76"
 dependencies = [
  "bytemuck",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "neat-core"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/docs/archive/pr-summaries/pr-summary-609.md
+++ b/docs/archive/pr-summaries/pr-summary-609.md
@@ -34,8 +34,8 @@ ceiling.
 
 This PR is that deliberate acknowledgement: a regression suite pinning the new
 refusal from the scorer's side, and the baseline moved to the sibling version
-with the usual header paragraph. No production scorer code changed. Closes
-#609.
+with the usual header paragraph. No production scorer code changed.
+Closes #609.
 
 ## Evidence
 

--- a/docs/archive/pr-summaries/pr-summary-609.md
+++ b/docs/archive/pr-summaries/pr-summary-609.md
@@ -1,0 +1,190 @@
+# Handle the neat-core 0.14.0 breaking bump and move the baseline off 0.13.0 (Issue #609)
+
+## Summary
+
+`Develop` recorded `0.13.0` in `neat-core.expected-version` while the sibling
+`NEAT-AI-core` clone that every host and runner builds against had moved to
+`0.14.x`. Pre-1.0 the minor is the breaking component, so the Issue #252
+breaking-bump gate failed `Project Validation` on **every** PR and nothing in
+the repository could merge:
+
+```text
+FAIL: breaking neat-core bump: 0.14.1 exceeds handled baseline 0.13.0 (pre-1.0 minor increased)
+```
+
+The unhandled bump is neat-core 0.14.0 (NEAT-AI-core#622 / PR #640): the
+**declared** observation width is now bounded before it is walked.
+`CreatureExport::input` is a declared count with no backing data in the JSON, so
+a sub-100-byte creature saying `"input": 100000000` used to cost one owned
+`String` UUID per declared input; `validate_creature_width` now refuses a
+declared `input` above `MAX_NODE_COUNT` with `CreatureError::TooManyNodes`, and
+`parse_creature_json`, `compile_creature`, `creature_to_json`,
+`creature_to_json_pretty`, `validate_creature_topology` and
+`cleanup_creature_with` all inherit that refusal.
+
+It is a **behavioural narrowing, not a signature change** — no public type or
+function signature `rust_scorer` names moved — and no scorer-reachable creature
+can be caught by it. `compile_creature` has refused a **total** node count
+(`input` plus the listed neurons) above the same ceiling with the same typed
+error since neat-core #177, and the total is never below `input`, so every
+creature the new width check refuses was already refused one step later; 0.14.0
+only moves the refusal ahead of the allocation it was sizing. Production width
+is 2461 inputs (`rust_scorer::prod_fixture`), twenty-six times below the
+ceiling.
+
+This PR is that deliberate acknowledgement: a regression suite pinning the new
+refusal from the scorer's side, and the baseline moved to the sibling version
+with the usual header paragraph. No production scorer code changed. Closes
+#609.
+
+## Evidence
+
+This is a CLI/back-end change with no web interface to screenshot. The evidence
+is the gate flipping green and the regression suite, both run in this worktree
+against the sibling clone at `0.14.1` (`255b06e`).
+
+**The gate, before and after:**
+
+```text
+$ ./scripts/check-neat-core-version.sh          # before
+FAIL: breaking neat-core bump: 0.14.1 exceeds handled baseline 0.13.0 (pre-1.0 minor increased)
+exit=1
+
+$ ./scripts/check-neat-core-version.sh          # after
+OK   neat-core 0.14.1 matches handled baseline 0.14.1 (patch-level drift allowed)
+exit=0
+```
+
+```mermaid
+flowchart LR
+    A["sibling NEAT-AI-core<br/>0.14.1"] --> B{"breaking component<br/>above baseline?"}
+    B -->|"before: baseline 0.13.0<br/>minor 13 &lt; 14"| C["FAIL — every PR blocked"]
+    B -->|"after: baseline 0.14.1<br/>patch drift allowed"| D["OK — Project Validation green"]
+    C --> E["this PR:<br/>declared_width_ceiling.rs<br/>+ baseline paragraph"]
+    E --> D
+```
+
+**The regression suite** (`rust_scorer/tests/declared_width_ceiling.rs`), run
+against a temporary `neat-core` worktree pinned at `0.13.0` (`59eb6e6`) and then
+against the sibling clone at `0.14.1`:
+
+```text
+# against neat-core 0.13.0 — the unfixed core
+test result: FAILED. 3 passed; 3 failed
+  absurd_declared_width_is_refused_on_parse_with_the_typed_error
+  no_boundary_accepts_a_declared_width_past_the_ceiling
+  the_ceiling_is_inclusive
+
+# against the sibling clone at 0.14.1
+test result: ok. 6 passed; 0 failed; finished in 0.07s
+```
+
+The 0.13.0 run also reproduces the symptom the bump exists to remove: it took
+**566 s**, because the CLI test's 100-million-input creature was walked into a
+hundred-million-entry map. Against 0.14.1 the same suite finishes in **0.07 s**.
+
+**Full gate:** `./quality.sh` passes end to end (exit 0) — 626 bats tests and
+562 Rust tests, plus `cargo fmt --check`,
+`cargo clippy --all-targets -- -D warnings`, `cargo-deny`, rustdoc and the
+release build.
+
+> Note for reviewers: this container has no `en_US.UTF-8` locale, which
+> `tests/scripts/diagrams_mermaid.bats` sets in `setup()`. Under the failed
+> `setlocale` the box-drawing bracket expression degrades to byte matching and
+> every em dash in `README.md` looks like a box-drawing character, so that one
+> bats test fails on `Develop` too — it is environmental and unrelated to this
+> diff (`README.md` is not touched here). Running the same gate as
+> `LC_ALL=C.UTF-8 ./quality.sh` — a valid UTF-8 locale, no repository change —
+> passes everything, exit 0.
+
+## Reproduction
+
+- **symptom** — `Project Validation` failed on every PR against `Develop` at
+  `./scripts/check-neat-core-version.sh`:
+  `FAIL: breaking neat-core bump: 0.14.1 exceeds handled baseline 0.13.0
+  (pre-1.0 minor increased)`, exit 1
+- **status** — `verified` — the gate was observed exiting 1 on the unfixed
+  branch and exiting 0 after the baseline bump, and the new regression suite was
+  observed failing (3 of its 6 tests) against a `neat-core` 0.13.0 worktree and
+  passing (6 of 6) against the sibling clone at 0.14.1
+- **regression test** —
+  `rust_scorer/tests/declared_width_ceiling.rs::absurd_declared_width_is_refused_on_parse_with_the_typed_error`
+  (with `::the_ceiling_is_inclusive`, the other assertion that distinguishes
+  0.13.0 from 0.14.1; the gate itself is re-run by `./quality.sh` and by CI)
+
+## Acceptance Criteria
+
+<!-- vibe-spec-review inputs="diff+issue-body" -->
+
+- **met** — confirms no scorer-reachable creature legitimately declares an `input` above `MAX_NODE_COUNT`, with a regression test pinning the new `CreatureError::TooManyNodes` on the width path — evidence: `rust_scorer/tests/declared_width_ceiling.rs` (6 tests, all passing); the reviewer independently confirmed the scorer reaches only two of the six narrowed APIs (`rust_scorer/src/gpu/forward_mse_batched.rs:1521` is the sole other `MAX_NODE_COUNT` reference) and that production width 2461 (`rust_scorer/src/prod_fixture.rs:48`) sits 26× below the ceiling — reviewer: met
+- **met** — bumps `neat-core.expected-version` to the sibling version with the usual header paragraph documenting the 0.13.0 -> 0.14.x bump and how it was verified — evidence: `neat-core.expected-version` (0.13.0 → 0.14.1 with the header paragraph); `./scripts/check-neat-core-version.sh` exits 0 — reviewer: met
+- **unrequested** — `Cargo.lock` records `neat-core` 0.13.0 → 0.14.1 — reviewer: unrequested — reason: a mechanical consequence of building against the sibling at 0.14.1; leaving it stale would make the lock file wrong
+- **unrequested** — `CHANGELOG.md` gains an Unreleased/Fixed entry — reviewer: unrequested — reason: required by `CONTRIBUTING.md` step 4 for every PR, not by the issue
+- **unrequested** — `the_cli_reports_the_refusal_and_scores_nothing` drives the real binary and asserts no score JSON is emitted and the data directory is never touched — reviewer: unrequested — reason: it is the "scorer-reachable" half of criterion 1 — the refusal has to reach the scorer's own boundary, not just `neat-core`'s — and it mirrors the existing `rust_scorer/tests/input_output_width_guard.rs` shape; kept
+- **unrequested** — `docs/archive/pr-summaries/pr-summary-609.md` — reviewer: unrequested — reason: this file; `CONTRIBUTING.md:155-164` requires one committed summary per PR
+
+The Spec reviewer also raised three non-blocking accuracy points, all acted on
+or recorded:
+
+- Its finding that `absurd_declared_width_is_refused_on_compile_with_the_same_typed_error`
+  pinned a **pre-existing** guarantee despite its name is correct — the compile
+  refusal predates 0.14.0 (Issue #177), and that test only went red against
+  0.13.0 through its parse precondition. Fixed here: renamed to
+  `no_boundary_accepts_a_declared_width_past_the_ceiling`, with the split
+  spelled out in the test and in the `neat-core.expected-version` paragraph.
+- Its reading that the parse test against 0.13.0 "would attempt the 100M-entry
+  walk" is not what was observed: `parse_creature_json` allocates nothing per
+  declared input, so it returned an accepted creature and the assertion failed
+  cleanly. The 566 s in the Evidence section came from the **CLI** test, which
+  does compile.
+- `rust_scorer/src/creature_width.rs` still enforces only the lower bound
+  (`input >= 1`), so the scorer's own boundary guard is one-sided while the
+  ceiling lives in `neat-core`. Left as is: the core refusal covers every path
+  the scorer takes (it parses before it compiles), and an upper bound in the
+  local guard is not something this issue asked for.
+
+## Standards Review
+
+<!-- vibe-standards-review inputs="diff+CODING-STANDARDS.md" -->
+
+The repository has no `CODING-STANDARDS.md`; the reviewer used `CONTRIBUTING.md`
+and `AGENTS.md`, which are its documented standards, and said so.
+
+- **violation** — the PR summary was missing from the branch, against `CONTRIBUTING.md:160-163` ("PR summaries live there, one file per PR") — evidence: `docs/archive/pr-summaries/pr-summary-609.md` was untracked when the diff was reviewed — reason: fixed here; the file is committed in this PR
+- **clean** — Australian English throughout the added lines (*behavioural*, *serialisers*), codespell exit 0
+- **clean** — tests call real code: `parse_creature_json` / `compile_creature` directly and the real binary via `CARGO_BIN_EXE_rust_scorer`, asserting typed errors, stderr, exit status and empty stdout; no source-grepping tests
+- **clean** — creature JSON built through `rust_scorer::fixture_json`, not hand-encoded (`CONTRIBUTING.md:141-148`)
+- **clean** — no ASCII/box-drawing diagrams added; CHANGELOG entry under `## [Unreleased]` → `### Fixed`; breaking-bump gate acknowledged in the same PR; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `check-pr-summary-archive.sh` and `check-docs-cross-references.sh` all clean; positional CLI contract and `.github/workflows/` untouched
+
+## Test Plan
+
+New file `rust_scorer/tests/declared_width_ceiling.rs` — six tests, all calling
+real `neat-core` / `rust_scorer` entry points:
+
+- `absurd_declared_width_is_refused_on_parse_with_the_typed_error` — a
+  sub-200-byte creature declaring 100 000 000 inputs is refused by
+  `parse_creature_json` with `CreatureError::TooManyNodes { count: 100_000_001 }`
+  (`input` plus the listed neurons, the same declared node count the
+  post-compile ceiling reports).
+- `no_boundary_accepts_a_declared_width_past_the_ceiling` — the same width is
+  refused by `compile_creature` with the same typed error. Only the parse half
+  of this test is new behaviour: `compile_creature` has refused the width since
+  Issue #177 through its total-node check, and 0.14.0 moved that refusal ahead
+  of the walk. It is here so the suite pins that *no* boundary accepts the
+  width, not just the one that moved.
+- `the_ceiling_is_inclusive` — `input == MAX_NODE_COUNT` still parses;
+  `MAX_NODE_COUNT + 1` does not. The narrowing starts exactly one input past the
+  widest addressable network.
+- `the_widest_compilable_creature_still_compiles` — `MAX_NODE_COUNT - 1` inputs
+  plus one output neuron (total nodes exactly `MAX_NODE_COUNT`, the Issue #177
+  ceiling) parses and compiles, and the compiled network reports those widths.
+  This is the direct evidence that nothing compilable was lost.
+- `production_width_parses_and_compiles_unchanged` — the production 2461-input
+  shape parses, compiles and keeps its exact width; a compile-time assertion
+  pins that width below the ceiling.
+- `the_cli_reports_the_refusal_and_scores_nothing` — the real `rust_scorer`
+  binary, pointed at an oversized creature and a data directory that does not
+  exist, exits non-zero, carries the typed node-count wording on stderr, emits
+  no score JSON, and never reaches the data directory.
+
+No existing test was modified, commented out or removed.

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -101,4 +101,30 @@
 # neat-core at head, so the break was fleet-wide within minutes of merging.
 # Verified by `cargo clippy --all-targets -- -D warnings` and the full scorer
 # test suite against the sibling clone at 0.13.0 (59eb6e6).
-0.13.0
+#
+# 0.13.0 -> 0.14.1: acknowledge neat-core #640 (Issue #622, 0.14.0), which bound
+# the *declared* observation width before it is walked. `CreatureExport::input`
+# is a declared count with no backing data in the JSON, so a sub-100-byte
+# creature saying `"input": 100000000` used to cost one owned String UUID per
+# declared input; `validate_creature_width` now refuses a declared `input` above
+# `MAX_NODE_COUNT` with `CreatureError::TooManyNodes`, and `parse_creature_json`,
+# `compile_creature`, `creature_to_json`, `creature_to_json_pretty`,
+# `validate_creature_topology` and `cleanup_creature_with` all inherit the
+# refusal. 0.14.1 is patch-level within that line (#641, bump-deps quarantine).
+#
+# It is a behavioural narrowing, not a signature change: no public type or
+# function signature rust_scorer names moved, and no scorer-reachable creature
+# can be caught by the new refusal. `compile_creature` has refused a *total*
+# node count (`input` + listed neurons) above `MAX_NODE_COUNT` with the same
+# typed error since neat-core #177, and the total is never below `input`, so
+# every creature the width check now refuses was already refused one step
+# later — 0.14.0 only moves the refusal ahead of the allocation it was sizing.
+# Production width is 2461 inputs (`rust_scorer::prod_fixture`), twenty-six
+# times below the ceiling. Verified by `cargo fmt --check`,
+# `cargo clippy --all-targets -- -D warnings` and the full scorer test suite
+# against the sibling clone at 0.14.1 (255b06e), plus
+# `rust_scorer/tests/declared_width_ceiling.rs`, which pins the typed refusal on
+# the parse, compile and CLI paths, that the ceiling is inclusive, and that the
+# widest creature which has ever compiled still compiles. That suite fails
+# against 0.13.0 (3 of its 6 tests) and passes against the sibling clone.
+0.14.1

--- a/neat-core.expected-version
+++ b/neat-core.expected-version
@@ -126,5 +126,8 @@
 # `rust_scorer/tests/declared_width_ceiling.rs`, which pins the typed refusal on
 # the parse, compile and CLI paths, that the ceiling is inclusive, and that the
 # widest creature which has ever compiled still compiles. That suite fails
-# against 0.13.0 (3 of its 6 tests) and passes against the sibling clone.
+# against 0.13.0 (3 of its 6 tests) and passes against the sibling clone; the
+# assertions that distinguish the two versions are the parse-path refusal and
+# the inclusive ceiling, since the *compile*-path refusal itself predates the
+# bump (#177) and only moved ahead of the walk.
 0.14.1

--- a/rust_scorer/Cargo.toml
+++ b/rust_scorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scorer"
-version = "1.1.75"
+version = "1.1.76"
 edition = "2024"
 license = "Apache-2.0"
 description = "Native CLI binary for scoring NEAT-AI creatures against training data."

--- a/rust_scorer/tests/declared_width_ceiling.rs
+++ b/rust_scorer/tests/declared_width_ceiling.rs
@@ -1,0 +1,176 @@
+//! Issue #609 — the declared observation width is bounded before it is walked.
+//!
+//! `neat-core` 0.14.0 (NEAT-AI-core#622 / PR #640) added the `MAX_NODE_COUNT`
+//! ceiling to `validate_creature_width`, the single home of the width rule. A
+//! declared `input` above that ceiling is now `CreatureError::TooManyNodes`,
+//! refused **before** any allocation is sized by it — `parse_creature_json`,
+//! `compile_creature`, the two serialisers, `validate_creature_topology` and
+//! `cleanup_creature_with` all inherit the refusal. Pre-1.0 that is a minor
+//! bump, so the scorer had to acknowledge it in `neat-core.expected-version`.
+//!
+//! The bump is a **behavioural narrowing, not a signature change**, and this
+//! suite is the evidence that the narrowing cannot reject a creature the fleet
+//! actually scores:
+//!
+//! 1. **The refusal is typed and reaches the scorer's own boundary.** An absurd
+//!    declared width fails on parse and on compile with `TooManyNodes`, and the
+//!    CLI reports it and scores nothing.
+//! 2. **The ceiling is inclusive.** `input == MAX_NODE_COUNT` still parses, so
+//!    the narrowing starts exactly one input past the widest addressable
+//!    network.
+//! 3. **Nothing compilable was lost.** The widest creature that has ever
+//!    compiled — total nodes exactly `MAX_NODE_COUNT`, the Issue #177 ceiling
+//!    `compile_creature` has enforced since long before this bump — still
+//!    compiles. Every creature the new width check refuses would already have
+//!    earned the same `TooManyNodes` from that total-node check, because the
+//!    total (`input + neurons.len()`) is never below `input`; 0.14.0 only moves
+//!    the refusal earlier, ahead of the per-input allocation.
+//! 4. **Production width is nowhere near it.** The production creature's 2461
+//!    inputs (`rust_scorer::prod_fixture`) parse, compile and keep their exact
+//!    width, twenty-six times below the ceiling.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use neat_core::creature::{CreatureError, compile_creature, parse_creature_json};
+use neat_core::network::MAX_NODE_COUNT;
+use rust_scorer::fixture_json::{creature_envelope, dense_mlp_creature_json, neuron_json};
+
+/// The production observation width, as recorded in `rust_scorer::prod_fixture`.
+const PRODUCTION_INPUTS: usize = 2461;
+
+/// A minimal forward-only creature declaring `inputs` observations and exactly
+/// one output neuron, with no synapses. `neurons` lists only non-input
+/// neurons, so the declared width is carried by the top-level `input` alone —
+/// which is precisely why it needs its own ceiling.
+fn creature_json(inputs: usize) -> String {
+    let neurons = vec![neuron_json("output", "output-0", 0.0, "IDENTITY")];
+    creature_envelope(inputs, 1, &neurons, &[])
+}
+
+#[test]
+fn absurd_declared_width_is_refused_on_parse_with_the_typed_error() {
+    // Under 200 bytes of JSON declaring a hundred million inputs: before
+    // neat-core 0.14.0 this was walked into a hundred million map entries.
+    let json = creature_json(100_000_000);
+    assert!(
+        json.len() < 200,
+        "the fixture must stay a tiny payload declaring an enormous width"
+    );
+
+    let err = parse_creature_json(&json).expect_err("a width past the ceiling must be refused");
+    // `count` is `input` plus the listed (non-input) neurons — the same
+    // declared node count the post-compile ceiling reports.
+    assert!(
+        matches!(err, CreatureError::TooManyNodes { count } if count == 100_000_001),
+        "the width path must report the typed node-count error, got: {err}"
+    );
+}
+
+#[test]
+fn absurd_declared_width_is_refused_on_compile_with_the_same_typed_error() {
+    let json = creature_json(MAX_NODE_COUNT + 1);
+    // Parsing already refuses it, so compile is exercised through the struct
+    // the parser would have produced: build it by hand at the boundary.
+    let err = parse_creature_json(&json).expect_err("parse must refuse it");
+    assert!(matches!(err, CreatureError::TooManyNodes { .. }));
+
+    let mut creature = parse_creature_json(&creature_json(MAX_NODE_COUNT))
+        .expect("the ceiling itself parses, giving a valid export to widen");
+    creature.input = MAX_NODE_COUNT + 1;
+    // `CompiledNetwork` is not `Debug`, so match the result rather than
+    // `expect_err`-ing it.
+    let err = match compile_creature(&creature) {
+        Ok(_) => panic!("compile must refuse the widened export"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(err, CreatureError::TooManyNodes { count } if count == MAX_NODE_COUNT + 2),
+        "compile must refuse it before sizing anything by the declared width, got: {err}"
+    );
+}
+
+#[test]
+fn the_ceiling_is_inclusive() {
+    // MAX_NODE_COUNT inputs is the widest addressable observation vector, so it
+    // is accepted; one more is not. Parsing allocates nothing per input, so the
+    // acceptance here is cheap.
+    let at_ceiling = parse_creature_json(&creature_json(MAX_NODE_COUNT))
+        .expect("a width exactly at the ceiling must still parse");
+    assert_eq!(at_ceiling.input, MAX_NODE_COUNT);
+
+    assert!(
+        parse_creature_json(&creature_json(MAX_NODE_COUNT + 1)).is_err(),
+        "one input past the ceiling must be refused"
+    );
+}
+
+#[test]
+fn the_widest_compilable_creature_still_compiles() {
+    // Total nodes = MAX_NODE_COUNT - 1 inputs + 1 output = MAX_NODE_COUNT, the
+    // Issue #177 ceiling `compile_creature` has always allowed. If the 0.14.0
+    // width check could reject a creature that used to compile, it would reject
+    // this one.
+    let creature = parse_creature_json(&creature_json(MAX_NODE_COUNT - 1))
+        .expect("the widest compilable width must parse");
+    let network = compile_creature(&creature).expect("the widest compilable width must compile");
+    assert_eq!(network.num_inputs(), MAX_NODE_COUNT - 1);
+    assert_eq!(network.num_neurons(), MAX_NODE_COUNT);
+}
+
+#[test]
+fn production_width_parses_and_compiles_unchanged() {
+    let json = dense_mlp_creature_json(PRODUCTION_INPUTS, 1, 2, "TANH");
+    let creature = parse_creature_json(&json).expect("the production width must parse");
+    assert_eq!(creature.input, PRODUCTION_INPUTS);
+
+    let network = compile_creature(&creature).expect("the production width must compile");
+    assert_eq!(network.num_inputs(), PRODUCTION_INPUTS);
+    // Compile-time: the production width can never reach the ceiling.
+    const { assert!(PRODUCTION_INPUTS < MAX_NODE_COUNT) };
+}
+
+#[test]
+fn the_cli_reports_the_refusal_and_scores_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let creature_path = tmp.path().join("absurd-width.json");
+    let mut file = std::fs::File::create(&creature_path).unwrap();
+    file.write_all(creature_json(100_000_000).as_bytes())
+        .unwrap();
+    drop(file);
+
+    // A data directory that does not exist: the width refusal must fire first,
+    // so no training byte is ever opened.
+    let missing = tmp.path().join("no-such-data-dir");
+    assert!(!missing.exists());
+
+    let output = Command::new(PathBuf::from(env!("CARGO_BIN_EXE_rust_scorer")))
+        .arg(&creature_path)
+        .arg(&missing)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("scorer binary must run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "an unhostable declared width must exit non-zero, stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        stderr.contains("100000001 nodes")
+            && stderr.contains(&format!("maximum of {MAX_NODE_COUNT}")),
+        "stderr must carry the typed node-count refusal, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("is not a directory") && !stderr.contains("No .bin files"),
+        "the refusal must fire before the data directory is touched, got:\n{stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "no score JSON may be emitted, got:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/rust_scorer/tests/declared_width_ceiling.rs
+++ b/rust_scorer/tests/declared_width_ceiling.rs
@@ -14,7 +14,10 @@
 //!
 //! 1. **The refusal is typed and reaches the scorer's own boundary.** An absurd
 //!    declared width fails on parse and on compile with `TooManyNodes`, and the
-//!    CLI reports it and scores nothing.
+//!    CLI reports it and scores nothing. Only the *parse-path* refusal is new:
+//!    `compile_creature` has refused the same width since Issue #177, through
+//!    the total-node check described in point 3 — what 0.14.0 adds there is
+//!    that the refusal now happens **before** the walk.
 //! 2. **The ceiling is inclusive.** `input == MAX_NODE_COUNT` still parses, so
 //!    the narrowing starts exactly one input past the widest addressable
 //!    network.
@@ -69,12 +72,17 @@ fn absurd_declared_width_is_refused_on_parse_with_the_typed_error() {
 }
 
 #[test]
-fn absurd_declared_width_is_refused_on_compile_with_the_same_typed_error() {
+fn no_boundary_accepts_a_declared_width_past_the_ceiling() {
+    // The parse boundary refuses it (new in 0.14.0) ...
     let json = creature_json(MAX_NODE_COUNT + 1);
-    // Parsing already refuses it, so compile is exercised through the struct
-    // the parser would have produced: build it by hand at the boundary.
     let err = parse_creature_json(&json).expect_err("parse must refuse it");
     assert!(matches!(err, CreatureError::TooManyNodes { .. }));
+
+    // ... and so does the compile boundary, which cannot be reached through
+    // the parser any more. Widen an export the parser did produce, so compile
+    // is exercised on the same shape. This half is the Issue #177 total-node
+    // guarantee, unchanged by the bump: it is here so the suite pins that
+    // *no* boundary accepts the width, not just the one that moved.
 
     let mut creature = parse_creature_json(&creature_json(MAX_NODE_COUNT))
         .expect("the ceiling itself parses, giving a valid export to widen");


### PR DESCRIPTION
# Handle the neat-core 0.14.0 breaking bump and move the baseline off 0.13.0 (Issue #609)

## Summary

`Develop` recorded `0.13.0` in `neat-core.expected-version` while the sibling
`NEAT-AI-core` clone that every host and runner builds against had moved to
`0.14.x`. Pre-1.0 the minor is the breaking component, so the Issue #252
breaking-bump gate failed `Project Validation` on **every** PR and nothing in
the repository could merge:

```text
FAIL: breaking neat-core bump: 0.14.1 exceeds handled baseline 0.13.0 (pre-1.0 minor increased)
```

The unhandled bump is neat-core 0.14.0 (NEAT-AI-core#622 / PR #640): the
**declared** observation width is now bounded before it is walked.
`CreatureExport::input` is a declared count with no backing data in the JSON, so
a sub-100-byte creature saying `"input": 100000000` used to cost one owned
`String` UUID per declared input; `validate_creature_width` now refuses a
declared `input` above `MAX_NODE_COUNT` with `CreatureError::TooManyNodes`, and
`parse_creature_json`, `compile_creature`, `creature_to_json`,
`creature_to_json_pretty`, `validate_creature_topology` and
`cleanup_creature_with` all inherit that refusal.

It is a **behavioural narrowing, not a signature change** — no public type or
function signature `rust_scorer` names moved — and no scorer-reachable creature
can be caught by it. `compile_creature` has refused a **total** node count
(`input` plus the listed neurons) above the same ceiling with the same typed
error since neat-core #177, and the total is never below `input`, so every
creature the new width check refuses was already refused one step later; 0.14.0
only moves the refusal ahead of the allocation it was sizing. Production width
is 2461 inputs (`rust_scorer::prod_fixture`), twenty-six times below the
ceiling.

This PR is that deliberate acknowledgement: a regression suite pinning the new
refusal from the scorer's side, and the baseline moved to the sibling version
with the usual header paragraph. No production scorer code changed.
Closes issue #609.

## Evidence

This is a CLI/back-end change with no web interface to screenshot. The evidence
is the gate flipping green and the regression suite, both run in this worktree
against the sibling clone at `0.14.1` (`255b06e`).

**The gate, before and after:**

```text
$ ./scripts/check-neat-core-version.sh          # before
FAIL: breaking neat-core bump: 0.14.1 exceeds handled baseline 0.13.0 (pre-1.0 minor increased)
exit=1

$ ./scripts/check-neat-core-version.sh          # after
OK   neat-core 0.14.1 matches handled baseline 0.14.1 (patch-level drift allowed)
exit=0
```

```mermaid
flowchart LR
    A["sibling NEAT-AI-core<br/>0.14.1"] --> B{"breaking component<br/>above baseline?"}
    B -->|"before: baseline 0.13.0<br/>minor 13 &lt; 14"| C["FAIL — every PR blocked"]
    B -->|"after: baseline 0.14.1<br/>patch drift allowed"| D["OK — Project Validation green"]
    C --> E["this PR:<br/>declared_width_ceiling.rs<br/>+ baseline paragraph"]
    E --> D
```

**The regression suite** (`rust_scorer/tests/declared_width_ceiling.rs`), run
against a temporary `neat-core` worktree pinned at `0.13.0` (`59eb6e6`) and then
against the sibling clone at `0.14.1`:

```text
# against neat-core 0.13.0 — the unfixed core
test result: FAILED. 3 passed; 3 failed
  absurd_declared_width_is_refused_on_parse_with_the_typed_error
  no_boundary_accepts_a_declared_width_past_the_ceiling
  the_ceiling_is_inclusive

# against the sibling clone at 0.14.1
test result: ok. 6 passed; 0 failed; finished in 0.07s
```

The 0.13.0 run also reproduces the symptom the bump exists to remove: it took
**566 s**, because the CLI test's 100-million-input creature was walked into a
hundred-million-entry map. Against 0.14.1 the same suite finishes in **0.07 s**.

**Full gate:** `./quality.sh` passes end to end (exit 0) — 626 bats tests and
562 Rust tests, plus `cargo fmt --check`,
`cargo clippy --all-targets -- -D warnings`, `cargo-deny`, rustdoc and the
release build.

> Note for reviewers: this container has no `en_US.UTF-8` locale, which
> `tests/scripts/diagrams_mermaid.bats` sets in `setup()`. Under the failed
> `setlocale` the box-drawing bracket expression degrades to byte matching and
> every em dash in `README.md` looks like a box-drawing character, so that one
> bats test fails on `Develop` too — it is environmental and unrelated to this
> diff (`README.md` is not touched here). Running the same gate as
> `LC_ALL=C.UTF-8 ./quality.sh` — a valid UTF-8 locale, no repository change —
> passes everything, exit 0.

## Reproduction

- **symptom** — `Project Validation` failed on every PR against `Develop` at
  `./scripts/check-neat-core-version.sh`:
  `FAIL: breaking neat-core bump: 0.14.1 exceeds handled baseline 0.13.0
  (pre-1.0 minor increased)`, exit 1
- **status** — `verified` — the gate was observed exiting 1 on the unfixed
  branch and exiting 0 after the baseline bump, and the new regression suite was
  observed failing (3 of its 6 tests) against a `neat-core` 0.13.0 worktree and
  passing (6 of 6) against the sibling clone at 0.14.1
- **regression test** —
  `rust_scorer/tests/declared_width_ceiling.rs::absurd_declared_width_is_refused_on_parse_with_the_typed_error`
  (with `::the_ceiling_is_inclusive`, the other assertion that distinguishes
  0.13.0 from 0.14.1; the gate itself is re-run by `./quality.sh` and by CI)

## Acceptance Criteria

<!-- vibe-spec-review inputs="diff+issue-body" -->

- **met** — confirms no scorer-reachable creature legitimately declares an `input` above `MAX_NODE_COUNT`, with a regression test pinning the new `CreatureError::TooManyNodes` on the width path — evidence: `rust_scorer/tests/declared_width_ceiling.rs` (6 tests, all passing); the reviewer independently confirmed the scorer reaches only two of the six narrowed APIs (`rust_scorer/src/gpu/forward_mse_batched.rs:1521` is the sole other `MAX_NODE_COUNT` reference) and that production width 2461 (`rust_scorer/src/prod_fixture.rs:48`) sits 26× below the ceiling — reviewer: met
- **met** — bumps `neat-core.expected-version` to the sibling version with the usual header paragraph documenting the 0.13.0 -> 0.14.x bump and how it was verified — evidence: `neat-core.expected-version` (0.13.0 → 0.14.1 with the header paragraph); `./scripts/check-neat-core-version.sh` exits 0 — reviewer: met
- **unrequested** — `Cargo.lock` records `neat-core` 0.13.0 → 0.14.1 — reviewer: unrequested — reason: a mechanical consequence of building against the sibling at 0.14.1; leaving it stale would make the lock file wrong
- **unrequested** — `CHANGELOG.md` gains an Unreleased/Fixed entry — reviewer: unrequested — reason: required by `CONTRIBUTING.md` step 4 for every PR, not by the issue
- **unrequested** — `the_cli_reports_the_refusal_and_scores_nothing` drives the real binary and asserts no score JSON is emitted and the data directory is never touched — reviewer: unrequested — reason: it is the "scorer-reachable" half of criterion 1 — the refusal has to reach the scorer's own boundary, not just `neat-core`'s — and it mirrors the existing `rust_scorer/tests/input_output_width_guard.rs` shape; kept
- **unrequested** — `docs/archive/pr-summaries/pr-summary-609.md` — reviewer: unrequested — reason: this file; `CONTRIBUTING.md:155-164` requires one committed summary per PR

The Spec reviewer also raised three non-blocking accuracy points, all acted on
or recorded:

- Its finding that `absurd_declared_width_is_refused_on_compile_with_the_same_typed_error`
  pinned a **pre-existing** guarantee despite its name is correct — the compile
  refusal predates 0.14.0 (Issue #177), and that test only went red against
  0.13.0 through its parse precondition. Fixed here: renamed to
  `no_boundary_accepts_a_declared_width_past_the_ceiling`, with the split
  spelled out in the test and in the `neat-core.expected-version` paragraph.
- Its reading that the parse test against 0.13.0 "would attempt the 100M-entry
  walk" is not what was observed: `parse_creature_json` allocates nothing per
  declared input, so it returned an accepted creature and the assertion failed
  cleanly. The 566 s in the Evidence section came from the **CLI** test, which
  does compile.
- `rust_scorer/src/creature_width.rs` still enforces only the lower bound
  (`input >= 1`), so the scorer's own boundary guard is one-sided while the
  ceiling lives in `neat-core`. Left as is: the core refusal covers every path
  the scorer takes (it parses before it compiles), and an upper bound in the
  local guard is not something this issue asked for.

## Standards Review

<!-- vibe-standards-review inputs="diff+CODING-STANDARDS.md" -->

The repository has no `CODING-STANDARDS.md`; the reviewer used `CONTRIBUTING.md`
and `AGENTS.md`, which are its documented standards, and said so.

- **violation** — the PR summary was missing from the branch, against `CONTRIBUTING.md:160-163` ("PR summaries live there, one file per PR") — evidence: `docs/archive/pr-summaries/pr-summary-609.md` was untracked when the diff was reviewed — reason: fixed here; the file is committed in this PR
- **clean** — Australian English throughout the added lines (*behavioural*, *serialisers*), codespell exit 0
- **clean** — tests call real code: `parse_creature_json` / `compile_creature` directly and the real binary via `CARGO_BIN_EXE_rust_scorer`, asserting typed errors, stderr, exit status and empty stdout; no source-grepping tests
- **clean** — creature JSON built through `rust_scorer::fixture_json`, not hand-encoded (`CONTRIBUTING.md:141-148`)
- **clean** — no ASCII/box-drawing diagrams added; CHANGELOG entry under `## [Unreleased]` → `### Fixed`; breaking-bump gate acknowledged in the same PR; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `check-pr-summary-archive.sh` and `check-docs-cross-references.sh` all clean; positional CLI contract and `.github/workflows/` untouched

## Test Plan

New file `rust_scorer/tests/declared_width_ceiling.rs` — six tests, all calling
real `neat-core` / `rust_scorer` entry points:

- `absurd_declared_width_is_refused_on_parse_with_the_typed_error` — a
  sub-200-byte creature declaring 100 000 000 inputs is refused by
  `parse_creature_json` with `CreatureError::TooManyNodes { count: 100_000_001 }`
  (`input` plus the listed neurons, the same declared node count the
  post-compile ceiling reports).
- `no_boundary_accepts_a_declared_width_past_the_ceiling` — the same width is
  refused by `compile_creature` with the same typed error. Only the parse half
  of this test is new behaviour: `compile_creature` has refused the width since
  Issue #177 through its total-node check, and 0.14.0 moved that refusal ahead
  of the walk. It is here so the suite pins that *no* boundary accepts the
  width, not just the one that moved.
- `the_ceiling_is_inclusive` — `input == MAX_NODE_COUNT` still parses;
  `MAX_NODE_COUNT + 1` does not. The narrowing starts exactly one input past the
  widest addressable network.
- `the_widest_compilable_creature_still_compiles` — `MAX_NODE_COUNT - 1` inputs
  plus one output neuron (total nodes exactly `MAX_NODE_COUNT`, the Issue #177
  ceiling) parses and compiles, and the compiled network reports those widths.
  This is the direct evidence that nothing compilable was lost.
- `production_width_parses_and_compiles_unchanged` — the production 2461-input
  shape parses, compiles and keeps its exact width; a compile-time assertion
  pins that width below the ceiling.
- `the_cli_reports_the_refusal_and_scores_nothing` — the real `rust_scorer`
  binary, pointed at an oversized creature and a data directory that does not
  exist, exits non-zero, carries the typed node-count wording on stderr, emits
  no score JSON, and never reaches the data directory.

No existing test was modified, commented out or removed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mttphkp8-d3a869`<!-- vibe-worker-issue-609 -->

Closes #609